### PR TITLE
fix(profile): preserve leading 0 in displayed phone number

### DIFF
--- a/docs/codebase/src/components/profile/PhoneNumberUpdate.md
+++ b/docs/codebase/src/components/profile/PhoneNumberUpdate.md
@@ -1,8 +1,9 @@
 # PhoneNumberUpdate.tsx
 
 **File:** `src/components/profile/PhoneNumberUpdate.tsx`  
-**Lines:** 362 ⚠️ LONG  
+**Lines:** 365 ⚠️ LONG  
 **Status:** Active (mock OTP)
+**Tests:** `src/components/profile/__tests__/PhoneNumberUpdate.test.tsx`
 
 ## Purpose
 
@@ -25,8 +26,12 @@ Phone number update workflow with OTP verification. Steps: (1) show current numb
 | `otpCode` | `string` | OTP input |
 | `updateState` | `object` | `{ isUpdating, otpSent, otpVerified, error, success, countdown }` |
 
+## Display formatting
+
+`formatPhoneDisplay()` accepts numbers in international (`+972...`) or local (`0XX...`) format and renders them as `0XX-XXX-XXXX`. The leading `0` is preserved when stripping the `972` country code.
+
 ## Known Issues / TODO
 
 - Mock OTP/SMS services — not integrated with Twilio or real backend.
-- 362 lines — should be split.
+- 365 lines — should be split.
 - Extensive inline Hebrew text.

--- a/src/components/profile/PhoneNumberUpdate.tsx
+++ b/src/components/profile/PhoneNumberUpdate.tsx
@@ -26,13 +26,16 @@ export default function PhoneNumberUpdate({
     countdown: 0
   });
 
-  // Format phone number for display
+  // Format phone number for display as 0XX-XXX-XXXX (Israeli local format)
   const formatPhoneDisplay = (phone: string) => {
     if (!phone) return '';
-    // Remove country code and format as XXX-XXX-XXXX
     const cleaned = phone.replace(/\D/g, '');
     if (cleaned.startsWith('972')) {
-      return cleaned.slice(3).replace(/(\d{2})(\d{3})(\d{4})/, '$1-$2-$3');
+      const local = `0${cleaned.slice(3)}`;
+      return local.replace(/(\d{3})(\d{3})(\d{4})/, '$1-$2-$3');
+    }
+    if (/^0\d{9}$/.test(cleaned)) {
+      return cleaned.replace(/(\d{3})(\d{3})(\d{4})/, '$1-$2-$3');
     }
     return phone;
   };

--- a/src/components/profile/__tests__/PhoneNumberUpdate.test.tsx
+++ b/src/components/profile/__tests__/PhoneNumberUpdate.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import PhoneNumberUpdate from '../PhoneNumberUpdate';
+
+jest.mock('@/constants/text', () => ({
+  TEXT_CONSTANTS: {
+    PROFILE_COMPONENTS: {
+      INVALID_PHONE_ERROR: 'invalid phone',
+      INVALID_OTP_LENGTH: 'invalid otp length',
+      INVALID_OTP_ERROR: 'invalid otp',
+      INVALID_OTP_SERVER_ERROR: 'invalid otp server',
+      OTP_SEND_ERROR: 'otp send error',
+      SMS_SEND_ERROR: 'sms send error',
+      PHONE_PLACEHOLDER: '050-1234567',
+      OTP_PLACEHOLDER: '------',
+      SEND_CODE: 'send',
+      SEND_CODE_AGAIN: 'send again',
+    },
+  },
+}));
+
+describe('PhoneNumberUpdate — phone display formatting', () => {
+  it('preserves the leading 0 when displaying an international number', () => {
+    render(
+      <PhoneNumberUpdate
+        currentPhoneNumber="+972505123456"
+        onPhoneUpdate={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText('050-512-3456')).toBeInTheDocument();
+  });
+
+  it('formats a stored local-format number with the existing leading 0', () => {
+    render(
+      <PhoneNumberUpdate
+        currentPhoneNumber="0521234567"
+        onPhoneUpdate={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText('052-123-4567')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
formatPhoneDisplay stripped the 972 country code without re-prepending the Israeli leading 0, so +972505123456 rendered as 50-512-3456 instead of 050-512-3456. Re-prepend 0 after slicing 972 and add a 10-digit local fallback path.