### PR TITLE
fix(personnel): bug #1 — allow hyphen and apostrophe in names

### DIFF
--- a/docs/bugs.md
+++ b/docs/bugs.md
@@ -1,8 +1,12 @@
 
 # bugs need to be fix UI/UX
 
-1. in the admin routs when we add CSV or just one personnal to the authorized_personnel we can't use - or ' for names
-wqe need to support this chars
+1. ~~in the admin routs when we add CSV or just one personnal to the authorized_personnel we can't use - or ' for names~~
+   - **FIXED (2026-04-28):** Two regex broadened to accept hyphens and apostrophes/geresh.
+     - `src/utils/validationUtils.ts` `VALIDATION_PATTERNS.HEBREW_NAME`: `/^[א-ת\s\-'׳]+$/` (registration flow).
+     - `src/lib/equipmentValidation.ts` `validateUserName.validNamePattern`: `/^[א-תA-Za-z\s\.\-'׳]+$/` (admin AddPersonnel / BulkUpload / UpdatePersonnel via `adminUtils.validateFirstName` / `validateLastName`).
+   - Accepts: ASCII hyphen `-`, ASCII apostrophe `'`, Hebrew geresh `׳` (U+05F3). Examples now valid: `כהן-לוי`, `ז'אן`, `ז׳אן`.
+   - Tests in `src/utils/__tests__/validationUtils.test.ts` updated: prior reject-hyphen test flipped to accept; new tests for apostrophe and geresh.
 2. make sure we can handle multiple possibility to insert phone numbers
 ignore not digits charas and multiple -  or spaces
 3. in the admin panel we need the ability to update some fields in the authorized_personnel.

--- a/docs/codebase/src/lib/equipmentValidation.md
+++ b/docs/codebase/src/lib/equipmentValidation.md
@@ -29,3 +29,4 @@ Comprehensive validation for equipment forms and individual fields. Validates se
 
 - 417 lines — could be split by validation domain.
 - Pure functions, no side effects.
+- `validateUserName` accepts Hebrew letters, English letters, whitespace, dots, ASCII hyphen `-`, ASCII apostrophe `'`, Hebrew geresh `׳` (U+05F3) — supports compound surnames and transliterated names. Used by `adminUtils.validateFirstName` / `validateLastName` for `authorized_personnel` flows. Bug #1 fix.

--- a/docs/codebase/src/utils/validationUtils.md
+++ b/docs/codebase/src/utils/validationUtils.md
@@ -22,3 +22,7 @@ Form validation utility class and phone formatting utilities. Provides validatio
 
 - 444 lines — candidate for split.
 - `VALIDATION_PATTERNS` partially duplicated with `src/constants/admin.ts`.
+
+## Notes
+
+- `HEBREW_NAME` regex accepts Hebrew letters (`א-ת`), whitespace, ASCII hyphen `-`, ASCII apostrophe `'`, and Hebrew geresh `׳` (U+05F3) — supports compound surnames (`כהן-לוי`) and transliterated names (`ז'אן` / `ז׳אן`). Bug #1 fix.

--- a/src/lib/equipmentValidation.ts
+++ b/src/lib/equipmentValidation.ts
@@ -287,10 +287,10 @@ export function validateUserName(name: string): { isValid: boolean; error?: stri
     return { isValid: false, error: 'שם ארוך מדי (מקסימום 50 תווים)' };
   }
 
-  // Check for valid name characters (Hebrew, English, spaces, dots)
-  const validNamePattern = /^[א-תA-Za-z\s\.]+$/;
+  // Check for valid name characters (Hebrew, English, spaces, dots, hyphens, apostrophes/geresh)
+  const validNamePattern = /^[א-תA-Za-z\s\.\-'׳]+$/;
   if (!validNamePattern.test(trimmedName)) {
-    return { isValid: false, error: 'שם יכול להכיל רק אותיות עבריות, אנגליות, רווחים ונקודות' };
+    return { isValid: false, error: 'שם יכול להכיל רק אותיות עבריות, אנגליות, רווחים, נקודות, מקפים (-) או גרש (\')' };
   }
 
   return { isValid: true };

--- a/src/utils/__tests__/validationUtils.test.ts
+++ b/src/utils/__tests__/validationUtils.test.ts
@@ -925,10 +925,22 @@ describe('Personal Number Validation', () => {
           expect(result.errorMessage).toBe(VALIDATION_MESSAGES_HE.NAME_INVALID);
         });
 
-        it('should reject hyphens (special case)', () => {
+        it('should accept Hebrew name with hyphen (compound surname)', () => {
           const result = validateHebrewName('כהן-לוי');
-          expect(result.isValid).toBe(false);
-          expect(result.errorMessage).toBe(VALIDATION_MESSAGES_HE.NAME_INVALID);
+          expect(result.isValid).toBe(true);
+          expect(result.errorMessage).toBeNull();
+        });
+
+        it('should accept Hebrew name with apostrophe', () => {
+          const result = validateHebrewName("ז'אן");
+          expect(result.isValid).toBe(true);
+          expect(result.errorMessage).toBeNull();
+        });
+
+        it('should accept Hebrew name with geresh (׳)', () => {
+          const result = validateHebrewName('ז׳אן');
+          expect(result.isValid).toBe(true);
+          expect(result.errorMessage).toBeNull();
         });
       });
     });

--- a/src/utils/validationUtils.ts
+++ b/src/utils/validationUtils.ts
@@ -7,7 +7,7 @@ export const VALIDATION_PATTERNS = {
   PERSONAL_NUMBER: /^[0-9]{5,7}$/,
   EMAIL: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
   PHONE: /^(?:\+972-?|0)(5[0-9])-?\d{7}$/,
-  HEBREW_NAME: /^[\u05D0-\u05EA\s]+$/,
+  HEBREW_NAME: /^[\u05D0-\u05EA\s\-'\u05F3]+$/,
   PASSWORD: /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$/,
 } as const;
 
@@ -22,7 +22,7 @@ export const VALIDATION_MESSAGES_HE = {
   PHONE_REQUIRED: 'מספר טלפון הוא שדה חובה',
   PHONE_INVALID: 'מספר טלפון לא תקין',
   NAME_REQUIRED: 'שם הוא שדה חובה',
-  NAME_INVALID: 'השם חייב להכיל רק אותיות עבריות',
+  NAME_INVALID: 'השם חייב להכיל רק אותיות עבריות, רווחים, מקפים (-) או גרש (\')',
   OTP_INVALID: 'הקוד חייב להכיל 6 ספרות בדיוק',
   PASSWORD_REQUIRED: 'סיסמה היא שדה חובה',
   PASSWORD_INVALID: 'סיסמה חייבת להכיל לפחות 8 תווים, אות גדולה, אות קטנה ומספר',


### PR DESCRIPTION
Broaden two name-validation regexes so admin AddPersonnel / BulkUpload / UpdatePersonnel and the registration flow accept compound surnames (e.g. כהן-לוי) and transliterated names (e.g. ז'אן / ז׳אן).

- src/utils/validationUtils.ts: HEBREW_NAME pattern now allows `-`, `'`, and Hebrew geresh `׳` (U+05F3); error message updated.
- src/lib/equipmentValidation.ts: validateUserName regex extended with the same characters; error message updated.
- Tests: flipped reject-hyphen case to accept; added apostrophe and geresh accept tests.
- Docs: bugs.md #1 marked FIXED; codebase docs note the new accepted set.