### PR TITLE
fix(auth): clean up incomplete registration + protect all routes

### DIFF
--- a/docs/bugs.md
+++ b/docs/bugs.md
@@ -1,6 +1,15 @@
 
 # bugs need to be fix UI/UX
 
+> **Note (2026-04-29):** Incomplete-registration leak fixed on `fix/incomplete-registration-leak`. Bugs addressed in one branch:
+> - **Orphan Firebase Auth user on abandon** — `RegistrationModal` now calls `deleteCurrentUser()` on close/back/unmount; falls back to `signOutCurrentUser()` if `auth/requires-recent-login`. New helpers in `src/lib/firebasePhoneAuth.ts`, sessionStorage flag in `src/lib/registrationFlowFlag.ts`.
+> - **AuthContext authenticated orphans** — listener now signs out a Firebase user that has no Firestore profile unless `registrationInProgress` is set.
+> - **Welcome popup on partial profile** — `AppShell.needsOnboarding` now also requires `firstName` + `lastName`.
+> - **Unprotected routes** — `/tools`, `/tools/convoy`, `/tools/logistics`, `/test-dashboard` now wrapped in `AuthGuard`.
+> - **Team text input** — replaced with dropdown sourced from `systemConfig/main.teams`. Admin can manage the list under admin → System Config tab. Empty list shows Hebrew "no teams configured" error.
+> - **Background scrolls behind overlays** — new `useScrollLock` hook applied to `WelcomeModal` and (mobile only) `ManagementSidebar`.
+> - **Firebase phone-auth alignment** — reCAPTCHA now reset on send-failure path; `appVerificationDisabledForTesting` enabled in the Jest mock.
+
 > **Note (2026-04-28):** `usePersonnelManagement` mutations (`addPersonnel`, `updatePersonnel`, `deletePersonnel`) used to update the localStorage `PersonnelCache` only — the React `personnel` state stayed stale, so admin UI rows did not appear/update/disappear until a full re-fetch. Now each success branch also calls `setPersonnel(...)` so the change is reflected in-place without a DB round-trip.
 >
 > The 44s first-call DELETE seen in `next dev` is dev-only cold start (Next.js compiling the API route + firebase-admin gRPC handshake on first invocation). Subsequent calls are 100–200ms once the singleton in `src/lib/db/admin.ts` is warm. Production (Vercel) reuses the SDK instance across requests; not an action item.

--- a/docs/codebase/src/components/registration/RegistrationModal.md
+++ b/docs/codebase/src/components/registration/RegistrationModal.md
@@ -1,12 +1,17 @@
 # RegistrationModal.tsx
 
 **File:** `src/components/registration/RegistrationModal.tsx`
-**Lines:** 95
 **Status:** Active
 
 ## Purpose
 
 Shell modal for the multi-step registration flow. Manages the overall step state and personal number value at the top level. Composes `RegistrationHeader`, `RegistrationStepDots`, `RegistrationForm`, and `RegistrationFooter`. Handles backward navigation between steps.
+
+## Orphan Auth user cleanup
+
+After phone OTP succeeds the Firebase Auth user already exists, but the Firestore profile is only created on a successful `/api/auth/register` call. If the user closes the modal, switches to login, or navigates away before that point, the modal calls `deleteCurrentUser()` from `@/lib/firebasePhoneAuth` to remove the orphan account. If Firebase rejects the delete with `auth/requires-recent-login` (sign-in older than the recent-login window), the modal falls back to `signOutCurrentUser()`. `AuthContext` will then refuse to authenticate the orphan on the next page load.
+
+A `registrationCompleteRef` is set on the success step to skip cleanup. The modal also sets/clears the `registrationInProgress` sessionStorage flag (via `@/lib/registrationFlowFlag`) so `AuthContext.onAuthStateChanged` does not race the in-flight registration and sign the user out prematurely.
 
 ## Props
 

--- a/docs/codebase/src/hooks/useScrollLock.md
+++ b/docs/codebase/src/hooks/useScrollLock.md
@@ -1,0 +1,23 @@
+# useScrollLock.ts
+
+**File:** `src/hooks/useScrollLock.ts`
+**Status:** Active
+
+## Purpose
+
+Locks `document.body` scrolling while a modal or drawer is active. Sets `body.style.overflow = 'hidden'` on activation and restores the previous value on cleanup.
+
+## Usage
+
+```ts
+import { useScrollLock } from '@/hooks/useScrollLock';
+
+useScrollLock(isOpen);
+```
+
+Pass `true` to lock unconditionally (e.g. inside a modal that only mounts when shown), or a boolean tied to open-state for drawers that mount in both states.
+
+## Where it's used
+
+- `src/components/onboarding/WelcomeModal.tsx` — locks while the mandatory team-selection modal is shown.
+- `src/components/management/sidebar/ManagementSidebar.tsx` — locks only on mobile (`max-width: 1023px`); on `lg+` the sidebar is in document flow and does not require scroll containment.

--- a/docs/codebase/src/hooks/useSystemConfig.md
+++ b/docs/codebase/src/hooks/useSystemConfig.md
@@ -15,8 +15,13 @@ helper for admin updates. Single source for the System Config tab.
   config: SystemConfig | null;
   isLoading: boolean;
   error: string | null;
-  save: (payload: { ammoNotificationRecipientUserId?: string }) => Promise<boolean>;
+  save: (payload: SystemConfigSavePayload) => Promise<boolean>;
   refresh: () => Promise<void>;
+}
+
+interface SystemConfigSavePayload {
+  ammoNotificationRecipientUserId?: string;
+  teams?: string[];
 }
 ```
 
@@ -36,6 +41,13 @@ helper for admin updates. Single source for the System Config tab.
 
 ## Consumers
 
-- `SystemConfigTab.tsx` (only consumer for now).
+- `SystemConfigPanel.tsx` (admin tab) — manages `teams[]`.
+- `WelcomeModal.tsx` — reads `teams[]` to populate the onboarding dropdown.
 - Phase 4 ammunition report submit will read the recipient on the server, not
   via this hook.
+
+## Fields on `systemConfig/main`
+
+- `ammoNotificationRecipientUserId: string` — recipient for ammunition alerts.
+- `teams: string[]` — predefined team names. Source of the dropdown shown to
+  users during onboarding (WelcomeModal). Edited in admin → System Config tab.

--- a/docs/firebase-operations.md
+++ b/docs/firebase-operations.md
@@ -33,7 +33,7 @@ All Firestore operations in the codebase, organized by collection.
 | `ammunitionInventory` | `COLLECTIONS.AMMUNITION_INVENTORY = 'ammunitionInventory'` | `src/lib/db/collections.ts` (Phase 3) |
 | `ammunitionReports` | `COLLECTIONS.AMMUNITION_REPORTS = 'ammunitionReports'` | `src/lib/db/collections.ts` (Phase 4 — server: `src/lib/db/server/ammunitionReportsService.ts`; client: `src/lib/ammunition/reportsService.ts`) |
 | `ammunitionReportRequests` | `COLLECTIONS.AMMUNITION_REPORT_REQUESTS = 'ammunitionReportRequests'` | `src/lib/db/collections.ts` (Phase 6 — server: `src/lib/db/server/ammunitionReportRequestService.ts`) |
-| `systemConfig` | `COLLECTIONS.SYSTEM_CONFIG = 'systemConfig'` | `src/lib/db/collections.ts` (Phase 1 — `ammoNotificationRecipientUserId`) |
+| `systemConfig` | `COLLECTIONS.SYSTEM_CONFIG = 'systemConfig'` | `src/lib/db/collections.ts` — single doc `main`. Fields: `ammoNotificationRecipientUserId` (Phase 1 ammunition), `teams: string[]` (registration team dropdown source — admin tab editable). |
 
 ---
 

--- a/src/app/admin/components/AdminDashboard.tsx
+++ b/src/app/admin/components/AdminDashboard.tsx
@@ -11,6 +11,7 @@ import BulkUpload from './BulkUpload';
 import ViewPersonnel from './ViewPersonnel';
 import UpdatePersonnel from './UpdatePersonnel';
 import SystemStats from './SystemStats';
+import SystemConfigPanel from './SystemConfigPanel';
 import { cn } from '@/lib/cn';
 
 interface AdminDashboardProps {
@@ -71,6 +72,7 @@ export default function AdminDashboard({ onLogout }: AdminDashboardProps) {
                 {tab.id === 'view-personnel' && <ViewPersonnel />}
                 {tab.id === 'update-personnel' && <UpdatePersonnel />}
                 {tab.id === 'system-stats' && <SystemStats />}
+                {tab.id === 'system-config' && <SystemConfigPanel />}
               </div>
             );
           })}

--- a/src/app/admin/components/SystemConfigPanel.tsx
+++ b/src/app/admin/components/SystemConfigPanel.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useSystemConfig } from '@/hooks/useSystemConfig';
+
+export default function SystemConfigPanel() {
+  const { config, isLoading, error, save, refresh } = useSystemConfig();
+  const [teams, setTeams] = useState<string[]>([]);
+  const [newTeam, setNewTeam] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [feedback, setFeedback] = useState<{ kind: 'success' | 'error'; text: string } | null>(null);
+
+  useEffect(() => {
+    setTeams(config?.teams ?? []);
+  }, [config?.teams]);
+
+  const addTeam = () => {
+    const trimmed = newTeam.trim();
+    if (!trimmed) return;
+    if (teams.includes(trimmed)) {
+      setFeedback({ kind: 'error', text: 'הצוות כבר קיים' });
+      return;
+    }
+    setTeams((prev) => [...prev, trimmed]);
+    setNewTeam('');
+    setFeedback(null);
+  };
+
+  const removeTeam = (name: string) => {
+    setTeams((prev) => prev.filter((t) => t !== name));
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    setFeedback(null);
+    const ok = await save({ teams });
+    setSaving(false);
+    if (ok) {
+      setFeedback({ kind: 'success', text: 'נשמר בהצלחה' });
+      await refresh();
+    } else {
+      setFeedback({ kind: 'error', text: 'שמירה נכשלה' });
+    }
+  };
+
+  if (isLoading) {
+    return <p className="text-sm text-neutral-500">טוען הגדרות...</p>;
+  }
+
+  return (
+    <div className="space-y-6">
+      <section>
+        <h4 className="font-semibold text-neutral-900 mb-2">צוותים</h4>
+        <p className="text-sm text-neutral-600 mb-3">
+          רשימת הצוותים הזמינה למשתמשים בעת רישום ובהגדרות פרופיל.
+        </p>
+
+        {error && (
+          <p className="text-sm text-danger-600 mb-2">{error}</p>
+        )}
+
+        <ul className="space-y-2 mb-4">
+          {teams.length === 0 && (
+            <li className="text-sm text-neutral-500 italic">אין עדיין צוותים — הוסף אחד למטה.</li>
+          )}
+          {teams.map((team) => (
+            <li key={team} className="flex items-center justify-between bg-neutral-50 px-3 py-2 rounded-lg">
+              <span>{team}</span>
+              <button
+                type="button"
+                onClick={() => removeTeam(team)}
+                className="text-danger-600 hover:text-danger-800 text-sm"
+              >
+                הסר
+              </button>
+            </li>
+          ))}
+        </ul>
+
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={newTeam}
+            onChange={(e) => setNewTeam(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                addTeam();
+              }
+            }}
+            placeholder="שם צוות חדש"
+            className="input-base flex-1"
+          />
+          <button type="button" onClick={addTeam} className="btn-secondary">
+            הוסף
+          </button>
+        </div>
+      </section>
+
+      {feedback && (
+        <p
+          className={`text-sm ${
+            feedback.kind === 'success' ? 'text-success-700' : 'text-danger-600'
+          }`}
+        >
+          {feedback.text}
+        </p>
+      )}
+
+      <button type="button" onClick={handleSave} disabled={saving} className="btn-primary">
+        {saving ? 'שומר...' : 'שמור שינויים'}
+      </button>
+    </div>
+  );
+}

--- a/src/app/components/AppShell.tsx
+++ b/src/app/components/AppShell.tsx
@@ -36,7 +36,11 @@ export default function AppShell({
 
   // Onboarding gate: block UI when authenticated user hasn't filled team yet.
   // Equipment scope queries depend on this field, so we surface a mandatory modal.
-  const needsOnboarding = !!enhancedUser && !enhancedUser.teamId;
+  // Require core profile fields too — guards against the welcome modal appearing
+  // for an orphan auth user that has no Firestore profile (AuthContext will sign
+  // them out, but this prevents a flash on slow listeners).
+  const hasProfile = !!enhancedUser?.firstName && !!enhancedUser?.lastName;
+  const needsOnboarding = !!enhancedUser && hasProfile && !enhancedUser.teamId;
 
   return (
     <div className="min-h-screen bg-neutral-50 flex flex-col overflow-x-hidden">

--- a/src/app/test-dashboard/page.tsx
+++ b/src/app/test-dashboard/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useEffect } from 'react';
 import { ChevronDown, ChevronRight, Play, CheckCircle, XCircle, Clock, RotateCcw } from 'lucide-react';
+import AuthGuard from '@/components/auth/AuthGuard';
 import Button from '@/components/ui/Button';
 import { initializeEquipmentTypes, checkEquipmentTypesInitialized, getEquipmentTypeStats } from '@/lib/equipmentInitializer';
 import { EquipmentService } from '@/lib/equipmentService';
@@ -48,7 +49,7 @@ interface TestSubCategory {
   tests: TestItem[];
 }
 
-export default function TestDashboardPage() {
+function TestDashboardContent() {
   const [testResults, setTestResults] = useState<Record<string, TestResult>>({});
   const [expandedCategories, setExpandedCategories] = useState<Set<string>>(new Set(['database', 'equipment']));
   const [expandedSubCategories, setExpandedSubCategories] = useState<Set<string>>(new Set());
@@ -775,5 +776,13 @@ export default function TestDashboardPage() {
         </div>
       </div>
     </div>
+  );
+}
+
+export default function TestDashboardPage() {
+  return (
+    <AuthGuard>
+      <TestDashboardContent />
+    </AuthGuard>
   );
 }

--- a/src/app/tools/convoy/page.tsx
+++ b/src/app/tools/convoy/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from 'react';
 import Link from 'next/link';
+import AuthGuard from '@/components/auth/AuthGuard';
 import { useAuth } from '@/contexts/AuthContext';
 import { trackRouteVisit } from '@/utils/recentRoutesStorage';
 
@@ -14,7 +15,7 @@ function handleDownload() {
   document.body.removeChild(link);
 }
 
-export default function ConvoyToolPage() {
+function ConvoyToolContent() {
   const { isAuthenticated } = useAuth();
 
   useEffect(() => {
@@ -52,5 +53,13 @@ export default function ConvoyToolPage() {
         title="מארגן שיירות"
       />
     </div>
+  );
+}
+
+export default function ConvoyToolPage() {
+  return (
+    <AuthGuard>
+      <ConvoyToolContent />
+    </AuthGuard>
   );
 }

--- a/src/app/tools/logistics/page.tsx
+++ b/src/app/tools/logistics/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from 'react';
 import Link from 'next/link';
+import AuthGuard from '@/components/auth/AuthGuard';
 import { useAuth } from '@/contexts/AuthContext';
 import { trackRouteVisit } from '@/utils/recentRoutesStorage';
 
@@ -14,7 +15,7 @@ function handleDownload() {
   document.body.removeChild(link);
 }
 
-export default function LogisticsToolPage() {
+function LogisticsToolContent() {
   const { isAuthenticated } = useAuth();
 
   useEffect(() => {
@@ -52,5 +53,13 @@ export default function LogisticsToolPage() {
         title="דרישות מל״מ"
       />
     </div>
+  );
+}
+
+export default function LogisticsToolPage() {
+  return (
+    <AuthGuard>
+      <LogisticsToolContent />
+    </AuthGuard>
   );
 }

--- a/src/app/tools/page.tsx
+++ b/src/app/tools/page.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import AppShell from '@/app/components/AppShell';
+import AuthGuard from '@/components/auth/AuthGuard';
 import { downloadTool } from '@/utils/downloadUtils';
 
 const tools = [
@@ -27,6 +28,7 @@ const tools = [
 
 export default function ToolsPage() {
   return (
+    <AuthGuard>
     <AppShell title="🔧 כלים נוספים" subtitle="כלי עזר לשטח — עובדים גם אופליין">
       <div className="max-w-4xl mx-auto w-full">
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
@@ -66,5 +68,6 @@ export default function ToolsPage() {
         </div>
       </div>
     </AppShell>
+    </AuthGuard>
   );
 }

--- a/src/components/management/sidebar/ManagementSidebar.tsx
+++ b/src/components/management/sidebar/ManagementSidebar.tsx
@@ -1,12 +1,13 @@
 /**
  * Management sidebar container component
  */
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { cn } from '@/lib/cn';
 import SidebarHeader from './SidebarHeader';
 import SidebarNavigation from './SidebarNavigation';
 import SidebarFooter from './SidebarFooter';
 import type { ManagementTab } from '@/types/management';
+import { useScrollLock } from '@/hooks/useScrollLock';
 
 export interface ManagementSidebarProps {
   isOpen: boolean;
@@ -25,6 +26,15 @@ export default function ManagementSidebar({
   onClose,
   userName,
 }: ManagementSidebarProps) {
+  const [isMobile, setIsMobile] = useState(false);
+  useEffect(() => {
+    const mql = window.matchMedia('(max-width: 1023px)');
+    const update = () => setIsMobile(mql.matches);
+    update();
+    mql.addEventListener('change', update);
+    return () => mql.removeEventListener('change', update);
+  }, []);
+  useScrollLock(isOpen && isMobile);
   return (
     <div className={cn(
       'fixed inset-y-0 right-0 z-50 w-80 bg-white shadow-2xl transform transition-all duration-500 ease-out',

--- a/src/components/onboarding/WelcomeModal.tsx
+++ b/src/components/onboarding/WelcomeModal.tsx
@@ -5,6 +5,8 @@ import { useAuth } from '@/contexts/AuthContext';
 import { updateUserProfile } from '@/lib/userProfileService';
 import { TEXT_CONSTANTS } from '@/constants/text';
 import ProfileImageUpload from '@/components/profile/ProfileImageUpload';
+import { useScrollLock } from '@/hooks/useScrollLock';
+import { useSystemConfig } from '@/hooks/useSystemConfig';
 
 /**
  * Mandatory onboarding modal. Surfaces whenever an authenticated user is missing
@@ -14,8 +16,12 @@ import ProfileImageUpload from '@/components/profile/ProfileImageUpload';
  * Rendered by AppShell conditionally on `enhancedUser && !teamId`.
  */
 export default function WelcomeModal() {
+  useScrollLock(true);
   const { enhancedUser, refreshEnhancedUser } = useAuth();
+  const { config, isLoading: teamsLoading, error: teamsError } = useSystemConfig();
   const [teamId, setTeamId] = useState(enhancedUser?.teamId ?? '');
+  const teams = config?.teams ?? [];
+  const teamsAvailable = teams.length > 0;
   // Drop legacy blob: URLs from the old mock — they error on render and would re-persist on save.
   const initialProfileImage =
     enhancedUser?.profileImage && /^https?:\/\//i.test(enhancedUser.profileImage)
@@ -76,18 +82,31 @@ export default function WelcomeModal() {
             <label htmlFor="welcome-team" className="block text-sm font-medium text-neutral-700 mb-1">
               {TEXT_CONSTANTS.ONBOARDING.TEAM_LABEL}
             </label>
-            <input
+            <select
               id="welcome-team"
-              type="text"
               value={teamId}
               onChange={(e) => setTeamId(e.target.value)}
-              placeholder={TEXT_CONSTANTS.ONBOARDING.TEAM_PLACEHOLDER}
               className={`input-base ${errors.teamId ? 'border-danger-500' : ''}`}
-              autoComplete="off"
+              disabled={teamsLoading || !teamsAvailable}
               autoFocus
-            />
+            >
+              <option value="">
+                {teamsLoading
+                  ? TEXT_CONSTANTS.ONBOARDING.TEAMS_LOADING
+                  : TEXT_CONSTANTS.ONBOARDING.TEAM_SELECT_PLACEHOLDER}
+              </option>
+              {teams.map((t) => (
+                <option key={t} value={t}>{t}</option>
+              ))}
+            </select>
             <p className="text-xs text-neutral-500 mt-1">{TEXT_CONSTANTS.ONBOARDING.TEAM_HELP}</p>
             {errors.teamId && <p className="text-danger-600 text-xs mt-1">{errors.teamId}</p>}
+            {!teamsLoading && !teamsAvailable && !teamsError && (
+              <p className="text-warning-700 text-xs mt-1">{TEXT_CONSTANTS.ONBOARDING.TEAMS_EMPTY}</p>
+            )}
+            {teamsError && (
+              <p className="text-danger-600 text-xs mt-1">{TEXT_CONSTANTS.ONBOARDING.TEAMS_LOAD_ERROR}</p>
+            )}
           </div>
 
           {errors.submit && (
@@ -96,7 +115,11 @@ export default function WelcomeModal() {
             </div>
           )}
 
-          <button type="submit" disabled={saving} className="btn-primary w-full">
+          <button
+            type="submit"
+            disabled={saving || teamsLoading || !teamsAvailable || !teamId}
+            className="btn-primary w-full"
+          >
             {saving ? TEXT_CONSTANTS.ONBOARDING.SAVING : TEXT_CONSTANTS.ONBOARDING.SUBMIT}
           </button>
         </form>

--- a/src/components/registration/RegistrationForm.tsx
+++ b/src/components/registration/RegistrationForm.tsx
@@ -17,6 +17,10 @@ import {
   sendVerificationEmail,
   mapFirebaseAuthError,
 } from '@/lib/firebasePhoneAuth';
+import {
+  setRegistrationInProgress,
+  clearRegistrationInProgress,
+} from '@/lib/registrationFlowFlag';
 import type { ConfirmationResult } from 'firebase/auth';
 
 interface RegistrationFormProps {
@@ -117,6 +121,9 @@ export default function RegistrationForm({ personalNumber, setPersonalNumber, on
         setConfirmationResult(confirmation);
         updateCurrentStep('otp');
       } catch (error) {
+        // Per Firebase docs, reset reCAPTCHA after a failed send so the next
+        // attempt issues a fresh token instead of replaying a consumed one.
+        resetRecaptcha();
         setOtpSendError(mapFirebaseAuthError(error));
       } finally {
         setIsSendingOTP(false);
@@ -129,6 +136,10 @@ export default function RegistrationForm({ personalNumber, setPersonalNumber, on
   };
 
   const handleOTPVerifySuccess = () => {
+    // Auth user now exists; mark registration in progress so AuthContext
+    // does not sign the user out for missing Firestore profile while the
+    // remaining steps run.
+    setRegistrationInProgress();
     updateCurrentStep('personal');
   };
 
@@ -186,6 +197,7 @@ export default function RegistrationForm({ personalNumber, setPersonalNumber, on
       const result = await response.json();
 
       if (response.ok && result.success) {
+        clearRegistrationInProgress();
         updateCurrentStep('success');
       } else {
         setValidationError(result.error || 'Profile creation failed. Please contact support.');

--- a/src/components/registration/RegistrationModal.tsx
+++ b/src/components/registration/RegistrationModal.tsx
@@ -1,8 +1,15 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import RegistrationHeader from './RegistrationHeader';
 import RegistrationForm from './RegistrationForm';
 import RegistrationFooter from './RegistrationFooter';
 import RegistrationStepDots, { RegistrationStep } from './RegistrationStepDots';
+import { auth } from '@/lib/firebase';
+import {
+  deleteCurrentUser,
+  signOutCurrentUser,
+  RequiresRecentLoginError,
+} from '@/lib/firebasePhoneAuth';
+import { clearRegistrationInProgress } from '@/lib/registrationFlowFlag';
 
 interface RegistrationModalProps {
   isOpen: boolean;
@@ -14,21 +21,59 @@ interface RegistrationModalProps {
 export default function RegistrationModal({ isOpen, onClose, onSwitch, onRegistrationSuccess }: RegistrationModalProps) {
   const [personalNumber, setPersonalNumber] = useState('');
   const [currentStep, setCurrentStep] = useState<RegistrationStep>('personal-number');
+  const registrationCompleteRef = useRef(false);
+
+  // Cleanup orphan Firebase Auth user when the user abandons the flow.
+  // Same-session abandon (immediate close after OTP) deletes the user. If
+  // Firebase rejects delete with requires-recent-login (>5 min after OTP),
+  // we fall back to signOut — AuthContext will refuse to mark the orphan
+  // as authenticated on the next page load.
+  const cleanupOrphanAuthUser = async () => {
+    if (registrationCompleteRef.current) return;
+    if (!auth.currentUser) return;
+    try {
+      await deleteCurrentUser();
+    } catch (err) {
+      if (err instanceof RequiresRecentLoginError) {
+        try { await signOutCurrentUser(); } catch { /* swallow */ }
+      } else {
+        console.error('[RegistrationModal] cleanup failed', err);
+        try { await signOutCurrentUser(); } catch { /* swallow */ }
+      }
+    } finally {
+      clearRegistrationInProgress();
+    }
+  };
+
+  // Unmount cleanup — covers route-change abandon. Intentional empty deps:
+  // we only want this to run on unmount; the helper closure is defined inline
+  // and the cleanup logic is idempotent.
+  useEffect(() => {
+    return () => {
+      void cleanupOrphanAuthUser();
+    };
+  }, []);
 
   if (!isOpen) return null;
 
   const handleClose = () => {
-    // Reset form state when closing
+    void cleanupOrphanAuthUser();
     setPersonalNumber('');
     setCurrentStep('personal-number');
     onClose();
   };
 
   const handleSwitchToLogin = () => {
-    // Reset form state when switching
+    void cleanupOrphanAuthUser();
     setPersonalNumber('');
     setCurrentStep('personal-number');
     onSwitch();
+  };
+
+  const handleRegistrationComplete = () => {
+    registrationCompleteRef.current = true;
+    clearRegistrationInProgress();
+    onRegistrationSuccess?.();
   };
 
   const handleStepChange = (step: RegistrationStep) => {
@@ -79,13 +124,13 @@ export default function RegistrationModal({ isOpen, onClose, onSwitch, onRegistr
             <RegistrationStepDots currentStep={currentStep} />
           </div>
           
-          <RegistrationForm 
+          <RegistrationForm
             personalNumber={personalNumber}
             setPersonalNumber={setPersonalNumber}
             onSwitchToLogin={handleSwitchToLogin}
             onStepChange={handleStepChange}
             currentStep={currentStep}
-            onRegistrationSuccess={onRegistrationSuccess}
+            onRegistrationSuccess={handleRegistrationComplete}
           />
           
           <RegistrationFooter showRegistrationNote={currentStep === 'personal-number'} />

--- a/src/constants/admin.ts
+++ b/src/constants/admin.ts
@@ -105,6 +105,11 @@ export const ADMIN_TABS = [
     id: 'system-stats' as const,
     name: '📊 סטטיסטיקות מערכת',
     description: 'סקירה של נתוני המערכת ומצבה.'
+  },
+  {
+    id: 'system-config' as const,
+    name: '⚙️ הגדרות מערכת',
+    description: 'נהל ערכים גלובליים — רשימת צוותים, נמען התראות תחמושת ועוד.'
   }
 ] as const;
 

--- a/src/constants/text.ts
+++ b/src/constants/text.ts
@@ -83,6 +83,8 @@ export const TEXT_CONSTANTS = {
     PROVIDER_ALREADY_LINKED: 'שיטת ההתחברות כבר משויכת לחשבון.',
     WEAK_PASSWORD: 'הסיסמה חלשה מדי. בחר סיסמה חזקה יותר.',
     INVALID_EMAIL: 'כתובת אימייל לא תקינה.',
+    REQUIRES_RECENT_LOGIN: 'הפעולה דורשת התחברות מחדש. אנא התחבר ונסה שוב.',
+    REGISTRATION_ABANDONED_FALLBACK: 'הרישום בוטל. ייתכן שיהיה צורך לפנות למנהל כדי להסיר את החשבון.',
 
     // Email verification (soft)
     EMAIL_VERIFICATION_BANNER: 'אנא אמת את כתובת האימייל שלך כדי לאפשר איפוס סיסמה.',
@@ -1619,6 +1621,10 @@ export const TEXT_CONSTANTS = {
     SAVING: 'שומר...',
     VALIDATION_TEAM_REQUIRED: 'חובה למלא צוות',
     SAVE_ERROR: 'שמירה נכשלה. נסה שוב.',
+    TEAM_SELECT_PLACEHOLDER: 'בחר צוות',
+    TEAMS_LOADING: 'טוען רשימת צוותים...',
+    TEAMS_EMPTY: 'אין צוותים מוגדרים — פנה למנהל המערכת.',
+    TEAMS_LOAD_ERROR: 'שגיאה בטעינת רשימת צוותים. נסה לרענן.',
     ASSIGNMENT_TITLE: 'הצוות שלי',
     SAVE: 'שמור',
     SAVED: 'נשמר בהצלחה'

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -7,6 +7,7 @@ import { sendVerificationEmail as sendVerificationEmailHelper } from '@/lib/fire
 import { ADMIN_CONFIG, ADMIN_MESSAGES } from '@/constants/admin';
 import { UserDataService } from '@/lib/userDataService';
 import { EnhancedAuthUser, UserType } from '@/types/user';
+import { isRegistrationInProgress } from '@/lib/registrationFlowFlag';
 
 // Types
 export interface AuthUser {
@@ -84,6 +85,21 @@ export function AuthProvider({ children }: AuthProviderProps) {
           console.log('🔍 Fetching user data from Firestore...');
           const userDataResult = await UserDataService.fetchUserDataByUid(firebaseUser.uid);
           
+          if (!userDataResult.success || !userDataResult.userData) {
+            // No Firestore profile: this user is either an admin without a
+            // profile yet, or an orphan from an abandoned registration. We
+            // do NOT trust Firebase Auth alone — sign them out unless they
+            // are actively progressing through the registration flow.
+            if (!isRegistrationInProgress()) {
+              console.warn('[AuthContext] No Firestore profile; signing out orphan auth user');
+              try { await signOut(auth); } catch (signOutErr) { console.error(signOutErr); }
+              setUser(null);
+              setEnhancedUser(null);
+              setIsLoading(false);
+              return;
+            }
+          }
+
           if (userDataResult.success && userDataResult.userData) {
             const firestoreData = userDataResult.userData;
             userType = firestoreData.userType;

--- a/src/hooks/useScrollLock.ts
+++ b/src/hooks/useScrollLock.ts
@@ -1,0 +1,14 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export function useScrollLock(active: boolean): void {
+  useEffect(() => {
+    if (!active) return;
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [active]);
+}

--- a/src/hooks/useSystemConfig.ts
+++ b/src/hooks/useSystemConfig.ts
@@ -5,11 +5,16 @@ import { useAuth } from '@/contexts/AuthContext';
 import type { SystemConfig } from '@/types/ammunition';
 import type { ApiActor } from '@/lib/equipmentService';
 
+export interface SystemConfigSavePayload {
+  ammoNotificationRecipientUserId?: string;
+  teams?: string[];
+}
+
 export interface UseSystemConfigReturn {
   config: SystemConfig | null;
   isLoading: boolean;
   error: string | null;
-  save: (payload: { ammoNotificationRecipientUserId?: string }) => Promise<boolean>;
+  save: (payload: SystemConfigSavePayload) => Promise<boolean>;
   refresh: () => Promise<void>;
 }
 
@@ -56,7 +61,7 @@ export function useSystemConfig(): UseSystemConfigReturn {
   }, [refresh]);
 
   const save = useCallback(
-    async (payload: { ammoNotificationRecipientUserId?: string }) => {
+    async (payload: SystemConfigSavePayload) => {
       const actor = buildActor(enhancedUser);
       if (!actor) {
         setError('דרושה התחברות');

--- a/src/lib/__mocks__/firebase.ts
+++ b/src/lib/__mocks__/firebase.ts
@@ -1,5 +1,12 @@
 export const db = {};
-export const auth = { currentUser: null };
+// Per Firebase phone-auth docs, set appVerificationDisabledForTesting on the
+// auth settings object so component tests can simulate OTP without invoking
+// real reCAPTCHA. Fictional test phone numbers configured in Firebase Console
+// will resolve without sending an SMS.
+export const auth = {
+  currentUser: null,
+  settings: { appVerificationDisabledForTesting: true },
+};
 export const app = {};
 
 // firebase/app

--- a/src/lib/db/server/systemConfigService.ts
+++ b/src/lib/db/server/systemConfigService.ts
@@ -13,11 +13,12 @@ const MAIN_DOC_ID = 'main';
 
 export type SystemConfigUpdatableFields = Pick<
   SystemConfig,
-  'ammoNotificationRecipientUserId'
+  'ammoNotificationRecipientUserId' | 'teams'
 >;
 
 export interface SystemConfigPayload {
   ammoNotificationRecipientUserId?: string;
+  teams?: string[];
 }
 
 export async function serverGetSystemConfig(): Promise<SystemConfig | null> {
@@ -49,6 +50,24 @@ export function validateSystemConfigPayload(payload: unknown): SystemConfigPaylo
       throw new Error('ammoNotificationRecipientUserId must be a string');
     }
   }
+
+  if ('teams' in p) {
+    const v = p.teams;
+    if (!Array.isArray(v)) {
+      throw new Error('teams must be an array of strings');
+    }
+    const normalized: string[] = [];
+    for (const item of v) {
+      if (typeof item !== 'string') {
+        throw new Error('teams entries must be strings');
+      }
+      const trimmed = item.trim();
+      if (!trimmed) continue;
+      if (!normalized.includes(trimmed)) normalized.push(trimmed);
+    }
+    out.teams = normalized;
+  }
+
   return out;
 }
 

--- a/src/lib/firebasePhoneAuth.ts
+++ b/src/lib/firebasePhoneAuth.ts
@@ -5,12 +5,20 @@ import {
   linkWithCredential,
   sendEmailVerification,
   sendPasswordResetEmail,
+  signOut,
   type ConfirmationResult,
   type User,
   type UserCredential,
 } from 'firebase/auth';
 import { auth } from '@/lib/firebase';
 import { TEXT_CONSTANTS } from '@/constants/text';
+
+export class RequiresRecentLoginError extends Error {
+  constructor() {
+    super('auth/requires-recent-login');
+    this.name = 'RequiresRecentLoginError';
+  }
+}
 
 let cachedVerifier: RecaptchaVerifier | null = null;
 
@@ -62,6 +70,36 @@ export async function sendPasswordReset(email: string): Promise<void> {
   return sendPasswordResetEmail(auth, email);
 }
 
+/**
+ * Delete the currently signed-in Firebase user. Used to clean up the orphan
+ * Auth account left behind when registration is abandoned after phone OTP
+ * but before the Firestore profile is written.
+ *
+ * Throws RequiresRecentLoginError when Firebase rejects the delete because
+ * the sign-in is no longer "recent" (typically >5 min after OTP confirm).
+ * Callers should fall back to signOutCurrentUser() in that case.
+ */
+export async function deleteCurrentUser(): Promise<void> {
+  const user = auth.currentUser;
+  if (!user) return;
+  try {
+    await user.delete();
+  } catch (error) {
+    const code =
+      error && typeof error === 'object' && 'code' in error
+        ? (error as { code: string }).code
+        : '';
+    if (code === 'auth/requires-recent-login') {
+      throw new RequiresRecentLoginError();
+    }
+    throw error;
+  }
+}
+
+export async function signOutCurrentUser(): Promise<void> {
+  await signOut(auth);
+}
+
 export function mapFirebaseAuthError(error: unknown): string {
   const code =
     error && typeof error === 'object' && 'code' in error
@@ -93,6 +131,8 @@ export function mapFirebaseAuthError(error: unknown): string {
       return TEXT_CONSTANTS.AUTH.WEAK_PASSWORD;
     case 'auth/invalid-email':
       return TEXT_CONSTANTS.AUTH.INVALID_EMAIL;
+    case 'auth/requires-recent-login':
+      return TEXT_CONSTANTS.AUTH.REQUIRES_RECENT_LOGIN;
     default:
       return TEXT_CONSTANTS.AUTH.OTP_INTERNAL_ERROR;
   }

--- a/src/lib/registrationFlowFlag.ts
+++ b/src/lib/registrationFlowFlag.ts
@@ -1,0 +1,36 @@
+/**
+ * SessionStorage flag indicating that the user is actively progressing through
+ * the registration flow. While set, AuthContext must NOT treat a Firebase Auth
+ * user with no Firestore profile as an orphan to sign out — registration is
+ * legitimately in that intermediate state until /api/auth/register completes.
+ *
+ * Cleared as soon as registration succeeds or the modal cleans up.
+ */
+const KEY = 'registrationInProgress';
+
+export function setRegistrationInProgress(): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.sessionStorage.setItem(KEY, '1');
+  } catch {
+    // sessionStorage unavailable (private mode, SSR) — best-effort.
+  }
+}
+
+export function clearRegistrationInProgress(): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.sessionStorage.removeItem(KEY);
+  } catch {
+    // best-effort
+  }
+}
+
+export function isRegistrationInProgress(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    return window.sessionStorage.getItem(KEY) === '1';
+  } catch {
+    return false;
+  }
+}

--- a/src/types/admin.ts
+++ b/src/types/admin.ts
@@ -90,7 +90,7 @@ export interface ValidationResult {
 }
 
 // Admin dashboard types
-export type AdminTabType = 'add-personnel' | 'bulk-upload' | 'view-personnel' | 'update-personnel' | 'system-stats';
+export type AdminTabType = 'add-personnel' | 'bulk-upload' | 'view-personnel' | 'update-personnel' | 'system-stats' | 'system-config';
 
 export interface SystemStats {
   authorizedPersonnelCount: number;

--- a/src/types/ammunition.ts
+++ b/src/types/ammunition.ts
@@ -120,6 +120,7 @@ export interface AmmunitionReportRequest {
 export interface SystemConfig {
   id: string;
   ammoNotificationRecipientUserId?: string;
+  teams?: string[];
   updatedAt: Timestamp;
   updatedBy: string;
 }


### PR DESCRIPTION
Mid-flow registration left a Firebase Auth user with no Firestore profile, which AuthContext still treated as authenticated. The user could navigate the app and the welcome popup appeared for an account that had no profile at all.

Changes:
- RegistrationModal: on close/back/unmount, delete the orphan Firebase Auth user via new deleteCurrentUser(); fall back to signOut on auth/requires-recent-login. Skip cleanup once registration succeeds.
- registrationFlowFlag: sessionStorage signal so AuthContext does not race the in-flight flow and sign the user out before profile write.
- AuthContext: if Firebase user has no Firestore profile and the flag is not set, signOut immediately.
- AppShell: welcome gate now also requires firstName + lastName.
- AuthGuard: wrapped previously unprotected /tools, /tools/convoy, /tools/logistics, /test-dashboard.
- WelcomeModal: team field is now a dropdown sourced from systemConfig/main.teams. Empty list shows Hebrew "no teams configured" message and disables submit. Body scroll locked while modal open.
- ManagementSidebar: body scroll locked on mobile when drawer is open.
- New shared useScrollLock hook.
- SystemConfig: extended type/server/hook to accept teams: string[]. New admin tab (SystemConfigPanel) to manage the list.
- firebasePhoneAuth: reset reCAPTCHA on send-failure path per Firebase docs; map auth/requires-recent-login. Enable appVerificationDisabledForTesting in Jest mock.
- Docs updated: bugs.md, firebase-operations.md, RegistrationModal.md, useSystemConfig.md, useScrollLock.md.