### PR TITLE
feat(ui): replace native <select> with Headless UI Listbox wrapper

### DIFF
--- a/docs/codebase/src/components/equipment/wizard/WizardStepTemplate.md
+++ b/docs/codebase/src/components/equipment/wizard/WizardStepTemplate.md
@@ -14,4 +14,4 @@ Renders a "request a new template" link that emits `onRequestNew` to the orchest
 
 ## Styling
 
-Both selects (category + subcategory) use the shared `input-base` component class with `text-sm truncate`. This keeps them within the wizard modal's inner padding on small viewports and prevents long Hebrew option labels from blowing the field's width past the screen edge.
+Category + subcategory pickers use the shared `Select` component (`src/components/ui/Select.tsx`) — a Headless UI `Listbox` wrapper. Native `<select>` was removed because OS-rendered option panels overflow the modal and ignore site CSS. Both selects are `clearable` so the user can deselect back to no choice. See `docs/codebase/src/components/ui/Select.md`.

--- a/docs/codebase/src/components/ui/Select.md
+++ b/docs/codebase/src/components/ui/Select.md
@@ -1,0 +1,71 @@
+# Select.tsx
+
+**File:** `src/components/ui/Select.tsx`
+**Status:** Active
+
+## Purpose
+
+Custom dropdown built on Headless UI `Listbox`. Replaces native `<select>`/`<option>` everywhere a styled dropdown is needed. Native select panels are OS-rendered and cannot be styled by CSS — this component fixes width-overflow, OS focus colors, and font/border mismatches.
+
+## Why not native `<select>`
+
+- Browsers ignore CSS `border-radius`, `border-color`, `background`, `font-*` on `<option>`.
+- Panel width sized by longest option, can overflow modal.
+- Highlight color = OS theme (Windows blue), not brand.
+
+## Why Headless UI
+
+- Tailwind ecosystem fit, used by Tailwind UI examples.
+- Built-in ARIA + keyboard navigation.
+- `anchor` prop uses Floating UI to position panel; exposes `--button-width` CSS var so panel matches trigger width without manual measurement.
+
+## Props
+
+| Prop | Type | Default | Notes |
+|---|---|---|---|
+| `value` | `T \| null` | — | Current value; `null` = unselected |
+| `onChange` | `(v: T \| null) => void` | — | Selection handler |
+| `options` | `SelectOption<T>[]` | — | `{ value, label, disabled? }` |
+| `placeholder` | `string` | `"—"` | Trigger text + clear-row label when value is null |
+| `clearable` | `boolean` | `false` | Render explicit clear row at top of panel |
+| `disabled` | `boolean` | `false` | Disables trigger |
+| `id` | `string` | — | Forwarded to trigger button |
+| `className` | `string` | — | Forwarded to trigger button |
+| `ariaLabel` | `string` | — | Forwarded to trigger button |
+
+## Styling
+
+- Trigger uses `input-base` (single source of truth from `globals.css`).
+- Panel: `rounded-xl border border-neutral-300 bg-white shadow-medium`, `max-h-60 overflow-auto`, `z-50`.
+- Hover row: `data-[focus]:bg-primary-50`.
+- Selected row: `data-[selected]:bg-primary-100 data-[selected]:text-primary-700`, with `Check` icon on visual end.
+- All colors are Tailwind tokens — no arbitrary values.
+
+## RTL
+
+`<html dir="rtl">` is global. Logical Tailwind classes (`text-start`, `ms-auto`) handle direction. Do not add `dir` to the component.
+
+## Usage
+
+```tsx
+import { Select } from '@/components/ui';
+
+<Select
+  value={categoryId}
+  onChange={(v) => setCategoryId(v)}
+  options={categories.map((c) => ({ value: c.id, label: c.name }))}
+  placeholder="בחירת קטגוריה"
+  clearable
+  ariaLabel="קטגוריה"
+/>
+```
+
+For non-nullable required values omit `clearable` and pass a non-null `value`.
+
+## Integration with `FormField`
+
+`FormField.tsx` clones its single child and injects classes meant for native inputs. `Select` does not nest cleanly inside `FormField`. Use a plain `<label>` next to `<Select>` instead (see `EmailTab.tsx` for the pattern).
+
+## Related
+
+- Replaced native `<select>` across: equipment wizard, equipment template form, equipment table sort, equipment status filter, ammunition forms (template, report, inventory, reports section), management tabs (Users, Permissions, EnforceTransfer, Email, DataManagement, AuditLogs, CustomUserSelectionModal), admin personnel (Add/View/Update), registration steps, status page, settings page, AddSoldierForm.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "ISC",
       "dependencies": {
+        "@headlessui/react": "^2.2.10",
         "date-fns": "^4.1.0",
         "firebase": "^12.0.0",
         "firebase-admin": "^13.7.0",
@@ -1415,6 +1416,59 @@
       "integrity": "sha512-6m8+P+dE/RPl4OPzjTxcTbQ0rGeRyeTvAi9KwIffBVCiAMKrfXfLZaqD1F+m8t4B5/Q5aHsMozOgirkH1F5oMQ==",
       "license": "Apache-2.0"
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.26.28",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.28.tgz",
+      "integrity": "sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.2",
+        "@floating-ui/utils": "^0.2.8",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
+    },
     "node_modules/@google-cloud/firestore": {
       "version": "7.11.6",
       "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-7.11.6.tgz",
@@ -1666,6 +1720,26 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@headlessui/react": {
+      "version": "2.2.10",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-2.2.10.tgz",
+      "integrity": "sha512-5pVLNK9wlpxTUTy9GpgbX/SdcRh+HBnPktjM2wbiLTH4p+2EPHBO1aoSryUCuKUIItdDWO9ITlhUL8UnUN/oIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react": "^0.26.16",
+        "@react-aria/focus": "^3.20.2",
+        "@react-aria/interactions": "^3.25.0",
+        "@tanstack/react-virtual": "^3.13.9",
+        "use-sync-external-store": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/@humanfs/core": {
@@ -2128,6 +2202,33 @@
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@internationalized/date": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.1.tgz",
+      "integrity": "sha512-6IedsVWXyq4P9Tj+TxuU8WGWM70hYLl12nbYU8jkikVpa6WXapFazPUcHUMDMoWftIDE2ILDkFFte6W2nFCkRQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/number": {
+      "version": "3.6.6",
+      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.6.tgz",
+      "integrity": "sha512-iFgmQaXHE0vytNfpLZWOC2mEJCBRzcUxt53Xf/yCXG93lRvqas237i3r7X4RKMwO3txiyZD4mQjKAByFv6UGSQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/string": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.8.tgz",
+      "integrity": "sha512-NdbMQUSfXLYIQol5VyMtinm9pZDciiMfN7RtmSuSB78io1hqwJ0naYfxyW6vgxWBkzWymQa/3uLDlbfmshtCaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -3068,6 +3169,44 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@react-aria/focus": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.22.0.tgz",
+      "integrity": "sha512-ZfDOVuVhqDsM9mkNji3QUZ/d40JhlVgXrDkrfXylM1035QCrcTHN7m2DpbE95sU2A8EQb4wikvt5jM6K/73BPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0",
+        "react-aria": "3.48.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/interactions": {
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.28.0.tgz",
+      "integrity": "sha512-OXwdU1EWFdMxmr/K1CXNGJzmNlCClByb+PuCaqUyzBymHPCGVhawirLIon/CrIN5psh3AiWpHSh4H0WeJdVpng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.34.0",
+        "@swc/helpers": "^0.5.0",
+        "react-aria": "3.48.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/shared": {
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.34.0.tgz",
+      "integrity": "sha512-gp6xo/s2lX54AlTjOiqwDnxA7UW79BNvI9dB9pr3LZTzRKCd1ZA+ZbgKw/ReIiWuvvVw/8QFJpnqeeFyLocMcQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -3122,6 +3261,33 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.24",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.24.tgz",
+      "integrity": "sha512-aIJvz5OSkhNIhZIpYivrxrPTKYsjW9Uzy+sP/mx0S3sev2HyvPb7xmjbYvokzEpfgYHy/HjzJ2zFAETuUfgCpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.14.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.14.0.tgz",
+      "integrity": "sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -4276,6 +4442,18 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/aria-query": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
@@ -5064,6 +5242,15 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/co": {
@@ -11153,6 +11340,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-aria": {
+      "version": "3.48.0",
+      "resolved": "https://registry.npmjs.org/react-aria/-/react-aria-3.48.0.tgz",
+      "integrity": "sha512-jQjd4rBEIMqecBaAKYJbVGK6EqIHLa5znVQ7jwFyK5vCyljoj6KhgtiahmcIPsG5vG5vEDLw+ba+bEWn6A2P4w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.1",
+        "@internationalized/number": "^3.6.6",
+        "@internationalized/string": "^3.2.8",
+        "@react-types/shared": "^3.34.0",
+        "@swc/helpers": "^0.5.0",
+        "aria-hidden": "^1.2.3",
+        "clsx": "^2.0.0",
+        "react-stately": "3.46.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
@@ -11180,6 +11388,23 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-stately": {
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/react-stately/-/react-stately-3.46.0.tgz",
+      "integrity": "sha512-OdxhWvHgs2L4OJGIs7hnuTr5WjjMM6enhNEAMRqiekhF8+ITvA2LRwNftOZwcogaoCslGYq5S2VQTQwnm0GbCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.1",
+        "@internationalized/number": "^3.6.6",
+        "@internationalized/string": "^3.2.8",
+        "@react-types/shared": "^3.34.0",
+        "@swc/helpers": "^0.5.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
     },
     "node_modules/read-cache": {
       "version": "1.0.0",
@@ -12270,6 +12495,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "3.4.18",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.18.tgz",
@@ -13000,6 +13231,15 @@
       "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
       "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
       "license": "BSD"
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "vercel-build": "npm run build"
   },
   "dependencies": {
+    "@headlessui/react": "^2.2.10",
     "date-fns": "^4.1.0",
     "firebase": "^12.0.0",
     "firebase-admin": "^13.7.0",

--- a/src/app/admin/components/AddPersonnel.tsx
+++ b/src/app/admin/components/AddPersonnel.tsx
@@ -5,6 +5,7 @@ import { usePersonnelManagement } from '@/hooks/usePersonnelManagement';
 import { RANK_OPTIONS, USER_TYPE_OPTIONS, FORM_CONSTRAINTS } from '@/constants/admin';
 import { UserType } from '@/types/user';
 import { TEXT_CONSTANTS } from '@/constants/text';
+import { Select } from '@/components/ui';
 
 
 export default function AddPersonnel() {
@@ -104,23 +105,16 @@ export default function AddPersonnel() {
             <label htmlFor="rank" className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2">
               Military Rank *
             </label>
-            <select
+            <Select
               id="rank"
-              value={formData.rank}
-              onChange={(e) => handleInputChange('rank', e.target.value)}
-              className="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-600 rounded-md 
-                         bg-white dark:bg-neutral-700 text-neutral-900 dark:text-white
-                         focus:ring-2 focus:ring-info-500 focus:border-info-500
-                         disabled:opacity-50"
+              value={formData.rank || null}
+              onChange={(v) => handleInputChange('rank', v ?? '')}
+              options={RANK_OPTIONS.map((r) => ({ value: r.value, label: r.label }))}
+              placeholder="Select Rank"
+              clearable
               disabled={isLoading}
-            >
-              <option value="">Select Rank</option>
-              {RANK_OPTIONS.map((rank) => (
-                <option key={rank.value} value={rank.value}>
-                  {rank.label}
-                </option>
-              ))}
-            </select>
+              ariaLabel="Military Rank"
+            />
           </div>
 
           {/* User Type */}
@@ -128,22 +122,14 @@ export default function AddPersonnel() {
             <label htmlFor="userType" className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2">
               User Type *
             </label>
-            <select
+            <Select
               id="userType"
               value={formData.userType || UserType.USER}
-              onChange={(e) => handleInputChange('userType', e.target.value)}
-              className="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-600 rounded-md 
-                         bg-white dark:bg-neutral-700 text-neutral-900 dark:text-white
-                         focus:ring-2 focus:ring-info-500 focus:border-info-500
-                         disabled:opacity-50"
+              onChange={(v) => v && handleInputChange('userType', v)}
+              options={USER_TYPE_OPTIONS.map((o) => ({ value: o.value, label: o.label }))}
               disabled={isLoading}
-            >
-              {USER_TYPE_OPTIONS.map(option => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
-                </option>
-              ))}
-            </select>
+              ariaLabel="User Type"
+            />
             <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
               🔑 Determines system access level
             </p>

--- a/src/app/admin/components/UpdatePersonnel.tsx
+++ b/src/app/admin/components/UpdatePersonnel.tsx
@@ -7,6 +7,7 @@ import { formatPhoneForDisplay, normalizePhoneForSearch } from '@/utils/validati
 import { AuthorizedPersonnel } from '@/types/admin';
 import { UserType } from '@/types/user';
 import { TEXT_CONSTANTS } from '@/constants/text';
+import { Select } from '@/components/ui';
 
 
 
@@ -365,23 +366,15 @@ export default function UpdatePersonnel() {
                   <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2">
                     Military Rank (דרגה) *
                   </label>
-                  <select
-                    value={editForm.rank}
-                    onChange={(e) => handleFormChange('rank', e.target.value)}
-                    className="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-600 rounded-md 
-                               bg-white dark:bg-neutral-700 text-neutral-900 dark:text-white
-                               focus:ring-2 focus:ring-info-500 focus:border-info-500
-                               disabled:opacity-50"
+                  <Select
+                    value={editForm.rank || null}
+                    onChange={(v) => handleFormChange('rank', v ?? '')}
+                    options={RANK_OPTIONS.map((r) => ({ value: r.value, label: r.label }))}
+                    placeholder="Select Rank"
+                    clearable
                     disabled={isUpdating}
-                    required
-                  >
-                    <option value="">Select Rank</option>
-                    {RANK_OPTIONS.map(rank => (
-                      <option key={rank.value} value={rank.value}>
-                        {rank.label}
-                      </option>
-                    ))}
-                  </select>
+                    ariaLabel="Military Rank"
+                  />
                 </div>
 
                 {/* User Type */}
@@ -389,22 +382,13 @@ export default function UpdatePersonnel() {
                   <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2">
                     User Type (סוג משתמש) *
                   </label>
-                  <select
+                  <Select
                     value={editForm.userType}
-                    onChange={(e) => handleFormChange('userType', e.target.value)}
-                    className="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-600 rounded-md 
-                               bg-white dark:bg-neutral-700 text-neutral-900 dark:text-white
-                               focus:ring-2 focus:ring-info-500 focus:border-info-500
-                               disabled:opacity-50"
+                    onChange={(v) => v && handleFormChange('userType', v)}
+                    options={USER_TYPE_OPTIONS.map((t) => ({ value: t.value, label: t.label }))}
                     disabled={isUpdating}
-                    required
-                  >
-                    {USER_TYPE_OPTIONS.map(type => (
-                      <option key={type.value} value={type.value}>
-                        {type.label}
-                      </option>
-                    ))}
-                  </select>
+                    ariaLabel="User Type"
+                  />
                 </div>
 
                 {/* Phone Number */}

--- a/src/app/admin/components/ViewPersonnel.tsx
+++ b/src/app/admin/components/ViewPersonnel.tsx
@@ -6,6 +6,7 @@ import { formatPhoneForDisplay, normalizePhoneForSearch } from '@/utils/validati
 import { UserType } from '@/types/user';
 import ConfirmationModal from '@/components/ui/ConfirmationModal';
 import { TEXT_CONSTANTS } from '@/constants/text';
+import { Select } from '@/components/ui';
 
 
 export default function ViewPersonnel() {
@@ -187,18 +188,14 @@ export default function ViewPersonnel() {
             <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2">
               🎖️ Filter by Rank
             </label>
-            <select
-              value={selectedRank}
-              onChange={(e) => setSelectedRank(e.target.value)}
-              className="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-600 rounded-md 
-                         bg-white dark:bg-neutral-700 text-neutral-900 dark:text-white
-                         focus:ring-2 focus:ring-info-500 focus:border-info-500"
-            >
-              <option value="">All Ranks</option>
-              {uniqueRanks.map(rank => (
-                <option key={rank} value={rank}>{rank}</option>
-              ))}
-            </select>
+            <Select
+              value={selectedRank || null}
+              onChange={(v) => setSelectedRank(v ?? '')}
+              options={uniqueRanks.map((r) => ({ value: r, label: r }))}
+              placeholder="All Ranks"
+              clearable
+              ariaLabel="Filter by Rank"
+            />
           </div>
 
           {/* User Type Filter */}
@@ -206,20 +203,17 @@ export default function ViewPersonnel() {
             <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2">
               🔑 Filter by User Type
             </label>
-            <select
-              value={selectedUserType}
-              onChange={(e) => setSelectedUserType(e.target.value)}
-              className="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-600 rounded-md 
-                         bg-white dark:bg-neutral-700 text-neutral-900 dark:text-white
-                         focus:ring-2 focus:ring-info-500 focus:border-info-500"
-            >
-              <option value="">All User Types</option>
-              {uniqueUserTypes.map(userType => (
-                <option key={userType} value={userType}>
-                  {userType.replace('_', ' ').split(' ').map(word => word.charAt(0).toUpperCase() + word.slice(1)).join(' ')}
-                </option>
-              ))}
-            </select>
+            <Select
+              value={selectedUserType || null}
+              onChange={(v) => setSelectedUserType(v ?? '')}
+              options={uniqueUserTypes.map((u) => ({
+                value: u,
+                label: u.replace('_', ' ').split(' ').map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(' '),
+              }))}
+              placeholder="All User Types"
+              clearable
+              ariaLabel="Filter by User Type"
+            />
           </div>
 
           {/* Filter by Registration Status */}
@@ -227,17 +221,16 @@ export default function ViewPersonnel() {
             <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2">
               📋 Registration Status
             </label>
-            <select
+            <Select
               value={registrationFilter}
-              onChange={(e) => setRegistrationFilter(e.target.value as 'all' | 'registered' | 'pending')}
-              className="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-600 rounded-md 
-                         bg-white dark:bg-neutral-700 text-neutral-900 dark:text-white
-                         focus:ring-2 focus:ring-info-500 focus:border-info-500"
-            >
-              <option value="all">All Status</option>
-              <option value="registered">✅ Registered</option>
-              <option value="pending">⏳ Pending</option>
-            </select>
+              onChange={(v) => v && setRegistrationFilter(v as 'all' | 'registered' | 'pending')}
+              options={[
+                { value: 'all', label: 'All Status' },
+                { value: 'registered', label: '✅ Registered' },
+                { value: 'pending', label: '⏳ Pending' },
+              ]}
+              ariaLabel="Registration Status"
+            />
           </div>
 
           {/* Sort By */}
@@ -245,17 +238,16 @@ export default function ViewPersonnel() {
             <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2">
               📊 Sort By
             </label>
-            <select
+            <Select
               value={sortBy}
-              onChange={(e) => setSortBy(e.target.value as 'name' | 'rank' | 'created')}
-              className="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-600 rounded-md 
-                         bg-white dark:bg-neutral-700 text-neutral-900 dark:text-white
-                         focus:ring-2 focus:ring-info-500 focus:border-info-500"
-            >
-              <option value="created">Creation Date</option>
-              <option value="name">Name</option>
-              <option value="rank">Rank</option>
-            </select>
+              onChange={(v) => v && setSortBy(v as 'name' | 'rank' | 'created')}
+              options={[
+                { value: 'created', label: 'Creation Date' },
+                { value: 'name', label: 'Name' },
+                { value: 'rank', label: 'Rank' },
+              ]}
+              ariaLabel="Sort By"
+            />
           </div>
 
           {/* Sort Order */}
@@ -263,16 +255,15 @@ export default function ViewPersonnel() {
             <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2">
               🔄 Order
             </label>
-            <select
+            <Select
               value={sortOrder}
-              onChange={(e) => setSortOrder(e.target.value as 'asc' | 'desc')}
-              className="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-600 rounded-md 
-                         bg-white dark:bg-neutral-700 text-neutral-900 dark:text-white
-                         focus:ring-2 focus:ring-info-500 focus:border-info-500"
-            >
-              <option value="desc">Newest First</option>
-              <option value="asc">Oldest First</option>
-            </select>
+              onChange={(v) => v && setSortOrder(v as 'asc' | 'desc')}
+              options={[
+                { value: 'desc', label: 'Newest First' },
+                { value: 'asc', label: 'Oldest First' },
+              ]}
+              ariaLabel="Sort Order"
+            />
           </div>
         </div>
 

--- a/src/app/components/AddSoldierForm.tsx
+++ b/src/app/components/AddSoldierForm.tsx
@@ -3,6 +3,7 @@ import { GiTank } from "react-icons/gi";
 import { MdNotListedLocation } from "react-icons/md";
 import { FormErrors, NewSoldierForm } from '../../types';
 import { TEXT_CONSTANTS } from '@/constants/text';
+import { Select } from '@/components/ui';
 
 interface AddSoldierFormProps {
   showForm: boolean;
@@ -105,20 +106,14 @@ export default function AddSoldierForm({
               <label className="block text-sm font-medium text-neutral-700 mb-1 pr-1.5">
                 צוות <span className="text-danger-500">*</span>
               </label>
-              <select 
-                value={newSoldier.platoon}
-                onChange={handlePlatoonChange}
-                className={`w-full h-10 border-2 rounded-md px-3 py-2 text-neutral-800 focus:outline-none focus:ring-2 ${
-                  formErrors.platoon 
-                    ? 'border-danger-500 focus:ring-danger-500 focus:border-danger-500' 
-                    : 'border-neutral-400 focus:ring-primary-500 focus:border-primary-500'
-                }`}
-              >
-                <option value="">בחר צוות</option>
-                {uniquePlatoons.map(platoon => (
-                  <option key={platoon} value={platoon}>{platoon}</option>
-                ))}
-              </select>
+              <Select
+                value={newSoldier.platoon || null}
+                onChange={(v) => handlePlatoonChange({ target: { value: v ?? '' } } as React.ChangeEvent<HTMLSelectElement>)}
+                options={uniquePlatoons.map((p) => ({ value: p, label: p }))}
+                placeholder="בחר צוות"
+                clearable
+                ariaLabel="צוות"
+              />
               {formErrors.platoon && (
                 <p className="mt-1 text-sm text-danger-600">{formErrors.platoon}</p>
               )}

--- a/src/app/equipment/page.tsx
+++ b/src/app/equipment/page.tsx
@@ -21,6 +21,7 @@ import TransferModal from '@/components/equipment/TransferModal';
 import ActionHistoryPanel from '@/components/equipment/ActionHistoryPanel';
 import { type Equipment, EquipmentStatus } from '@/types/equipment';
 import PersonalAmmunitionSection from '@/components/equipment/PersonalAmmunitionSection';
+import { Select } from '@/components/ui';
 
 type ActiveModal =
   | { kind: 'wizard' }
@@ -269,18 +270,20 @@ function FilterBar({
           className="w-full ps-9 pe-3 py-2 text-sm border border-neutral-200 rounded-lg bg-neutral-50 focus:bg-white focus:ring-2 focus:ring-primary-500"
         />
       </div>
-      <select
-        value={statusFilter}
-        onChange={(e) => onStatusChange(e.target.value as EquipmentStatus | 'all')}
-        className="px-3 py-2 text-sm border border-neutral-200 rounded-lg bg-neutral-50 focus:ring-2 focus:ring-primary-500"
-      >
-        <option value="all">{TEXT_CONSTANTS.FEATURES.EQUIPMENT.ALL_STATUSES}</option>
-        <option value={EquipmentStatus.AVAILABLE}>{TEXT_CONSTANTS.FEATURES.EQUIPMENT.STATUS_OPTIONS.AVAILABLE}</option>
-        <option value={EquipmentStatus.SECURITY}>{TEXT_CONSTANTS.FEATURES.EQUIPMENT.STATUS_OPTIONS.SECURITY}</option>
-        <option value={EquipmentStatus.REPAIR}>{TEXT_CONSTANTS.FEATURES.EQUIPMENT.STATUS_OPTIONS.REPAIR}</option>
-        <option value={EquipmentStatus.LOST}>{TEXT_CONSTANTS.FEATURES.EQUIPMENT.STATUS_OPTIONS.LOST}</option>
-        <option value={EquipmentStatus.PENDING_TRANSFER}>{TEXT_CONSTANTS.FEATURES.EQUIPMENT.STATUS_OPTIONS.PENDING_TRANSFER}</option>
-      </select>
+      <Select
+        value={statusFilter === 'all' ? null : statusFilter}
+        onChange={(v) => onStatusChange(v === null ? 'all' : (v as EquipmentStatus))}
+        options={[
+          { value: EquipmentStatus.AVAILABLE, label: TEXT_CONSTANTS.FEATURES.EQUIPMENT.STATUS_OPTIONS.AVAILABLE },
+          { value: EquipmentStatus.SECURITY, label: TEXT_CONSTANTS.FEATURES.EQUIPMENT.STATUS_OPTIONS.SECURITY },
+          { value: EquipmentStatus.REPAIR, label: TEXT_CONSTANTS.FEATURES.EQUIPMENT.STATUS_OPTIONS.REPAIR },
+          { value: EquipmentStatus.LOST, label: TEXT_CONSTANTS.FEATURES.EQUIPMENT.STATUS_OPTIONS.LOST },
+          { value: EquipmentStatus.PENDING_TRANSFER, label: TEXT_CONSTANTS.FEATURES.EQUIPMENT.STATUS_OPTIONS.PENDING_TRANSFER },
+        ]}
+        placeholder={TEXT_CONSTANTS.FEATURES.EQUIPMENT.ALL_STATUSES}
+        clearable
+        ariaLabel={TEXT_CONSTANTS.FEATURES.EQUIPMENT.ALL_STATUSES}
+      />
     </div>
   );
 }

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -6,6 +6,7 @@ import AuthGuard from '@/components/auth/AuthGuard';
 import AppShell from '@/app/components/AppShell';
 import { TEXT_CONSTANTS } from '@/constants/text';
 import ProfileImageUpload from '@/components/profile/ProfileImageUpload';
+import { Select } from '@/components/ui';
 import { 
   UserIcon, 
   PhoneIcon, 
@@ -273,15 +274,18 @@ export default function SettingsPage() {
                     </p>
                   </div>
                 </div>
-                <select
-                  value={settings.language}
-                  onChange={(e) => setSettings(prev => ({ ...prev, language: e.target.value }))}
-                  disabled
-                  className="px-3 py-2 border border-neutral-300 rounded-lg text-sm bg-neutral-100 text-neutral-400 cursor-not-allowed"
-                >
-                  <option value="hebrew">{TEXT_CONSTANTS.SETTINGS.LANGUAGE_HEBREW}</option>
-                  <option value="english">{TEXT_CONSTANTS.SETTINGS.LANGUAGE_ENGLISH}</option>
-                </select>
+                <div className="min-w-[10rem]">
+                  <Select
+                    value={settings.language}
+                    onChange={(v) => v && setSettings(prev => ({ ...prev, language: v }))}
+                    options={[
+                      { value: 'hebrew', label: TEXT_CONSTANTS.SETTINGS.LANGUAGE_HEBREW },
+                      { value: 'english', label: TEXT_CONSTANTS.SETTINGS.LANGUAGE_ENGLISH },
+                    ]}
+                    disabled
+                    ariaLabel={TEXT_CONSTANTS.SETTINGS.LANGUAGE_HEBREW}
+                  />
+                </div>
               </div>
 
               {/* Theme Switcher */}
@@ -297,15 +301,18 @@ export default function SettingsPage() {
                     </p>
                   </div>
                 </div>
-                <select
-                  value={settings.theme}
-                  onChange={(e) => setSettings(prev => ({ ...prev, theme: e.target.value }))}
-                  disabled
-                  className="px-3 py-2 border border-neutral-300 rounded-lg text-sm bg-neutral-100 text-neutral-400 cursor-not-allowed"
-                >
-                  <option value="light">{TEXT_CONSTANTS.SETTINGS.THEME_LIGHT}</option>
-                  <option value="dark">{TEXT_CONSTANTS.SETTINGS.THEME_DARK}</option>
-                </select>
+                <div className="min-w-[10rem]">
+                  <Select
+                    value={settings.theme}
+                    onChange={(v) => v && setSettings(prev => ({ ...prev, theme: v }))}
+                    options={[
+                      { value: 'light', label: TEXT_CONSTANTS.SETTINGS.THEME_LIGHT },
+                      { value: 'dark', label: TEXT_CONSTANTS.SETTINGS.THEME_DARK },
+                    ]}
+                    disabled
+                    ariaLabel={TEXT_CONSTANTS.SETTINGS.THEME_SWITCHER}
+                  />
+                </div>
               </div>
             </div>
           </div>

--- a/src/app/status/page.tsx
+++ b/src/app/status/page.tsx
@@ -17,6 +17,7 @@ import { Download } from "lucide-react";
 import SoldiersTableDesktop from '../components/SoldiersTableDesktop';
 import SoldiersTableMobile from '../components/SoldiersTableMobile';
 import AuthGuard from '@/components/auth/AuthGuard';
+import { Select } from '@/components/ui';
 // import { 
 //   createToggleAllVisibleHandler,
 //   createSelectAllHandler,
@@ -849,20 +850,14 @@ export default function StatusPage() {
                     <label className="block text-sm font-medium text-neutral-700 mb-1 pr-1.5">
                       צוות <span className="text-danger-500">*</span>
                     </label>
-                    <select 
-                      value={newSoldier.platoon}
-                      onChange={handlePlatoonChange}
-                      className={`w-full h-10 border-2 rounded-md px-3 py-2 text-neutral-800 focus:outline-none focus:ring-2 ${
-                        formErrors.platoon 
-                          ? 'border-danger-500 focus:ring-danger-500 focus:border-danger-500' 
-                          : 'border-neutral-400 focus:ring-primary-500 focus:border-primary-500'
-                      }`}
-                    >
-                      <option value="">{TEXT_CONSTANTS.STATUS_PAGE.SELECT_TEAM}</option>
-                      {uniquePlatoons.map(platoon => (
-                        <option key={platoon} value={platoon}>{platoon}</option>
-                      ))}
-                    </select>
+                    <Select
+                      value={newSoldier.platoon || null}
+                      onChange={(v) => handlePlatoonChange({ target: { value: v ?? '' } } as React.ChangeEvent<HTMLSelectElement>)}
+                      options={uniquePlatoons.map((p) => ({ value: p, label: p }))}
+                      placeholder={TEXT_CONSTANTS.STATUS_PAGE.SELECT_TEAM}
+                      clearable
+                      ariaLabel="צוות"
+                    />
                     {formErrors.platoon && (
                       <p className="mt-1 text-sm text-danger-600">{formErrors.platoon}</p>
                     )}

--- a/src/components/ammunition/AddInventoryModal.tsx
+++ b/src/components/ammunition/AddInventoryModal.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useMemo, useState } from 'react';
 import { X } from 'lucide-react';
-import { Button } from '@/components/ui';
+import { Button, Select } from '@/components/ui';
 import { FEATURES } from '@/constants/text';
 import UserSearchInput from '@/components/users/UserSearchInput';
 import type { UserSearchResult } from '@/lib/userService';
@@ -179,17 +179,15 @@ export default function AddInventoryModal({
 
           <div>
             <label className="block text-sm font-medium text-neutral-700 mb-1">פריט</label>
-            <select
+            <Select
               value={templateId}
-              onChange={(e) => setTemplateId(e.target.value)}
-              className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:ring-2 focus:ring-primary-500"
-            >
-              {selectableTemplates.map((t) => (
-                <option key={t.id} value={t.id}>
-                  {t.name} · {T.TRACKING_MODE[t.trackingMode]}
-                </option>
-              ))}
-            </select>
+              onChange={(v) => v && setTemplateId(v)}
+              options={selectableTemplates.map((t) => ({
+                value: t.id,
+                label: `${t.name} · ${T.TRACKING_MODE[t.trackingMode]}`,
+              }))}
+              ariaLabel="פריט"
+            />
           </div>
 
           {allowHolderPicker && isManagerOrTL && (
@@ -262,17 +260,15 @@ export default function AddInventoryModal({
                 <label className="block text-sm font-medium text-neutral-700 mb-1">
                   מצב ברוס פתוח
                 </label>
-                <select
+                <Select
                   value={openBruceState}
-                  onChange={(e) => setOpenBruceState(e.target.value as BruceState)}
-                  className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:ring-2 focus:ring-primary-500"
-                >
-                  {BRUCE_STATES.map((s) => (
-                    <option key={s} value={s}>
-                      {T.BRUCE_STATE[s]}
-                    </option>
-                  ))}
-                </select>
+                  onChange={(v) => v && setOpenBruceState(v as BruceState)}
+                  options={BRUCE_STATES.map((s) => ({
+                    value: s,
+                    label: T.BRUCE_STATE[s],
+                  }))}
+                  ariaLabel="מצב ברוס פתוח"
+                />
               </div>
             </div>
           )}

--- a/src/components/ammunition/AmmunitionTemplateForm.tsx
+++ b/src/components/ammunition/AmmunitionTemplateForm.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
-import { Button } from '@/components/ui';
+import React, { useEffect, useMemo, useState } from 'react';
+import { Button, Select } from '@/components/ui';
 import { FEATURES } from '@/constants/text';
 import { AMMUNITION_SUBCATEGORIES } from '@/lib/ammunition/subcategories';
 import type {
@@ -86,6 +86,39 @@ export default function AmmunitionTemplateForm({
     v: AmmunitionTemplateFormValues[K]
   ) => setValues((prev) => ({ ...prev, [k]: v }));
 
+  const subcategoryOptions = useMemo(
+    () =>
+      AMMUNITION_SUBCATEGORIES.map((s) => ({
+        value: s,
+        label: T.SUBCATEGORIES[s],
+      })),
+    []
+  );
+  const allocationOptions = useMemo(
+    () =>
+      (['USER', 'TEAM', 'BOTH'] as AmmunitionAllocation[]).map((a) => ({
+        value: a,
+        label: T.ALLOCATION[a],
+      })),
+    []
+  );
+  const trackingOptions = useMemo(
+    () =>
+      (['BRUCE', 'SERIAL', 'LOOSE_COUNT'] as TrackingMode[]).map((m) => ({
+        value: m,
+        label: T.TRACKING_MODE[m],
+      })),
+    []
+  );
+  const securityOptions = useMemo(
+    () =>
+      (['EXPLOSIVE', 'GRABBABLE'] as SecurityLevel[]).map((s) => ({
+        value: s,
+        label: T.SECURITY_LEVEL[s],
+      })),
+    []
+  );
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (values.name.trim().length < 2) {
@@ -134,61 +167,48 @@ export default function AmmunitionTemplateForm({
           <label className="block text-sm font-medium text-neutral-700 mb-1">
             {T.TEMPLATE_FORM.SUBCATEGORY}
           </label>
-          <select
+          <Select
             value={values.subcategory}
-            onChange={(e) => set('subcategory', e.target.value as AmmunitionSubcategory)}
-            className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
-          >
-            {AMMUNITION_SUBCATEGORIES.map((s) => (
-              <option key={s} value={s}>
-                {T.SUBCATEGORIES[s]}
-              </option>
-            ))}
-          </select>
+            onChange={(v) => v && set('subcategory', v as AmmunitionSubcategory)}
+            options={subcategoryOptions}
+            ariaLabel={T.TEMPLATE_FORM.SUBCATEGORY}
+          />
         </div>
 
         <div>
           <label className="block text-sm font-medium text-neutral-700 mb-1">
             {T.TEMPLATE_FORM.ALLOCATION}
           </label>
-          <select
+          <Select
             value={values.allocation}
-            onChange={(e) => set('allocation', e.target.value as AmmunitionAllocation)}
-            className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
-          >
-            <option value="USER">{T.ALLOCATION.USER}</option>
-            <option value="TEAM">{T.ALLOCATION.TEAM}</option>
-            <option value="BOTH">{T.ALLOCATION.BOTH}</option>
-          </select>
+            onChange={(v) => v && set('allocation', v as AmmunitionAllocation)}
+            options={allocationOptions}
+            ariaLabel={T.TEMPLATE_FORM.ALLOCATION}
+          />
         </div>
 
         <div>
           <label className="block text-sm font-medium text-neutral-700 mb-1">
             {T.TEMPLATE_FORM.TRACKING_MODE}
           </label>
-          <select
+          <Select
             value={values.trackingMode}
-            onChange={(e) => set('trackingMode', e.target.value as TrackingMode)}
-            className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
-          >
-            <option value="BRUCE">{T.TRACKING_MODE.BRUCE}</option>
-            <option value="SERIAL">{T.TRACKING_MODE.SERIAL}</option>
-            <option value="LOOSE_COUNT">{T.TRACKING_MODE.LOOSE_COUNT}</option>
-          </select>
+            onChange={(v) => v && set('trackingMode', v as TrackingMode)}
+            options={trackingOptions}
+            ariaLabel={T.TEMPLATE_FORM.TRACKING_MODE}
+          />
         </div>
 
         <div>
           <label className="block text-sm font-medium text-neutral-700 mb-1">
             {T.TEMPLATE_FORM.SECURITY_LEVEL}
           </label>
-          <select
+          <Select
             value={values.securityLevel}
-            onChange={(e) => set('securityLevel', e.target.value as SecurityLevel)}
-            className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
-          >
-            <option value="EXPLOSIVE">{T.SECURITY_LEVEL.EXPLOSIVE}</option>
-            <option value="GRABBABLE">{T.SECURITY_LEVEL.GRABBABLE}</option>
-          </select>
+            onChange={(v) => v && set('securityLevel', v as SecurityLevel)}
+            options={securityOptions}
+            ariaLabel={T.TEMPLATE_FORM.SECURITY_LEVEL}
+          />
         </div>
       </div>
 

--- a/src/components/ammunition/ReportUsageForm.tsx
+++ b/src/components/ammunition/ReportUsageForm.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useMemo, useState } from 'react';
 import { X } from 'lucide-react';
-import { Button } from '@/components/ui';
+import { Button, Select } from '@/components/ui';
 import { FEATURES } from '@/constants/text';
 import type {
   AmmunitionItem,
@@ -204,17 +204,15 @@ export default function ReportUsageForm({
                 <label className="block text-sm font-medium text-neutral-700 mb-1">
                   {T.REPORT_FORM.TEMPLATE}
                 </label>
-                <select
+                <Select
                   value={templateId}
-                  onChange={(e) => setTemplateId(e.target.value)}
-                  className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:ring-2 focus:ring-primary-500"
-                >
-                  {reportableTemplates.map((t) => (
-                    <option key={t.id} value={t.id}>
-                      {t.name} · {T.TRACKING_MODE[t.trackingMode]}
-                    </option>
-                  ))}
-                </select>
+                  onChange={(v) => v && setTemplateId(v)}
+                  options={reportableTemplates.map((t) => ({
+                    value: t.id,
+                    label: `${t.name} · ${T.TRACKING_MODE[t.trackingMode]}`,
+                  }))}
+                  ariaLabel={T.REPORT_FORM.TEMPLATE}
+                />
               </div>
 
               {template?.trackingMode === 'BRUCE' && (
@@ -261,17 +259,15 @@ export default function ReportUsageForm({
                     <label className="block text-xs font-medium text-neutral-700 mb-1">
                       {T.REPORT_FORM.FINAL_BRUCE_STATE}
                     </label>
-                    <select
+                    <Select
                       value={finalState}
-                      onChange={(e) => setFinalState(e.target.value as BruceState)}
-                      className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:ring-2 focus:ring-primary-500"
-                    >
-                      {BRUCE_STATES.map((s) => (
-                        <option key={s} value={s}>
-                          {T.BRUCE_STATE[s]}
-                        </option>
-                      ))}
-                    </select>
+                      onChange={(v) => v && setFinalState(v as BruceState)}
+                      options={BRUCE_STATES.map((s) => ({
+                        value: s,
+                        label: T.BRUCE_STATE[s],
+                      }))}
+                      ariaLabel={T.REPORT_FORM.FINAL_BRUCE_STATE}
+                    />
                   </div>
                   {myStockEntry && (
                     <p className="text-xs text-neutral-500">

--- a/src/components/equipment/EquipmentTable.tsx
+++ b/src/components/equipment/EquipmentTable.tsx
@@ -7,6 +7,7 @@ import type { Equipment } from '@/types/equipment';
 import { EquipmentStatus } from '@/types/equipment';
 import type { EnhancedAuthUser } from '@/types/user';
 import { TEXT_CONSTANTS } from '@/constants/text';
+import { Select } from '@/components/ui';
 import StatusComponent from './EquipmentStatus';
 import ConditionComponent from './EquipmentCondition';
 import EquipmentRowActions, { type EquipmentRowAction } from './EquipmentRowActions';
@@ -142,15 +143,18 @@ function SortBar({
       </label>
       <span className="text-neutral-300">|</span>
       <span className="text-neutral-500">מיון:</span>
-      <select
-        value={sortField}
-        onChange={(e) => onChangeField(e.target.value as SortField)}
-        className="px-2 py-1 text-xs border border-neutral-200 rounded-md bg-white focus:ring-2 focus:ring-primary-500"
-      >
-        {(Object.keys(sortLabels) as SortField[]).map((f) => (
-          <option key={f} value={f}>{sortLabels[f]}</option>
-        ))}
-      </select>
+      <div className="min-w-[8rem]">
+        <Select
+          value={sortField}
+          onChange={(v) => v && onChangeField(v as SortField)}
+          options={(Object.keys(sortLabels) as SortField[]).map((f) => ({
+            value: f,
+            label: sortLabels[f],
+          }))}
+          className="text-xs py-1"
+          ariaLabel="מיון"
+        />
+      </div>
       <button
         type="button"
         onClick={onToggleOrder}

--- a/src/components/equipment/template-form/FormFieldCategory.tsx
+++ b/src/components/equipment/template-form/FormFieldCategory.tsx
@@ -4,7 +4,7 @@
 
 import React, { useState } from 'react';
 import { Plus } from 'lucide-react';
-import { FormField, Button } from '@/components/ui';
+import { FormField, Button, Select } from '@/components/ui';
 import { TEXT_CONSTANTS } from '@/constants/text';
 import { Category } from './types';
 import { CategoriesService } from '@/lib/categoriesService';
@@ -62,25 +62,19 @@ export default function FormFieldCategory({
         required
         error={error}
       >
-        <div className="space-y-2">
-          <select
-            value={value}
-            onChange={(e) => onChange(e.target.value)}
-            disabled={disabled}
-            className="input-base max-w-sm text-sm"
-          >
-            <option value="">
-              {categories.length === 0 
-                ? 'אין קטגוריות עדיין - צור ראשונה' 
+        <div className="space-y-2 max-w-sm">
+          <Select
+            value={value || null}
+            onChange={(v) => onChange(v ?? '')}
+            options={categories.map((c) => ({ value: c.id, label: c.name }))}
+            placeholder={
+              categories.length === 0
+                ? 'אין קטגוריות עדיין - צור ראשונה'
                 : TEXT_CONSTANTS.FEATURES.EQUIPMENT.TEMPLATE_FORM.SELECT_CATEGORY
-              }
-            </option>
-            {categories.map(category => (
-              <option key={category.id} value={category.id}>
-                {category.name}
-              </option>
-            ))}
-          </select>
+            }
+            disabled={disabled}
+            ariaLabel={TEXT_CONSTANTS.FEATURES.EQUIPMENT.TEMPLATE_FORM.CATEGORY}
+          />
           <button
             type="button"
             onClick={() => setShowAddModal(true)}

--- a/src/components/equipment/template-form/FormFieldDefaultValues.tsx
+++ b/src/components/equipment/template-form/FormFieldDefaultValues.tsx
@@ -3,7 +3,7 @@
  */
 
 import React from 'react';
-import { FormField } from '@/components/ui';
+import { FormField, Select } from '@/components/ui';
 import { TEXT_CONSTANTS } from '@/constants/text';
 import { EquipmentStatus, EquipmentCondition } from '@/types/equipment';
 
@@ -22,35 +22,42 @@ export default function FormFieldDefaultValues({
   onConditionChange,
   disabled = false
 }: FormFieldDefaultValuesProps) {
+  const statusOptions = [
+    { value: EquipmentStatus.AVAILABLE, label: TEXT_CONSTANTS.FEATURES.EQUIPMENT.STATUS_OPTIONS.AVAILABLE },
+    { value: EquipmentStatus.SECURITY, label: TEXT_CONSTANTS.FEATURES.EQUIPMENT.STATUS_OPTIONS.SECURITY },
+    { value: EquipmentStatus.REPAIR, label: TEXT_CONSTANTS.FEATURES.EQUIPMENT.STATUS_OPTIONS.REPAIR },
+    { value: EquipmentStatus.LOST, label: TEXT_CONSTANTS.FEATURES.EQUIPMENT.STATUS_OPTIONS.LOST },
+  ];
+  const conditionOptions = [
+    { value: EquipmentCondition.GOOD, label: TEXT_CONSTANTS.FEATURES.EQUIPMENT.CONDITION_OPTIONS.GOOD },
+    { value: EquipmentCondition.NEEDS_REPAIR, label: TEXT_CONSTANTS.FEATURES.EQUIPMENT.CONDITION_OPTIONS.NEEDS_REPAIR },
+    { value: EquipmentCondition.WORN, label: TEXT_CONSTANTS.FEATURES.EQUIPMENT.CONDITION_OPTIONS.WORN },
+  ];
+
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
       <FormField
         label={TEXT_CONSTANTS.FEATURES.EQUIPMENT.TEMPLATE_FORM.DEFAULT_STATUS}
       >
-        <select
+        <Select
           value={defaultStatus}
-          onChange={(e) => onStatusChange(e.target.value as EquipmentStatus)}
+          onChange={(v) => v && onStatusChange(v as EquipmentStatus)}
+          options={statusOptions}
           disabled={disabled}
-        >
-          <option value={EquipmentStatus.AVAILABLE}>{TEXT_CONSTANTS.FEATURES.EQUIPMENT.STATUS_OPTIONS.AVAILABLE}</option>
-          <option value={EquipmentStatus.SECURITY}>{TEXT_CONSTANTS.FEATURES.EQUIPMENT.STATUS_OPTIONS.SECURITY}</option>
-          <option value={EquipmentStatus.REPAIR}>{TEXT_CONSTANTS.FEATURES.EQUIPMENT.STATUS_OPTIONS.REPAIR}</option>
-          <option value={EquipmentStatus.LOST}>{TEXT_CONSTANTS.FEATURES.EQUIPMENT.STATUS_OPTIONS.LOST}</option>
-        </select>
+          ariaLabel={TEXT_CONSTANTS.FEATURES.EQUIPMENT.TEMPLATE_FORM.DEFAULT_STATUS}
+        />
       </FormField>
 
       <FormField
         label={TEXT_CONSTANTS.FEATURES.EQUIPMENT.TEMPLATE_FORM.DEFAULT_CONDITION}
       >
-        <select
+        <Select
           value={defaultCondition}
-          onChange={(e) => onConditionChange(e.target.value as EquipmentCondition)}
+          onChange={(v) => v && onConditionChange(v as EquipmentCondition)}
+          options={conditionOptions}
           disabled={disabled}
-        >
-          <option value={EquipmentCondition.GOOD}>{TEXT_CONSTANTS.FEATURES.EQUIPMENT.CONDITION_OPTIONS.GOOD}</option>
-          <option value={EquipmentCondition.NEEDS_REPAIR}>{TEXT_CONSTANTS.FEATURES.EQUIPMENT.CONDITION_OPTIONS.NEEDS_REPAIR}</option>
-          <option value={EquipmentCondition.WORN}>{TEXT_CONSTANTS.FEATURES.EQUIPMENT.CONDITION_OPTIONS.WORN}</option>
-        </select>
+          ariaLabel={TEXT_CONSTANTS.FEATURES.EQUIPMENT.TEMPLATE_FORM.DEFAULT_CONDITION}
+        />
       </FormField>
     </div>
   );

--- a/src/components/equipment/template-form/FormFieldSubcategory.tsx
+++ b/src/components/equipment/template-form/FormFieldSubcategory.tsx
@@ -4,7 +4,7 @@
 
 import React, { useState } from 'react';
 import { Plus } from 'lucide-react';
-import { FormField, Button } from '@/components/ui';
+import { FormField, Button, Select } from '@/components/ui';
 import { TEXT_CONSTANTS } from '@/constants/text';
 import { Subcategory } from './types';
 import { CategoriesService } from '@/lib/categoriesService';
@@ -66,27 +66,21 @@ export default function FormFieldSubcategory({
         required
         error={error}
       >
-        <div className="space-y-2">
-          <select
-            value={value}
-            onChange={(e) => onChange(e.target.value)}
-            disabled={isSubcategoryDisabled}
-            className="input-base max-w-sm text-sm"
-          >
-            <option value="">
-              {!selectedCategoryId 
+        <div className="space-y-2 max-w-sm">
+          <Select
+            value={value || null}
+            onChange={(v) => onChange(v ?? '')}
+            options={subcategories.map((s) => ({ value: s.id, label: s.name }))}
+            placeholder={
+              !selectedCategoryId
                 ? 'בחר קטגוריה תחילה'
-                : subcategories.length === 0 
+                : subcategories.length === 0
                   ? 'אין תת-קטגוריות עדיין - צור ראשונה'
                   : TEXT_CONSTANTS.FEATURES.EQUIPMENT.TEMPLATE_FORM.SELECT_SUBCATEGORY
-              }
-            </option>
-            {subcategories.map(subcategory => (
-              <option key={subcategory.id} value={subcategory.id}>
-                {subcategory.name}
-              </option>
-            ))}
-          </select>
+            }
+            disabled={isSubcategoryDisabled}
+            ariaLabel={TEXT_CONSTANTS.FEATURES.EQUIPMENT.TEMPLATE_FORM.SUBCATEGORY}
+          />
           {selectedCategoryId && (
             <button
               type="button"

--- a/src/components/equipment/wizard/WizardStepTemplate.tsx
+++ b/src/components/equipment/wizard/WizardStepTemplate.tsx
@@ -5,6 +5,7 @@ import { TEXT_CONSTANTS } from '@/constants/text';
 import { type EquipmentType, TemplateStatus } from '@/types/equipment';
 import { CategoriesService, type Category } from '@/lib/categories';
 import { EquipmentService } from '@/lib/equipmentService';
+import { Select } from '@/components/ui';
 
 interface Props {
   categoryId: string | null;
@@ -58,7 +59,10 @@ export default function WizardStepTemplate({
     () => categories.find((c) => c.id === categoryId) ?? null,
     [categories, categoryId],
   );
-  const subcategories = selectedCategory?.subcategories ?? [];
+  const subcategories = useMemo(
+    () => selectedCategory?.subcategories ?? [],
+    [selectedCategory],
+  );
 
   const filteredTemplates = useMemo(() => {
     if (!categoryId) return [];
@@ -69,24 +73,30 @@ export default function WizardStepTemplate({
     });
   }, [allTemplates, categoryId, subcategoryId]);
 
+  const categoryOptions = useMemo(
+    () => categories.map((c) => ({ value: c.id, label: c.name })),
+    [categories],
+  );
+  const subcategoryOptions = useMemo(
+    () => subcategories.map((s) => ({ value: s.id, label: s.name })),
+    [subcategories],
+  );
+
   return (
     <div className="space-y-4">
       <div>
         <label className="block text-sm font-medium text-neutral-700 mb-1">{labels.CATEGORY}</label>
-        <select
-          value={categoryId ?? ''}
-          onChange={(e) => {
-            onSelectCategory(e.target.value || null);
+        <Select
+          value={categoryId}
+          onChange={(v) => {
+            onSelectCategory(v);
             onSelectSubcategory(null);
           }}
+          options={categoryOptions}
+          clearable
           disabled={loadingCats}
-          className="input-base text-sm truncate"
-        >
-          <option value="">—</option>
-          {categories.map((c) => (
-            <option key={c.id} value={c.id}>{c.name}</option>
-          ))}
-        </select>
+          ariaLabel={labels.CATEGORY}
+        />
         {!loadingCats && categories.length === 0 && (
           <p className="text-xs text-neutral-500 mt-1">{labels.EMPTY_CATEGORIES}</p>
         )}
@@ -95,16 +105,13 @@ export default function WizardStepTemplate({
       {selectedCategory && subcategories.length > 0 && (
         <div>
           <label className="block text-sm font-medium text-neutral-700 mb-1">{labels.SUBCATEGORY}</label>
-          <select
-            value={subcategoryId ?? ''}
-            onChange={(e) => onSelectSubcategory(e.target.value || null)}
-            className="input-base text-sm truncate"
-          >
-            <option value="">—</option>
-            {subcategories.map((s) => (
-              <option key={s.id} value={s.id}>{s.name}</option>
-            ))}
-          </select>
+          <Select
+            value={subcategoryId}
+            onChange={(v) => onSelectSubcategory(v)}
+            options={subcategoryOptions}
+            clearable
+            ariaLabel={labels.SUBCATEGORY}
+          />
         </div>
       )}
 

--- a/src/components/management/tabs/AuditLogsTab.tsx
+++ b/src/components/management/tabs/AuditLogsTab.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/lib/actionsLogService';
 import { ActionsLog } from '@/types/equipment';
 import { Timestamp } from 'firebase/firestore';
+import { Select } from '@/components/ui';
 
 export default function AuditLogsTab() {
   const [dateFrom, setDateFrom] = useState('');
@@ -105,17 +106,19 @@ export default function AuditLogsTab() {
           </div>
           <div>
             <label className="block text-sm font-medium text-neutral-700 mb-2">סוג פעולה</label>
-            <select
-              className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
-              value={actionFilter}
-              onChange={(e) => setActionFilter(e.target.value)}
-            >
-              <option value="all">כל הפעולות</option>
-              <option value="transfer">העברות</option>
-              <option value="created">יצירה</option>
-              <option value="update">עדכון</option>
-              <option value="reject">דחייה</option>
-            </select>
+            <Select
+              value={actionFilter === 'all' ? null : actionFilter}
+              onChange={(v) => setActionFilter(v ?? 'all')}
+              options={[
+                { value: 'transfer', label: 'העברות' },
+                { value: 'created', label: 'יצירה' },
+                { value: 'update', label: 'עדכון' },
+                { value: 'reject', label: 'דחייה' },
+              ]}
+              placeholder="כל הפעולות"
+              clearable
+              ariaLabel="סוג פעולה"
+            />
           </div>
           <div className="flex items-end">
             <button

--- a/src/components/management/tabs/CustomUserSelectionModal.tsx
+++ b/src/components/management/tabs/CustomUserSelectionModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useMemo } from 'react';
-import { Card, Button, FormField } from '@/components/ui';
+import { Card, Button, FormField, Select } from '@/components/ui';
 import { useUsers, UserForEmail } from '@/hooks/useUsers';
 import LoadingSpinner from '@/app/components/LoadingSpinner';
 import { TEXT_CONSTANTS } from '@/constants/text';
@@ -187,18 +187,16 @@ export default function CustomUserSelectionModal({
               <label className="text-sm font-medium text-neutral-700 whitespace-nowrap">
                 סינון לפי אות ראשונה:
               </label>
-              <select
-                value={alphabetFilter}
-                onChange={(e) => setAlphabetFilter(e.target.value as AlphabetFilter)}
-                className="px-3 py-2 border border-neutral-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 w-20 text-center"
-              >
-                <option value="all">הכל</option>
-                {hebrewAlphabet.map(letter => (
-                  <option key={letter} value={letter}>
-                    {letter}
-                  </option>
-                ))}
-              </select>
+              <div className="w-24">
+                <Select
+                  value={alphabetFilter === 'all' ? null : alphabetFilter}
+                  onChange={(v) => setAlphabetFilter((v ?? 'all') as AlphabetFilter)}
+                  options={hebrewAlphabet.map((letter) => ({ value: letter, label: letter }))}
+                  placeholder="הכל"
+                  clearable
+                  ariaLabel="סינון לפי אות ראשונה"
+                />
+              </div>
             </div>
 
             {/* Selection Controls */}

--- a/src/components/management/tabs/DataManagementTab.tsx
+++ b/src/components/management/tabs/DataManagementTab.tsx
@@ -2,6 +2,7 @@
  * Data management tab component - extracted from management page
  */
 import React, { useState } from 'react';
+import { Select } from '@/components/ui';
 
 export default function DataManagementTab() {
   const [selectedTable, setSelectedTable] = useState('');
@@ -57,31 +58,34 @@ export default function DataManagementTab() {
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div>
             <label className="block text-sm font-medium text-neutral-700 mb-2">בחר טבלה</label>
-            <select
-              className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
-              value={selectedTable}
-              onChange={(e) => setSelectedTable(e.target.value)}
-            >
-              <option value="">בחר טבלה...</option>
-              <option value="users">משתמשים</option>
-              <option value="equipment">ציוד</option>
-              <option value="logs">התיאמויות</option>
-              <option value="templates">תבניות</option>
-              <option value="all">כל הנתונים</option>
-            </select>
+            <Select
+              value={selectedTable || null}
+              onChange={(v) => setSelectedTable(v ?? '')}
+              options={[
+                { value: 'users', label: 'משתמשים' },
+                { value: 'equipment', label: 'ציוד' },
+                { value: 'logs', label: 'התיאמויות' },
+                { value: 'templates', label: 'תבניות' },
+                { value: 'all', label: 'כל הנתונים' },
+              ]}
+              placeholder="בחר טבלה..."
+              clearable
+              ariaLabel="בחר טבלה"
+            />
           </div>
           <div>
             <label className="block text-sm font-medium text-neutral-700 mb-2">פורמט ייצוא</label>
-            <select
-              className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+            <Select
               value={exportFormat}
-              onChange={(e) => setExportFormat(e.target.value)}
-            >
-              <option value="excel">Excel (.xlsx)</option>
-              <option value="csv">CSV (.csv)</option>
-              <option value="json">JSON (.json)</option>
-              <option value="pdf">PDF (.pdf)</option>
-            </select>
+              onChange={(v) => v && setExportFormat(v)}
+              options={[
+                { value: 'excel', label: 'Excel (.xlsx)' },
+                { value: 'csv', label: 'CSV (.csv)' },
+                { value: 'json', label: 'JSON (.json)' },
+                { value: 'pdf', label: 'PDF (.pdf)' },
+              ]}
+              ariaLabel="פורמט ייצוא"
+            />
           </div>
         </div>
         <div className="mt-4">

--- a/src/components/management/tabs/EmailTab.tsx
+++ b/src/components/management/tabs/EmailTab.tsx
@@ -2,7 +2,7 @@
  * Email tab component - extracted from management page
  */
 import React, { useState } from 'react';
-import { Card, Button, FormField, ConfirmationModal } from '@/components/ui';
+import { Card, Button, FormField, Select, ConfirmationModal } from '@/components/ui';
 import { UserType } from '@/types/user';
 import type { EmailRecipientType, EmailPriority, UserTypeOption, TeamOption } from '@/types/management';
 import CustomUserSelectionModal from './CustomUserSelectionModal';
@@ -118,17 +118,20 @@ export default function EmailTab() {
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
           {/* Left Column */}
           <div className="space-y-4">
-            <FormField label="נמענים">
-              <select
+            <div className="space-y-2">
+              <label className="block text-sm font-medium text-neutral-700">נמענים</label>
+              <Select
                 value={recipients}
-                onChange={(e) => handleRecipientsChange(e.target.value as EmailRecipientType)}
-              >
-                <option value="all">כל המשתמשים</option>
-                <option value="roles">לפי תפקידים</option>
-                <option value="teams">לפי צוותים</option>
-                <option value="custom">בחירה מותאמת</option>
-              </select>
-            </FormField>
+                onChange={(v) => v && handleRecipientsChange(v as EmailRecipientType)}
+                options={[
+                  { value: 'all', label: 'כל המשתמשים' },
+                  { value: 'roles', label: 'לפי תפקידים' },
+                  { value: 'teams', label: 'לפי צוותים' },
+                  { value: 'custom', label: 'בחירה מותאמת' },
+                ]}
+                ariaLabel="נמענים"
+              />
+            </div>
 
             {/* Role Selection */}
             {recipients === 'roles' && (
@@ -213,17 +216,20 @@ export default function EmailTab() {
               </div>
             )}
 
-            <FormField label="עדיפות">
-              <select
+            <div className="space-y-2">
+              <label className="block text-sm font-medium text-neutral-700">עדיפות</label>
+              <Select
                 value={priority}
-                onChange={(e) => setPriority(e.target.value as EmailPriority)}
-              >
-                <option value="low">נמוכה</option>
-                <option value="normal">רגילה</option>
-                <option value="high">גבוהה</option>
-                <option value="urgent">דחוף</option>
-              </select>
-            </FormField>
+                onChange={(v) => v && setPriority(v as EmailPriority)}
+                options={[
+                  { value: 'low', label: 'נמוכה' },
+                  { value: 'normal', label: 'רגילה' },
+                  { value: 'high', label: 'גבוהה' },
+                  { value: 'urgent', label: 'דחוף' },
+                ]}
+                ariaLabel="עדיפות"
+              />
+            </div>
           </div>
 
           {/* Right Column */}

--- a/src/components/management/tabs/EnforceTransferTab.tsx
+++ b/src/components/management/tabs/EnforceTransferTab.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/lib/transferRequestService';
 import { TransferRequest } from '@/types/equipment';
 import { Timestamp } from 'firebase/firestore';
+import { Select } from '@/components/ui';
 
 export default function EnforceTransferTab() {
   const { enhancedUser } = useAuth();
@@ -102,47 +103,52 @@ export default function EnforceTransferTab() {
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div>
             <label className="block text-sm font-medium text-neutral-700 mb-2">ציוד</label>
-            <select
-              className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:ring-2 focus:ring-danger-500 focus:border-danger-500"
-              value={selectedEquipment}
-              onChange={(e) => setSelectedEquipment(e.target.value)}
-            >
-              <option value="">בחר ציוד...</option>
-            </select>
+            <Select
+              value={selectedEquipment || null}
+              onChange={(v) => setSelectedEquipment(v ?? '')}
+              options={[]}
+              placeholder="בחר ציוד..."
+              clearable
+              ariaLabel="ציוד"
+            />
           </div>
           <div>
             <label className="block text-sm font-medium text-neutral-700 mb-2">מ-משתמש</label>
-            <select
-              className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:ring-2 focus:ring-danger-500 focus:border-danger-500"
-              value={fromUser}
-              onChange={(e) => setFromUser(e.target.value)}
-            >
-              <option value="">בחר משתמש...</option>
-            </select>
+            <Select
+              value={fromUser || null}
+              onChange={(v) => setFromUser(v ?? '')}
+              options={[]}
+              placeholder="בחר משתמש..."
+              clearable
+              ariaLabel="מ-משתמש"
+            />
           </div>
           <div>
             <label className="block text-sm font-medium text-neutral-700 mb-2">אל-משתמש</label>
-            <select
-              className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:ring-2 focus:ring-danger-500 focus:border-danger-500"
-              value={toUser}
-              onChange={(e) => setToUser(e.target.value)}
-            >
-              <option value="">בחר משתמש...</option>
-            </select>
+            <Select
+              value={toUser || null}
+              onChange={(v) => setToUser(v ?? '')}
+              options={[]}
+              placeholder="בחר משתמש..."
+              clearable
+              ariaLabel="אל-משתמש"
+            />
           </div>
           <div>
             <label className="block text-sm font-medium text-neutral-700 mb-2">סיבה להעברה</label>
-            <select
-              className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:ring-2 focus:ring-danger-500 focus:border-danger-500"
-              value={reason}
-              onChange={(e) => setReason(e.target.value)}
-            >
-              <option value="">בחר סיבה...</option>
-              <option value="emergency">מצב חירום</option>
-              <option value="unavailable">משתמש לא זמין</option>
-              <option value="maintenance">תחזוקה</option>
-              <option value="other">אחר</option>
-            </select>
+            <Select
+              value={reason || null}
+              onChange={(v) => setReason(v ?? '')}
+              options={[
+                { value: 'emergency', label: 'מצב חירום' },
+                { value: 'unavailable', label: 'משתמש לא זמין' },
+                { value: 'maintenance', label: 'תחזוקה' },
+                { value: 'other', label: 'אחר' },
+              ]}
+              placeholder="בחר סיבה..."
+              clearable
+              ariaLabel="סיבה להעברה"
+            />
           </div>
         </div>
         <div className="mt-4">

--- a/src/components/management/tabs/PermissionsTab.tsx
+++ b/src/components/management/tabs/PermissionsTab.tsx
@@ -2,6 +2,7 @@
  * Permissions management tab component - extracted from management page
  */
 import React, { useState } from 'react';
+import { Select } from '@/components/ui';
 
 export default function PermissionsTab() {
   const [selectedUser, setSelectedUser] = useState('');
@@ -55,18 +56,20 @@ export default function PermissionsTab() {
       <div className="bg-white rounded-lg border border-neutral-200 p-6">
         <h4 className="text-lg font-medium text-neutral-900 mb-4">הרשאות מותאמות אישית</h4>
         <div className="space-y-4">
-          <div>
+          <div className="md:max-w-xs">
             <label className="block text-sm font-medium text-neutral-700 mb-2">בחר משתמש</label>
-            <select
-              className="w-full md:w-64 px-3 py-2 border border-neutral-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
-              value={selectedUser}
-              onChange={(e) => setSelectedUser(e.target.value)}
-            >
-              <option value="">בחר משתמש...</option>
-              <option value="1">יוסי כהן</option>
-              <option value="2">שרה לוי</option>
-              <option value="3">דוד אבן</option>
-            </select>
+            <Select
+              value={selectedUser || null}
+              onChange={(v) => setSelectedUser(v ?? '')}
+              options={[
+                { value: '1', label: 'יוסי כהן' },
+                { value: '2', label: 'שרה לוי' },
+                { value: '3', label: 'דוד אבן' },
+              ]}
+              placeholder="בחר משתמש..."
+              clearable
+              ariaLabel="בחר משתמש"
+            />
           </div>
           {selectedUser && (
             <div className="border border-neutral-200 rounded-lg p-4">

--- a/src/components/management/tabs/UsersTab.tsx
+++ b/src/components/management/tabs/UsersTab.tsx
@@ -5,6 +5,7 @@ import React, { useState, useMemo } from 'react';
 import { Users, AlertCircle, RefreshCw } from 'lucide-react';
 import { useUsers } from '@/hooks/useUsers';
 import { TEXT_CONSTANTS } from '@/constants/text';
+import { Select } from '@/components/ui';
 
 export default function UsersTab() {
   const [searchTerm, setSearchTerm] = useState('');
@@ -161,34 +162,38 @@ export default function UsersTab() {
           </div>
           <div>
             <label className="block text-sm font-medium text-neutral-700 mb-2">תפקיד</label>
-            <select
-              className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
-              value={selectedRole}
-              onChange={(e) => setSelectedRole(e.target.value)}
-            >
-              <option value="all">{TEXT_CONSTANTS.MANAGEMENT.USERS.ALL_ROLES}</option>
-              <option value="admin">{TEXT_CONSTANTS.MANAGEMENT.USERS.ROLE_ADMIN}</option>
-              <option value="manager">{TEXT_CONSTANTS.MANAGEMENT.USERS.ROLE_MANAGER}</option>
-              <option value="user">{TEXT_CONSTANTS.MANAGEMENT.USERS.ROLE_USER}</option>
-              <option value="team_leader">{TEXT_CONSTANTS.MANAGEMENT.USERS.ROLE_TEAM_LEADER}</option>
-              <option value="officer">{TEXT_CONSTANTS.MANAGEMENT.USERS.ROLE_OFFICER}</option>
-              <option value="commander">{TEXT_CONSTANTS.MANAGEMENT.USERS.ROLE_COMMANDER}</option>
-              <option value="equipment_manager">{TEXT_CONSTANTS.MANAGEMENT.USERS.ROLE_EQUIPMENT_MANAGER}</option>
-            </select>
+            <Select
+              value={selectedRole === 'all' ? null : selectedRole}
+              onChange={(v) => setSelectedRole(v ?? 'all')}
+              options={[
+                { value: 'admin', label: TEXT_CONSTANTS.MANAGEMENT.USERS.ROLE_ADMIN },
+                { value: 'manager', label: TEXT_CONSTANTS.MANAGEMENT.USERS.ROLE_MANAGER },
+                { value: 'user', label: TEXT_CONSTANTS.MANAGEMENT.USERS.ROLE_USER },
+                { value: 'team_leader', label: TEXT_CONSTANTS.MANAGEMENT.USERS.ROLE_TEAM_LEADER },
+                { value: 'officer', label: TEXT_CONSTANTS.MANAGEMENT.USERS.ROLE_OFFICER },
+                { value: 'commander', label: TEXT_CONSTANTS.MANAGEMENT.USERS.ROLE_COMMANDER },
+                { value: 'equipment_manager', label: TEXT_CONSTANTS.MANAGEMENT.USERS.ROLE_EQUIPMENT_MANAGER },
+              ]}
+              placeholder={TEXT_CONSTANTS.MANAGEMENT.USERS.ALL_ROLES}
+              clearable
+              ariaLabel="תפקיד"
+            />
           </div>
           <div>
             <label className="block text-sm font-medium text-neutral-700 mb-2">סטטוס</label>
-            <select
-              className="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
-              value={selectedStatus}
-              onChange={(e) => setSelectedStatus(e.target.value)}
-            >
-              <option value="all">{TEXT_CONSTANTS.MANAGEMENT.USERS.ALL_STATUSES}</option>
-              <option value="active">{TEXT_CONSTANTS.MANAGEMENT.USERS.STATUS_ACTIVE}</option>
-              <option value="inactive">{TEXT_CONSTANTS.MANAGEMENT.USERS.STATUS_INACTIVE}</option>
-              <option value="transferred">{TEXT_CONSTANTS.MANAGEMENT.USERS.STATUS_TRANSFERRED}</option>
-              <option value="discharged">{TEXT_CONSTANTS.MANAGEMENT.USERS.STATUS_DISCHARGED}</option>
-            </select>
+            <Select
+              value={selectedStatus === 'all' ? null : selectedStatus}
+              onChange={(v) => setSelectedStatus(v ?? 'all')}
+              options={[
+                { value: 'active', label: TEXT_CONSTANTS.MANAGEMENT.USERS.STATUS_ACTIVE },
+                { value: 'inactive', label: TEXT_CONSTANTS.MANAGEMENT.USERS.STATUS_INACTIVE },
+                { value: 'transferred', label: TEXT_CONSTANTS.MANAGEMENT.USERS.STATUS_TRANSFERRED },
+                { value: 'discharged', label: TEXT_CONSTANTS.MANAGEMENT.USERS.STATUS_DISCHARGED },
+              ]}
+              placeholder={TEXT_CONSTANTS.MANAGEMENT.USERS.ALL_STATUSES}
+              clearable
+              ariaLabel="סטטוס"
+            />
           </div>
         </div>
         

--- a/src/components/management/tabs/ammunition/AmmunitionReportsSection.tsx
+++ b/src/components/management/tabs/ammunition/AmmunitionReportsSection.tsx
@@ -2,7 +2,7 @@
 
 import React, { useMemo, useState } from 'react';
 import { Download, AlertCircle } from 'lucide-react';
-import { Button } from '@/components/ui';
+import { Button, Select } from '@/components/ui';
 import { FEATURES } from '@/constants/text';
 import { useAmmunitionTemplates } from '@/hooks/useAmmunitionTemplates';
 import { useAmmunitionReports } from '@/hooks/useAmmunitionReports';
@@ -158,36 +158,31 @@ export default function AmmunitionReportsSection() {
         </div>
         <div>
           <label className="block text-xs font-medium text-neutral-700 mb-1">תת-קטגוריה</label>
-          <select
-            value={subcategory}
-            onChange={(e) => {
-              setSubcategory(e.target.value as AmmunitionSubcategory | '');
+          <Select
+            value={subcategory || null}
+            onChange={(v) => {
+              setSubcategory((v as AmmunitionSubcategory | null) ?? '');
               setTemplateId('');
             }}
-            className="w-full px-3 py-2 text-sm border border-neutral-200 rounded-lg focus:ring-2 focus:ring-primary-500"
-          >
-            <option value="">הכל</option>
-            {AMMUNITION_SUBCATEGORIES.map((s) => (
-              <option key={s} value={s}>
-                {T.SUBCATEGORIES[s]}
-              </option>
-            ))}
-          </select>
+            options={AMMUNITION_SUBCATEGORIES.map((s) => ({
+              value: s,
+              label: T.SUBCATEGORIES[s],
+            }))}
+            placeholder="הכל"
+            clearable
+            ariaLabel="תת-קטגוריה"
+          />
         </div>
         <div>
           <label className="block text-xs font-medium text-neutral-700 mb-1">פריט</label>
-          <select
-            value={templateId}
-            onChange={(e) => setTemplateId(e.target.value)}
-            className="w-full px-3 py-2 text-sm border border-neutral-200 rounded-lg focus:ring-2 focus:ring-primary-500"
-          >
-            <option value="">הכל</option>
-            {filteredTemplates.map((t) => (
-              <option key={t.id} value={t.id}>
-                {t.name}
-              </option>
-            ))}
-          </select>
+          <Select
+            value={templateId || null}
+            onChange={(v) => setTemplateId(v ?? '')}
+            options={filteredTemplates.map((t) => ({ value: t.id, label: t.name }))}
+            placeholder="הכל"
+            clearable
+            ariaLabel="פריט"
+          />
         </div>
         <div>
           <label className="block text-xs font-medium text-neutral-700 mb-1">צוות</label>

--- a/src/components/registration/PersonalDetailsStep.tsx
+++ b/src/components/registration/PersonalDetailsStep.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { TEXT_CONSTANTS } from '@/constants/text';
 import { validateHebrewName, validateGender, validateBirthdate } from '@/utils/validationUtils';
 import { PersonalDetailsStepProps, PersonalDetailsData, PersonalDetailsValidationErrors } from '@/types/registration';
+import { Select } from '@/components/ui';
 
 export default function PersonalDetailsStep({ 
   firstName, 
@@ -137,22 +138,18 @@ export default function PersonalDetailsStep({
           <div className="flex gap-4">
             {/* Gender Dropdown - No Label */}
             <div className="flex-1 space-y-1">
-              <select
-                value={formData.gender}
-                onChange={(e) => handleInputChange('gender', e.target.value)}
-                className={`w-full px-3 py-2 border-2 rounded-lg focus:ring-2 outline-none transition-all
-                         text-right text-neutral-800 bg-white text-sm ${
-                  validationErrors.gender && formData.gender
-                    ? 'border-danger-500 focus:border-danger-500 focus:ring-danger-500'
-                    : 'border-neutral-200 focus:border-info-500 focus:ring-info-500'
-                }`}
-                data-testid="gender-select"
-              >
-                <option value="">בחר מין</option>
-                <option value="male">{TEXT_CONSTANTS.AUTH.GENDER_MALE}</option>
-                <option value="female">{TEXT_CONSTANTS.AUTH.GENDER_FEMALE}</option>
-                <option value="other">{TEXT_CONSTANTS.AUTH.GENDER_OTHER}</option>
-              </select>
+              <Select
+                value={formData.gender || null}
+                onChange={(v) => handleInputChange('gender', v ?? '')}
+                options={[
+                  { value: 'male', label: TEXT_CONSTANTS.AUTH.GENDER_MALE },
+                  { value: 'female', label: TEXT_CONSTANTS.AUTH.GENDER_FEMALE },
+                  { value: 'other', label: TEXT_CONSTANTS.AUTH.GENDER_OTHER },
+                ]}
+                placeholder="בחר מין"
+                clearable
+                ariaLabel={TEXT_CONSTANTS.AUTH.GENDER}
+              />
               
               {/* Gender Error Message */}
               {validationErrors.gender && formData.gender && (

--- a/src/components/registration/RegistrationDetailsStep.tsx
+++ b/src/components/registration/RegistrationDetailsStep.tsx
@@ -8,6 +8,7 @@ import {
   validateConsent 
 } from '@/utils/validationUtils';
 import ConfirmationModal from '@/components/ui/ConfirmationModal';
+import { Select } from '@/components/ui';
 
 interface RegistrationDetailsStepProps {
   firstName: string;
@@ -243,22 +244,18 @@ export default function RegistrationDetailsStep({
             <label className="block text-sm font-medium text-neutral-700">
               {TEXT_CONSTANTS.AUTH.GENDER} *
             </label>
-            <select
-              value={formData.gender}
-              onChange={(e) => handleInputChange('gender', e.target.value)}
-              className={`w-full px-4 py-3.5 border-2 rounded-xl focus:ring-2 outline-none transition-all
-                       text-right text-neutral-800 bg-neutral-50 focus:bg-white ${
-                validationErrors.gender && formData.gender
-                  ? 'border-danger-500 focus:border-danger-500 focus:ring-danger-500'
-                  : 'border-neutral-200 focus:border-info-500 focus:ring-info-500'
-              }`}
-              data-testid="gender-select"
-            >
-              <option value="">בחר מין</option>
-              <option value="male">{TEXT_CONSTANTS.AUTH.GENDER_MALE}</option>
-              <option value="female">{TEXT_CONSTANTS.AUTH.GENDER_FEMALE}</option>
-              <option value="other">{TEXT_CONSTANTS.AUTH.GENDER_OTHER}</option>
-            </select>
+            <Select
+              value={formData.gender || null}
+              onChange={(v) => handleInputChange('gender', v ?? '')}
+              options={[
+                { value: 'male', label: TEXT_CONSTANTS.AUTH.GENDER_MALE },
+                { value: 'female', label: TEXT_CONSTANTS.AUTH.GENDER_FEMALE },
+                { value: 'other', label: TEXT_CONSTANTS.AUTH.GENDER_OTHER },
+              ]}
+              placeholder="בחר מין"
+              clearable
+              ariaLabel={TEXT_CONSTANTS.AUTH.GENDER}
+            />
             {validationErrors.gender && (
               <p className="text-sm text-danger-600 text-right px-1" data-testid="gender-error">
                 {validationErrors.gender}

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import React from 'react';
+import {
+  Listbox,
+  ListboxButton,
+  ListboxOption,
+  ListboxOptions,
+} from '@headlessui/react';
+import { ChevronDown, Check } from 'lucide-react';
+import { cn } from '@/lib/cn';
+
+export interface SelectOption<T extends string> {
+  value: T;
+  label: string;
+  disabled?: boolean;
+}
+
+export interface SelectProps<T extends string> {
+  value: T | null;
+  onChange: (value: T | null) => void;
+  options: SelectOption<T>[];
+  placeholder?: string;
+  /** When true, an explicit empty/clear row is rendered. Default false. */
+  clearable?: boolean;
+  disabled?: boolean;
+  id?: string;
+  className?: string;
+  ariaLabel?: string;
+}
+
+const NULL_SENTINEL = '__null__';
+
+export default function Select<T extends string>({
+  value,
+  onChange,
+  options,
+  placeholder = '—',
+  clearable = false,
+  disabled,
+  id,
+  className,
+  ariaLabel,
+}: SelectProps<T>) {
+  const selected = options.find((o) => o.value === value) ?? null;
+
+  const handleChange = (next: string) => {
+    onChange(next === NULL_SENTINEL ? null : (next as T));
+  };
+
+  return (
+    <Listbox
+      value={value ?? NULL_SENTINEL}
+      onChange={handleChange}
+      disabled={disabled}
+    >
+      <ListboxButton
+        id={id}
+        aria-label={ariaLabel}
+        className={cn(
+          'input-base flex items-center text-start text-sm',
+          !selected && 'text-neutral-400',
+          className,
+        )}
+      >
+        <span className="truncate">{selected?.label ?? placeholder}</span>
+        <ChevronDown
+          className="ms-auto h-4 w-4 text-neutral-500"
+          aria-hidden
+        />
+      </ListboxButton>
+      <ListboxOptions
+        anchor="bottom start"
+        className="w-[var(--button-width)] mt-1 max-h-60 overflow-auto rounded-xl border border-neutral-300 bg-white shadow-medium z-50 py-1 focus:outline-none"
+      >
+        {clearable && (
+          <ListboxOption
+            value={NULL_SENTINEL}
+            className="cursor-pointer select-none px-3 py-2 text-sm text-start text-neutral-500 data-[focus]:bg-primary-50"
+          >
+            {placeholder}
+          </ListboxOption>
+        )}
+        {options.map((opt) => (
+          <ListboxOption
+            key={opt.value}
+            value={opt.value}
+            disabled={opt.disabled}
+            className="flex items-center gap-2 cursor-pointer select-none px-3 py-2 text-sm text-start text-neutral-900 data-[focus]:bg-primary-50 data-[selected]:bg-primary-100 data-[selected]:text-primary-700 data-[disabled]:opacity-50 data-[disabled]:cursor-not-allowed"
+          >
+            {({ selected: isSel }) => (
+              <>
+                <span className="truncate">{opt.label}</span>
+                {isSel && (
+                  <Check
+                    className="ms-auto h-4 w-4 text-primary-600"
+                    aria-hidden
+                  />
+                )}
+              </>
+            )}
+          </ListboxOption>
+        ))}
+      </ListboxOptions>
+    </Listbox>
+  );
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -13,3 +13,6 @@ export type { BadgeProps } from './Badge';
 
 export { default as FormField } from './FormField';
 export type { FormFieldProps } from './FormField';
+
+export { default as Select } from './Select';
+export type { SelectProps, SelectOption } from './Select';


### PR DESCRIPTION
OS-rendered <option> panels ignore site CSS, overflow modals, and use OS focus colors. Add src/components/ui/Select.tsx as a Headless UI Listbox wrapper styled with project tokens (input-base, primary-*), RTL-aware via global dir, panel width anchored to trigger via --button-width. Sweep all native selects in equipment, ammunition, management, admin personnel, registration, status, settings, and AddSoldierForm to use it.