### PR TITLE
fix(registration): OTP resend, layout overflow, account-deletion guard

### DIFF
--- a/docs/codebase/src/components/registration/RegistrationModal.md
+++ b/docs/codebase/src/components/registration/RegistrationModal.md
@@ -13,6 +13,14 @@ After phone OTP succeeds the Firebase Auth user already exists, but the Firestor
 
 A `registrationCompleteRef` is set on the success step to skip cleanup. The modal also sets/clears the `registrationInProgress` sessionStorage flag (via `@/lib/registrationFlowFlag`) so `AuthContext.onAuthStateChanged` does not race the in-flight registration and sign the user out prematurely.
 
+Cleanup is gated by three checks before issuing `deleteCurrentUser()`:
+
+1. `registrationCompleteRef.current` — never delete after a successful registration.
+2. `isRegistrationInProgress()` — only act on auth users created by the current flow; protects users who reopened the modal while already logged in.
+3. `UserDataService.fetchUserDataByUid(uid)` — if a Firestore profile exists, the user is real and we never delete; this protects previously-registered users who happen to re-confirm OTP onto their existing account.
+
+The reCAPTCHA host (`<RecaptchaContainer />`) is rendered at the modal level, not inside step branches. If it lived inside a step branch, the DOM node would unmount/remount on every step transition and the cached `RecaptchaVerifier` would be left holding a detached node — which is what was breaking OTP resend.
+
 ## Props
 
 | Prop | Type | Required | Description |

--- a/src/app/components/AppShell.tsx
+++ b/src/app/components/AppShell.tsx
@@ -9,6 +9,7 @@ import QuickActionFab from './QuickActionFab';
 import WelcomeModal from '@/components/onboarding/WelcomeModal';
 import { useAuth } from '@/contexts/AuthContext';
 import { trackRouteVisit } from '@/utils/recentRoutesStorage';
+import { isRegistrationInProgress } from '@/lib/registrationFlowFlag';
 
 interface AppShellProps {
   title: string;
@@ -36,11 +37,12 @@ export default function AppShell({
 
   // Onboarding gate: block UI when authenticated user hasn't filled team yet.
   // Equipment scope queries depend on this field, so we surface a mandatory modal.
-  // Require core profile fields too — guards against the welcome modal appearing
-  // for an orphan auth user that has no Firestore profile (AuthContext will sign
-  // them out, but this prevents a flash on slow listeners).
+  // Require core profile fields AND no in-flight registration — prevents the
+  // welcome modal flashing for an orphan auth user mid-registration, or for a
+  // previously-registered user re-confirming OTP through the registration flow.
   const hasProfile = !!enhancedUser?.firstName && !!enhancedUser?.lastName;
-  const needsOnboarding = !!enhancedUser && hasProfile && !enhancedUser.teamId;
+  const needsOnboarding =
+    !!enhancedUser && hasProfile && !enhancedUser.teamId && !isRegistrationInProgress();
 
   return (
     <div className="min-h-screen bg-neutral-50 flex flex-col overflow-x-hidden">

--- a/src/components/registration/PersonalDetailsStep.tsx
+++ b/src/components/registration/PersonalDetailsStep.tsx
@@ -134,50 +134,48 @@ export default function PersonalDetailsStep({
             )}
           </div>
 
-          {/* Gender Dropdown - full width */}
-          <div className="space-y-1">
-            <Select
-              value={formData.gender || null}
-              onChange={(v) => handleInputChange('gender', v ?? '')}
-              options={[
-                { value: 'male', label: TEXT_CONSTANTS.AUTH.GENDER_MALE },
-                { value: 'female', label: TEXT_CONSTANTS.AUTH.GENDER_FEMALE },
-                { value: 'other', label: TEXT_CONSTANTS.AUTH.GENDER_OTHER },
-              ]}
-              placeholder="בחר מין"
-              clearable
-              ariaLabel={TEXT_CONSTANTS.AUTH.GENDER}
-            />
+          {/* Gender + Birthdate side by side to keep the modal compact */}
+          <div className="grid grid-cols-2 gap-2">
+            <div className="space-y-1">
+              <Select
+                value={formData.gender || null}
+                onChange={(v) => handleInputChange('gender', v ?? '')}
+                options={[
+                  { value: 'male', label: TEXT_CONSTANTS.AUTH.GENDER_MALE },
+                  { value: 'female', label: TEXT_CONSTANTS.AUTH.GENDER_FEMALE },
+                  { value: 'other', label: TEXT_CONSTANTS.AUTH.GENDER_OTHER },
+                ]}
+                placeholder="בחר מין"
+                clearable
+                ariaLabel={TEXT_CONSTANTS.AUTH.GENDER}
+                className="px-3 py-2 rounded-lg text-sm"
+              />
+              {validationErrors.gender && formData.gender && (
+                <p className="text-xs text-danger-600 text-right px-1" data-testid="gender-error">
+                  {validationErrors.gender}
+                </p>
+              )}
+            </div>
 
-            {/* Gender Error Message */}
-            {validationErrors.gender && formData.gender && (
-              <p className="text-xs text-danger-600 text-right px-1" data-testid="gender-error">
-                {validationErrors.gender}
-              </p>
-            )}
-          </div>
-
-          {/* Birthdate Picker - full width */}
-          <div className="space-y-1">
-            <input
-              type="date"
-              value={formData.birthdate}
-              onChange={(e) => handleInputChange('birthdate', e.target.value)}
-              className={`w-full px-3 py-2 border-2 rounded-lg focus:ring-2 outline-none transition-all
-                       text-right text-neutral-800 bg-white text-sm ${
-                validationErrors.birthdate && formData.birthdate
-                  ? 'border-danger-500 focus:border-danger-500 focus:ring-danger-500'
-                  : 'border-neutral-200 focus:border-info-500 focus:ring-info-500'
-              }`}
-              data-testid="birthdate-input"
-            />
-
-            {/* Birthdate Error Message */}
-            {validationErrors.birthdate && formData.birthdate && (
-              <p className="text-xs text-danger-600 text-right px-1" data-testid="birthdate-error">
-                {validationErrors.birthdate}
-              </p>
-            )}
+            <div className="space-y-1">
+              <input
+                type="date"
+                value={formData.birthdate}
+                onChange={(e) => handleInputChange('birthdate', e.target.value)}
+                className={`w-full px-3 py-2 border-2 rounded-lg focus:ring-2 outline-none transition-all
+                         text-right text-neutral-800 bg-white text-sm ${
+                  validationErrors.birthdate && formData.birthdate
+                    ? 'border-danger-500 focus:border-danger-500 focus:ring-danger-500'
+                    : 'border-neutral-200 focus:border-info-500 focus:ring-info-500'
+                }`}
+                data-testid="birthdate-input"
+              />
+              {validationErrors.birthdate && formData.birthdate && (
+                <p className="text-xs text-danger-600 text-right px-1" data-testid="birthdate-error">
+                  {validationErrors.birthdate}
+                </p>
+              )}
+            </div>
           </div>
 
           {/* Continue Button */}

--- a/src/components/registration/RegistrationForm.tsx
+++ b/src/components/registration/RegistrationForm.tsx
@@ -5,7 +5,7 @@ import OTPVerificationStep from './OTPVerificationStep';
 import PersonalDetailsStep from './PersonalDetailsStep';
 import AccountDetailsStep from './AccountDetailsStep';
 import RegistrationSuccessStep from './RegistrationSuccessStep';
-import RecaptchaContainer, { RECAPTCHA_CONTAINER_ID } from './RecaptchaContainer';
+import { RECAPTCHA_CONTAINER_ID } from './RecaptchaContainer';
 import RecaptchaAttribution from './RecaptchaAttribution';
 import { PersonalDetailsData, AccountDetailsData } from '@/types/registration';
 import { auth } from '@/lib/firebase';
@@ -216,7 +216,6 @@ export default function RegistrationForm({ personalNumber, setPersonalNumber, on
   if (currentStep === 'otp') {
     return (
       <>
-        <RecaptchaContainer />
         <OTPVerificationStep
           phoneNumber={userPhoneNumber}
           confirmationResult={confirmationResult}
@@ -261,7 +260,6 @@ export default function RegistrationForm({ personalNumber, setPersonalNumber, on
   }
   return (
     <>
-      <RecaptchaContainer />
       <div className="text-center px-6 pb-4">
         <div className="w-12 h-12 bg-gradient-to-br from-warning-400 to-warning-600 rounded-full flex items-center justify-center mx-auto mb-4">
           <svg className="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/src/components/registration/RegistrationModal.tsx
+++ b/src/components/registration/RegistrationModal.tsx
@@ -3,13 +3,18 @@ import RegistrationHeader from './RegistrationHeader';
 import RegistrationForm from './RegistrationForm';
 import RegistrationFooter from './RegistrationFooter';
 import RegistrationStepDots, { RegistrationStep } from './RegistrationStepDots';
+import RecaptchaContainer from './RecaptchaContainer';
 import { auth } from '@/lib/firebase';
 import {
   deleteCurrentUser,
   signOutCurrentUser,
   RequiresRecentLoginError,
 } from '@/lib/firebasePhoneAuth';
-import { clearRegistrationInProgress } from '@/lib/registrationFlowFlag';
+import {
+  clearRegistrationInProgress,
+  isRegistrationInProgress,
+} from '@/lib/registrationFlowFlag';
+import { UserDataService } from '@/lib/userDataService';
 
 interface RegistrationModalProps {
   isOpen: boolean;
@@ -24,13 +29,37 @@ export default function RegistrationModal({ isOpen, onClose, onSwitch, onRegistr
   const registrationCompleteRef = useRef(false);
 
   // Cleanup orphan Firebase Auth user when the user abandons the flow.
-  // Same-session abandon (immediate close after OTP) deletes the user. If
-  // Firebase rejects delete with requires-recent-login (>5 min after OTP),
-  // we fall back to signOut — AuthContext will refuse to mark the orphan
-  // as authenticated on the next page load.
+  // Guarded so we never delete a fully-registered user that happened to
+  // reopen the modal and re-confirm OTP onto their existing account:
+  //   1. registrationCompleteRef — set on the success step.
+  //   2. registrationInProgress flag — only set during a fresh OTP confirm.
+  //   3. Firestore profile lookup — if a profile exists, the user is real,
+  //      skip delete and only clear the in-progress flag.
+  // If Firebase rejects delete with requires-recent-login (>5 min after OTP),
+  // fall back to signOut — AuthContext will refuse to mark the orphan as
+  // authenticated on the next page load.
   const cleanupOrphanAuthUser = async () => {
     if (registrationCompleteRef.current) return;
-    if (!auth.currentUser) return;
+    const user = auth.currentUser;
+    if (!user) return;
+    if (!isRegistrationInProgress()) return;
+
+    try {
+      const result = await UserDataService.fetchUserDataByUid(user.uid);
+      if (result.success && result.userData) {
+        // Real user — never delete. Just clear the flag.
+        clearRegistrationInProgress();
+        return;
+      }
+    } catch (err) {
+      console.error('[RegistrationModal] profile lookup failed', err);
+      // Conservative: if lookup fails, do not delete; signOut so AuthContext
+      // re-evaluates next load.
+      try { await signOutCurrentUser(); } catch { /* swallow */ }
+      clearRegistrationInProgress();
+      return;
+    }
+
     try {
       await deleteCurrentUser();
     } catch (err) {
@@ -109,12 +138,18 @@ export default function RegistrationModal({ isOpen, onClose, onSwitch, onRegistr
         onClick={handleClose}
       />
       
+      {/* reCAPTCHA host — kept at modal level so the DOM node persists across
+          step transitions; Firebase RecaptchaVerifier caches a reference to
+          this node and re-mounting it (when the form re-renders for a new
+          step) would orphan the verifier and break OTP resend. */}
+      <RecaptchaContainer />
+
       {/* Modal Container - Centered for all screen sizes */}
       <div className="fixed inset-0 z-50 flex items-center justify-center p-4 sm:p-6 pointer-events-none">
-        <div className="relative bg-white rounded-2xl shadow-2xl w-full max-w-sm h-[600px] modal-enter pointer-events-auto 
+        <div className="relative bg-white rounded-2xl shadow-2xl w-full max-w-sm h-[600px] modal-enter pointer-events-auto
                 my-4 sm:my-8 flex flex-col">
-          
-          <RegistrationHeader 
+
+          <RegistrationHeader
             onBack={handleBackNavigation}
             onClose={handleClose}
           />


### PR DESCRIPTION
Three follow-up bugs from manual testing:

- Resend OTP threw "internal error". RecaptchaContainer was rendered inside two step branches in RegistrationForm; on step transition the DOM node unmounted/remounted while the cached RecaptchaVerifier still pointed at the detached node, so the second signInWithPhoneNumber call fed it a dead container. Hoisted RecaptchaContainer to RegistrationModal so the host node persists across all steps.

- PersonalDetailsStep overflowed the 600px modal. Gender (Listbox-based Select) and birthdate had been stacked vertically, each in its own full-width row, plus the Listbox button inherits input-base padding. Placed gender + birthdate side-by-side via grid-cols-2 so the form fits the modal again.

- Cleanup helper would delete any auth.currentUser when the modal closed mid-flow — including a fully-registered user who just reopened the modal and re-confirmed OTP onto their existing account. Now guarded by: registrationCompleteRef, isRegistrationInProgress, AND a Firestore profile lookup. If a profile exists we never delete. AppShell also suppresses WelcomeModal while registrationInProgress is set, to stop the flash on close.