### PR TITLE
fix(profile): wire image upload to Firebase Storage and persist URL

### DIFF
--- a/docs/codebase/src/components/profile/ProfileImageUpload.md
+++ b/docs/codebase/src/components/profile/ProfileImageUpload.md
@@ -14,6 +14,20 @@ Profile image selection and upload with file validation (type, size), preview, a
 - Rules: `firebase/storage.rules` — owner-only write (`request.auth.uid == userId`), authenticated read, 10 MB cap, image/* content type only.
 - Persisted to Firestore by the parent via `updateUserProfile(uid, { profileImage: downloadUrl })` (existing whitelist already covers `profileImage`).
 
+## Bucket CORS (manual, one-time)
+
+Browser uploads from `localhost` or Vercel preview origins fail the CORS preflight unless the bucket is configured. Run once per bucket from a machine with `gsutil` (Google Cloud SDK):
+
+```
+gsutil cors set firebase/storage.cors.json gs://sayeret-givati-1983.firebasestorage.app
+```
+
+Adjust origins in `firebase/storage.cors.json` if production domains change. Verify with `gsutil cors get gs://sayeret-givati-1983.firebasestorage.app`.
+
+## Defensive rendering
+
+Pre-Storage builds (mock upload) wrote `blob:` URLs into the user document. Those URLs are origin-scoped to a dead session and the browser blocks them on reload. The component (and the three call-site state initialisers in `profile/page.tsx`, `settings/page.tsx`, `WelcomeModal.tsx`) treat anything that is not `http(s)://` as missing — placeholder icon renders instead, and an explicit re-upload overwrites the bad value with a real download URL.
+
 ## Props
 
 | Prop | Type | Required | Default | Description |

--- a/docs/codebase/src/components/profile/ProfileImageUpload.md
+++ b/docs/codebase/src/components/profile/ProfileImageUpload.md
@@ -1,21 +1,29 @@
 # ProfileImageUpload.tsx
 
-**File:** `src/components/profile/ProfileImageUpload.tsx`  
-**Lines:** 214  
-**Status:** Active (mock upload)
+**File:** `src/components/profile/ProfileImageUpload.tsx`
+**Lines:** 198
+**Status:** Active (Firebase Storage)
 
 ## Purpose
 
-Profile image selection and upload with file validation (type, size), preview, and configurable display sizes (small/medium/large). Shows upload progress and error/success states. Currently uses a **mock upload** — no real storage service integration.
+Profile image selection and upload with file validation (type, size), preview, and configurable display sizes (small/medium/large). Uploads to Firebase Storage at `users/{userId}/profile/{timestamp}.{ext}` and returns the public download URL via `onImageUpdate`.
+
+## Storage path & rules
+
+- Path: `users/{userId}/profile/{timestamp}.{ext}` — one new object per upload, never overwrites prior images.
+- Rules: `firebase/storage.rules` — owner-only write (`request.auth.uid == userId`), authenticated read, 10 MB cap, image/* content type only.
+- Persisted to Firestore by the parent via `updateUserProfile(uid, { profileImage: downloadUrl })` (existing whitelist already covers `profileImage`).
 
 ## Props
 
 | Prop | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
-| `currentImageUrl` | `string` | ❌ | — | Current profile image URL |
-| `onImageUpdate` | `(url: string) => void` | ✅ | — | Called with new image URL after upload |
-| `size` | `'small' \| 'medium' \| 'large'` | ❌ | `'medium'` | Display size |
-| `className` | `string` | ❌ | — | Additional classes |
+| `userId` | `string` | yes | — | Firebase Auth uid; used to build the Storage path |
+| `currentImageUrl` | `string` | no | — | Current profile image URL |
+| `onImageUpdate` | `(url: string) => void` | yes | — | Called with the Storage download URL after upload |
+| `size` | `'small' \| 'medium' \| 'large'` | no | `'medium'` | Display size |
+| `className` | `string` | no | — | Additional classes |
+| `showInstructions` | `boolean` | no | `true` | Render the "click to upload" hint text below the avatar; pass `false` when embedding in a header to keep alignment compact |
 
 ## State
 
@@ -23,7 +31,7 @@ Profile image selection and upload with file validation (type, size), preview, a
 |-------|------|---------|
 | `uploadState` | `{ isUploading, error, success }` | Upload progress tracking |
 
-## Known Issues / TODO
+## Notes
 
-- Mock image upload — needs Firebase Storage or equivalent.
-- Inline Hebrew text.
+- Inline Hebrew text — should move to `TEXT_CONSTANTS` next time the file is touched.
+- Profile page passes `showInstructions={false}` to keep the avatar baseline-aligned with the user's name in the header card.

--- a/firebase/storage.cors.json
+++ b/firebase/storage.cors.json
@@ -1,0 +1,21 @@
+[
+  {
+    "origin": [
+      "http://localhost:3000",
+      "https://sayeret-givati.vercel.app",
+      "https://*.vercel.app"
+    ],
+    "method": ["GET", "HEAD", "PUT", "POST", "DELETE"],
+    "maxAgeSeconds": 3600,
+    "responseHeader": [
+      "Content-Type",
+      "Content-Length",
+      "Content-Encoding",
+      "Content-Disposition",
+      "Authorization",
+      "User-Agent",
+      "x-goog-resumable",
+      "x-goog-meta-*"
+    ]
+  }
+]

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -100,11 +100,15 @@ export default function ProfilePage() {
           <div className="bg-white rounded-2xl shadow-lg p-8 mb-8">
             <div className="flex items-center gap-6">
               {/* Profile Avatar with Upload */}
-              <ProfileImageUpload
-                currentImageUrl={profileImageUrl}
-                onImageUpdate={handleImageUpdate}
-                size="medium"
-              />
+              {enhancedUser?.uid && (
+                <ProfileImageUpload
+                  userId={enhancedUser.uid}
+                  currentImageUrl={profileImageUrl}
+                  onImageUpdate={handleImageUpdate}
+                  size="medium"
+                  showInstructions={false}
+                />
+              )}
 
               {/* Basic Info */}
               <div className="flex-1">

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -18,7 +18,12 @@ import { updateUserProfile } from '@/lib/userProfileService';
  */
 export default function ProfilePage() {
   const { enhancedUser, user, refreshEnhancedUser } = useAuth();
-  const [profileImageUrl, setProfileImageUrl] = useState<string | undefined>(enhancedUser?.profileImage);
+  // Drop legacy `blob:` URLs left over from the old mock upload; they error on render.
+  const initialProfileImage =
+    enhancedUser?.profileImage && /^https?:\/\//i.test(enhancedUser.profileImage)
+      ? enhancedUser.profileImage
+      : undefined;
+  const [profileImageUrl, setProfileImageUrl] = useState<string | undefined>(initialProfileImage);
   const [phoneNumber, setPhoneNumber] = useState<string>(enhancedUser?.phoneNumber || '');
   const [teamId, setTeamId] = useState<string>(enhancedUser?.teamId || '');
   const [assignmentSaving, setAssignmentSaving] = useState(false);

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -38,8 +38,12 @@ export default function SettingsPage() {
     theme: 'light'
   });
 
-  // Profile image state
-  const [profileImageUrl, setProfileImageUrl] = useState<string | undefined>(enhancedUser?.profileImage);
+  // Profile image state. Drop legacy blob: URLs from the old mock — they error on render.
+  const initialProfileImage =
+    enhancedUser?.profileImage && /^https?:\/\//i.test(enhancedUser.profileImage)
+      ? enhancedUser.profileImage
+      : undefined;
+  const [profileImageUrl, setProfileImageUrl] = useState<string | undefined>(initialProfileImage);
 
   // TODO: Replace with actual data when backend is implemented
   const mockPhoneNumber = enhancedUser?.phoneNumber || '+972-50-123-4567';

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -88,11 +88,14 @@ export default function SettingsPage() {
               {/* Profile Image */}
               <div className="flex items-center justify-between p-4 border border-neutral-200 rounded-xl">
                 <div className="flex items-center gap-4">
-                  <ProfileImageUpload
-                    currentImageUrl={profileImageUrl}
-                    onImageUpdate={handleImageUpdate}
-                    size="small"
-                  />
+                  {enhancedUser?.uid && (
+                    <ProfileImageUpload
+                      userId={enhancedUser.uid}
+                      currentImageUrl={profileImageUrl}
+                      onImageUpdate={handleImageUpdate}
+                      size="small"
+                    />
+                  )}
                   <div>
                     <h3 className="font-medium text-neutral-900">
                       {TEXT_CONSTANTS.SETTINGS.PROFILE_IMAGE}

--- a/src/components/onboarding/WelcomeModal.tsx
+++ b/src/components/onboarding/WelcomeModal.tsx
@@ -52,6 +52,7 @@ export default function WelcomeModal() {
       <div className="bg-white rounded-2xl shadow-2xl max-w-md w-full mx-4 p-6 sm:p-8">
         <div className="flex justify-center mb-4">
           <ProfileImageUpload
+            userId={enhancedUser.uid}
             currentImageUrl={profileImage}
             onImageUpdate={setProfileImage}
             size="medium"

--- a/src/components/onboarding/WelcomeModal.tsx
+++ b/src/components/onboarding/WelcomeModal.tsx
@@ -16,7 +16,12 @@ import ProfileImageUpload from '@/components/profile/ProfileImageUpload';
 export default function WelcomeModal() {
   const { enhancedUser, refreshEnhancedUser } = useAuth();
   const [teamId, setTeamId] = useState(enhancedUser?.teamId ?? '');
-  const [profileImage, setProfileImage] = useState<string | undefined>(enhancedUser?.profileImage);
+  // Drop legacy blob: URLs from the old mock — they error on render and would re-persist on save.
+  const initialProfileImage =
+    enhancedUser?.profileImage && /^https?:\/\//i.test(enhancedUser.profileImage)
+      ? enhancedUser.profileImage
+      : undefined;
+  const [profileImage, setProfileImage] = useState<string | undefined>(initialProfileImage);
   const [errors, setErrors] = useState<{ teamId?: string; submit?: string }>({});
   const [saving, setSaving] = useState(false);
 

--- a/src/components/profile/ProfileImageUpload.tsx
+++ b/src/components/profile/ProfileImageUpload.tsx
@@ -46,6 +46,12 @@ export default function ProfileImageUpload({
     large: 'text-3xl'
   };
 
+  // Pre-Storage builds wrote `blob:` URLs into Firestore via the old mock; those are
+  // origin-scoped to a dead session and the browser blocks them on reload. Treat
+  // anything that is not http(s) as missing so the placeholder icon renders instead.
+  const renderableImageUrl =
+    currentImageUrl && /^https?:\/\//i.test(currentImageUrl) ? currentImageUrl : undefined;
+
   const handleImageSelect = () => {
     fileInputRef.current?.click();
   };
@@ -122,11 +128,11 @@ export default function ProfileImageUpload({
         >
           {uploadState.isUploading ? (
             <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-white"></div>
-          ) : currentImageUrl ? (
+          ) : renderableImageUrl ? (
             // eslint-disable-next-line @next/next/no-img-element
-            <img 
-              src={currentImageUrl} 
-              alt={TEXT_CONSTANTS.PROFILE_COMPONENTS.PROFILE_ALT} 
+            <img
+              src={renderableImageUrl}
+              alt={TEXT_CONSTANTS.PROFILE_COMPONENTS.PROFILE_ALT}
               className="w-full h-full object-cover"
             />
           ) : (

--- a/src/components/profile/ProfileImageUpload.tsx
+++ b/src/components/profile/ProfileImageUpload.tsx
@@ -2,6 +2,8 @@
 
 import { useState, useRef } from 'react';
 import { CameraIcon, UserIcon, UploadIcon } from 'lucide-react';
+import { getDownloadURL, ref as storageRef, uploadBytes } from 'firebase/storage';
+import { storage } from '@/lib/firebase';
 import { ProfileImageUploadProps, ImageUploadState } from '@/types/profile';
 import { TEXT_CONSTANTS } from '@/constants/text';
 
@@ -9,11 +11,13 @@ import { TEXT_CONSTANTS } from '@/constants/text';
  * ProfileImageUpload component for uploading and updating profile images
  * Follows the app's existing UI/UX patterns
  */
-export default function ProfileImageUpload({ 
-  currentImageUrl, 
-  onImageUpdate, 
+export default function ProfileImageUpload({
+  userId,
+  currentImageUrl,
+  onImageUpdate,
   size = 'medium',
-  className = '' 
+  className = '',
+  showInstructions = true,
 }: ProfileImageUploadProps) {
   const [uploadState, setUploadState] = useState<ImageUploadState>({
     isUploading: false,
@@ -77,24 +81,24 @@ export default function ProfileImageUpload({
     });
 
     try {
-      // TODO: Replace with actual image upload service
-      await mockImageUpload(file);
-      
-      // Create temporary URL for preview
-      const imageUrl = URL.createObjectURL(file);
-      onImageUpdate(imageUrl);
-      
+      const ext = file.name.includes('.') ? file.name.split('.').pop() : 'jpg';
+      const path = `users/${userId}/profile/${Date.now()}.${ext}`;
+      const objectRef = storageRef(storage, path);
+      await uploadBytes(objectRef, file, { contentType: file.type });
+      const downloadUrl = await getDownloadURL(objectRef);
+
+      onImageUpdate(downloadUrl);
+
       setUploadState({
         isUploading: false,
         error: null,
         success: true
       });
 
-      // Clear success message after 3 seconds
       setTimeout(() => {
         setUploadState(prev => ({ ...prev, success: false }));
       }, 3000);
-      
+
     } catch (error) {
       setUploadState({
         isUploading: false,
@@ -103,24 +107,9 @@ export default function ProfileImageUpload({
       });
     }
 
-    // Reset file input
     if (fileInputRef.current) {
       fileInputRef.current.value = '';
     }
-  };
-
-  // Mock image upload function
-  const mockImageUpload = async (file: File): Promise<string> => {
-    return new Promise((resolve, reject) => {
-      setTimeout(() => {
-        // Simulate random success/failure for demo
-        if (Math.random() > 0.1) { // 90% success rate
-          resolve(`/api/uploads/${file.name}`);
-        } else {
-          reject(new Error(TEXT_CONSTANTS.PROFILE_COMPONENTS.SERVER_UPLOAD_ERROR));
-        }
-      }, 2000); // Simulate upload time
-    });
   };
 
   return (
@@ -182,7 +171,7 @@ export default function ProfileImageUpload({
       />
 
       {/* Upload Instructions */}
-      {size !== 'small' && (
+      {size !== 'small' && showInstructions && (
         <div className="mt-2 text-center">
           <p className="text-xs text-neutral-500">
             לחץ להעלאת תמונה חדשה

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -47,10 +47,12 @@ export interface OTPVerificationResult {
 }
 
 export interface ProfileImageUploadProps {
+  userId: string;
   currentImageUrl?: string;
   onImageUpdate: (imageUrl: string) => void;
   size?: 'small' | 'medium' | 'large';
   className?: string;
+  showInstructions?: boolean;
 }
 
 export interface PhoneNumberUpdateProps {


### PR DESCRIPTION
ProfileImageUpload was a mock with a 10% random failure that returned a blob: URL — unusable across sessions and the source of the perceived "500 error". Replace with a real uploadBytes call to users/{userId}/profile/{timestamp}.{ext}, write the resulting download URL through the existing PATCH /api/users/profile flow.

The component now requires userId and accepts showInstructions=false, which the profile header passes to keep the avatar baseline-aligned with the name. All call sites updated.

Storage rules at firebase/storage.rules already enforce owner-only write. Run `firebase deploy --only storage` after merge to publish them in case they have drifted from production.