### PR TITLE
fix(registration): race-proof OTP flag, instant verify->OTP, lock hea…

### DIFF
--- a/docs/codebase/src/components/registration/RegistrationModal.md
+++ b/docs/codebase/src/components/registration/RegistrationModal.md
@@ -21,6 +21,14 @@ Cleanup is gated by three checks before issuing `deleteCurrentUser()`:
 
 The reCAPTCHA host (`<RecaptchaContainer />`) is rendered at the modal level, not inside step branches. If it lived inside a step branch, the DOM node would unmount/remount on every step transition and the cached `RecaptchaVerifier` would be left holding a detached node — which is what was breaking OTP resend.
 
+## Race-proofing: registrationInProgress flag is set on OTP step mount
+
+`OTPVerificationStep` calls `setRegistrationInProgress()` from a mount-time `useEffect`. Firebase fires `onAuthStateChanged` synchronously around the resolution of `confirmation.confirm(code)`, which runs faster than the post-resolve callback chain that previously set the flag. Setting the flag at OTP-step mount guarantees the listener in `AuthContext` always sees it before the first confirm could fire, so it never signs the user out for "no Firestore profile" while registration is in flight.
+
+## Header lock during account creation
+
+When the user clicks "Create Account" on the account step, `RegistrationForm.handleAccountDetailsSubmit` runs `linkEmailPassword` → `sendEmailVerification` → `POST /api/auth/register`. While that chain is in flight, the modal locks both the X (close) and back buttons via `RegistrationHeader`'s new `disabled` prop, the backdrop `onClick` is suppressed, and `handleClose` / `handleBackNavigation` short-circuit defensively. This prevents abandonment in the half-linked window, which would leave a Firebase auth user with email credential attached but no Firestore profile.
+
 ## Props
 
 | Prop | Type | Required | Description |

--- a/src/components/registration/OTPVerificationStep.tsx
+++ b/src/components/registration/OTPVerificationStep.tsx
@@ -3,12 +3,15 @@ import type { ConfirmationResult } from 'firebase/auth';
 import { TEXT_CONSTANTS } from '@/constants/text';
 import { validateOTP, maskPhoneNumber } from '@/utils/validationUtils';
 import { confirmPhoneOtp, mapFirebaseAuthError } from '@/lib/firebasePhoneAuth';
+import { setRegistrationInProgress } from '@/lib/registrationFlowFlag';
 
 interface OTPVerificationStepProps {
   phoneNumber: string;
   confirmationResult: ConfirmationResult | null;
   onVerifySuccess?: () => void;
   onResendOtp?: () => Promise<void>;
+  isSending?: boolean;
+  sendError?: string | null;
 }
 
 export default function OTPVerificationStep({
@@ -16,7 +19,17 @@ export default function OTPVerificationStep({
   confirmationResult,
   onVerifySuccess,
   onResendOtp,
+  isSending = false,
+  sendError = null,
 }: OTPVerificationStepProps) {
+  // Mark registration as in-flight the moment the OTP step mounts. This must
+  // happen BEFORE confirmation.confirm() can fire, because Firebase triggers
+  // onAuthStateChanged synchronously around its resolve. Without the flag set,
+  // AuthContext would see "no Firestore profile" and sign the user out before
+  // the flow reaches the personal/account steps.
+  useEffect(() => {
+    setRegistrationInProgress();
+  }, []);
   const [otpCode, setOtpCode] = useState('');
   const [validationError, setValidationError] = useState<string | null>(null);
   const [isValid, setIsValid] = useState(false);
@@ -28,6 +41,7 @@ export default function OTPVerificationStep({
 
   const handleVerifyOTP = useCallback(async () => {
     if (!isValid || isVerifying || !otpCode || otpCode.length !== 6) return;
+    if (isSending) return;
     if (!confirmationResult) {
       setBackendError(TEXT_CONSTANTS.AUTH.OTP_INTERNAL_ERROR);
       return;
@@ -46,7 +60,7 @@ export default function OTPVerificationStep({
     } finally {
       setIsVerifying(false);
     }
-  }, [confirmationResult, otpCode, isValid, isVerifying, onVerifySuccess]);
+  }, [confirmationResult, otpCode, isValid, isVerifying, isSending, onVerifySuccess]);
 
   useEffect(() => {
     const validation = validateOTP(otpCode);
@@ -55,10 +69,10 @@ export default function OTPVerificationStep({
   }, [otpCode]);
 
   useEffect(() => {
-    if (isValid && otpCode.length === 6 && !hasAutoAttempted && !isVerifying) {
+    if (isValid && otpCode.length === 6 && !hasAutoAttempted && !isVerifying && !isSending) {
       handleVerifyOTP();
     }
-  }, [otpCode, isValid, hasAutoAttempted, isVerifying, handleVerifyOTP]);
+  }, [otpCode, isValid, hasAutoAttempted, isVerifying, isSending, handleVerifyOTP]);
 
   useEffect(() => {
     inputRef.current?.focus();
@@ -108,6 +122,28 @@ export default function OTPVerificationStep({
 
       <div className="px-6 pb-5">
         <div className="space-y-4">
+          {isSending && (
+            <div
+              className="flex items-center justify-center gap-2 text-sm text-neutral-600"
+              data-testid="otp-sending-indicator"
+            >
+              <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                <path className="opacity-75" fill="currentColor" d="m4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+              </svg>
+              {TEXT_CONSTANTS.REGISTRATION_COMPONENTS.SENDING_CODE}
+            </div>
+          )}
+
+          {sendError && !isSending && (
+            <p
+              className="text-sm text-danger-600 text-center px-1"
+              data-testid="otp-send-error-inline"
+            >
+              {sendError}
+            </p>
+          )}
+
           <div className="space-y-2">
             <div className="relative">
               <input
@@ -115,8 +151,10 @@ export default function OTPVerificationStep({
                 type="text"
                 value={otpCode}
                 onChange={handleInputChange}
+                disabled={isSending}
                 className={`w-full px-4 py-3.5 border-2 rounded-xl focus:ring-2 outline-none transition-all
-                         text-center tracking-widest text-neutral-800 bg-neutral-50 focus:bg-white placeholder-neutral-500 ${
+                         text-center tracking-widest text-neutral-800 bg-neutral-50 focus:bg-white placeholder-neutral-500
+                         disabled:bg-neutral-100 disabled:cursor-not-allowed ${
                   (validationError && otpCode) || backendError
                     ? 'border-danger-500 focus:border-danger-500 focus:ring-danger-500'
                     : 'border-neutral-200 focus:border-success-500 focus:ring-success-500'
@@ -157,11 +195,11 @@ export default function OTPVerificationStep({
           <button
             type="button"
             onClick={handleVerifyOTP}
-            disabled={!isValid || isVerifying}
+            disabled={!isValid || isVerifying || isSending}
             className={`w-full py-3 px-4 font-semibold rounded-xl btn-press focus-ring
                      flex items-center justify-center gap-2
                      transition-all duration-200 ${
-              isValid && !isVerifying
+              isValid && !isVerifying && !isSending
                 ? 'bg-gradient-to-r from-success-600 to-success-700 hover:from-success-700 hover:to-success-800 text-white hover:shadow-lg'
                 : 'bg-neutral-300 text-neutral-500 cursor-not-allowed'
             }`}
@@ -189,7 +227,7 @@ export default function OTPVerificationStep({
             <button
               type="button"
               onClick={handleResendCode}
-              disabled={isResending}
+              disabled={isResending || isSending}
               className="text-sm text-success-600 hover:text-success-800 disabled:text-neutral-400 disabled:cursor-not-allowed
                        transition-all duration-200 underline-offset-2 hover:underline focus-ring rounded-md"
             >

--- a/src/components/registration/PersonalDetailsStep.tsx
+++ b/src/components/registration/PersonalDetailsStep.tsx
@@ -134,9 +134,15 @@ export default function PersonalDetailsStep({
             )}
           </div>
 
-          {/* Gender + Birthdate side by side to keep the modal compact */}
+          {/* Gender + Birthdate side by side to keep the modal compact.
+              min-w-0 on each cell prevents <input type="date"> intrinsic
+              min-content from pushing past 1fr on narrow viewports.
+              Select uses `!` modifiers to defeat the components-layer
+              `input-base` px-4/rounded-xl so it matches the name inputs'
+              px-3/rounded-lg footprint exactly (project's cn() has no
+              tailwind-merge). */}
           <div className="grid grid-cols-2 gap-2">
-            <div className="space-y-1">
+            <div className="space-y-1 min-w-0">
               <Select
                 value={formData.gender || null}
                 onChange={(v) => handleInputChange('gender', v ?? '')}
@@ -148,7 +154,7 @@ export default function PersonalDetailsStep({
                 placeholder="בחר מין"
                 clearable
                 ariaLabel={TEXT_CONSTANTS.AUTH.GENDER}
-                className="px-3 py-2 rounded-lg text-sm"
+                className="!px-3 !py-2 !rounded-lg !text-sm"
               />
               {validationErrors.gender && formData.gender && (
                 <p className="text-xs text-danger-600 text-right px-1" data-testid="gender-error">
@@ -157,7 +163,7 @@ export default function PersonalDetailsStep({
               )}
             </div>
 
-            <div className="space-y-1">
+            <div className="space-y-1 min-w-0">
               <input
                 type="date"
                 value={formData.birthdate}

--- a/src/components/registration/RegistrationForm.tsx
+++ b/src/components/registration/RegistrationForm.tsx
@@ -30,9 +30,10 @@ interface RegistrationFormProps {
   onStepChange?: (step: 'personal-number' | 'otp' | 'personal' | 'account' | 'success') => void;
   currentStep: 'personal-number' | 'otp' | 'personal' | 'account' | 'success';
   onRegistrationSuccess?: () => void;
+  onSubmittingChange?: (submitting: boolean) => void;
 }
 
-export default function RegistrationForm({ personalNumber, setPersonalNumber, onSwitchToLogin, onStepChange, currentStep, onRegistrationSuccess }: RegistrationFormProps) {
+export default function RegistrationForm({ personalNumber, setPersonalNumber, onSwitchToLogin, onStepChange, currentStep, onRegistrationSuccess, onSubmittingChange }: RegistrationFormProps) {
   const [validationError, setValidationError] = useState<string | null>(null);
   const [isValid, setIsValid] = useState(false);
   const [isVerifying, setIsVerifying] = useState(false);
@@ -82,8 +83,19 @@ export default function RegistrationForm({ personalNumber, setPersonalNumber, on
   };
 
   const handleResendOtp = async () => {
-    const result = await sendOtpToPhone(userPhoneNumber);
-    setConfirmationResult(result);
+    setOtpSendError(null);
+    setConfirmationResult(null);
+    setIsSendingOTP(true);
+    try {
+      const result = await sendOtpToPhone(userPhoneNumber);
+      setConfirmationResult(result);
+    } catch (error) {
+      resetRecaptcha();
+      setOtpSendError(mapFirebaseAuthError(error));
+      throw error;
+    } finally {
+      setIsSendingOTP(false);
+    }
   };
 
   const handleVerifyPersonalNumber = async () => {
@@ -115,11 +127,17 @@ export default function RegistrationForm({ personalNumber, setPersonalNumber, on
       setUserFirstName(data.personnel.firstName);
       setUserLastName(data.personnel.lastName);
 
+      // Transition to the OTP screen IMMEDIATELY so the user sees the
+      // code-entry UI with a "sending..." indicator instead of waiting on
+      // the personal-number screen until the SMS request resolves.
+      setConfirmationResult(null);
+      setOtpSendError(null);
       setIsSendingOTP(true);
+      updateCurrentStep('otp');
+
       try {
         const confirmation = await sendOtpToPhone(data.personnel.phoneNumber);
         setConfirmationResult(confirmation);
-        updateCurrentStep('otp');
       } catch (error) {
         // Per Firebase docs, reset reCAPTCHA after a failed send so the next
         // attempt issues a fresh token instead of replaying a consumed one.
@@ -152,6 +170,7 @@ export default function RegistrationForm({ personalNumber, setPersonalNumber, on
     if (isSubmittingRegistration) return;
 
     setIsSubmittingRegistration(true);
+    onSubmittingChange?.(true);
     setAccountDetailsData(data);
     setValidationError(null);
 
@@ -165,7 +184,7 @@ export default function RegistrationForm({ personalNumber, setPersonalNumber, on
     try {
       const phoneAuthUser = auth.currentUser;
       if (!phoneAuthUser) {
-        setValidationError(TEXT_CONSTANTS.AUTH.OTP_INTERNAL_ERROR);
+        setValidationError(TEXT_CONSTANTS.AUTH.OTP_SESSION_EXPIRED);
         return;
       }
 
@@ -206,6 +225,7 @@ export default function RegistrationForm({ personalNumber, setPersonalNumber, on
       setValidationError(TEXT_CONSTANTS.REGISTRATION_COMPONENTS.CONNECTION_ERROR);
     } finally {
       setIsSubmittingRegistration(false);
+      onSubmittingChange?.(false);
     }
   };
 
@@ -221,6 +241,8 @@ export default function RegistrationForm({ personalNumber, setPersonalNumber, on
           confirmationResult={confirmationResult}
           onVerifySuccess={handleOTPVerifySuccess}
           onResendOtp={handleResendOtp}
+          isSending={isSendingOTP}
+          sendError={otpSendError}
         />
         <RecaptchaAttribution />
       </>

--- a/src/components/registration/RegistrationHeader.tsx
+++ b/src/components/registration/RegistrationHeader.tsx
@@ -3,32 +3,38 @@ import { TEXT_CONSTANTS } from '@/constants/text';
 interface RegistrationHeaderProps {
   onBack: () => void;
   onClose: () => void;
+  disabled?: boolean;
 }
 
-export default function RegistrationHeader({ onBack, onClose }: RegistrationHeaderProps) {
+export default function RegistrationHeader({ onBack, onClose, disabled = false }: RegistrationHeaderProps) {
+  const lockedClass = disabled ? 'opacity-50 cursor-not-allowed pointer-events-none' : '';
   return (
     <div className="px-6 pt-6 pb-4">
       <div className="flex items-center justify-between mb-4">
         {/* Close Button - Right Side */}
         <button
-          onClick={onClose}
-          className="p-2 hover:bg-neutral-100 rounded-full btn-press focus-ring
-                     text-neutral-400 hover:text-neutral-600 transition-all duration-200"
+          type="button"
+          onClick={disabled ? undefined : onClose}
+          disabled={disabled}
+          className={`p-2 hover:bg-neutral-100 rounded-full btn-press focus-ring
+                     text-neutral-400 hover:text-neutral-600 transition-all duration-200 ${lockedClass}`}
           aria-label={TEXT_CONSTANTS.ARIA_LABELS.CLOSE_MODAL}
         >
           <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
           </svg>
         </button>
-        
+
         {/* Title - Centered */}
         <h2 className="text-xl font-bold text-neutral-900">{TEXT_CONSTANTS.AUTH.REGISTER_TO_SYSTEM}</h2>
-        
+
         {/* Back Arrow - Left Side */}
         <button
-          onClick={onBack}
-          className="p-2 hover:bg-neutral-100 rounded-full btn-press focus-ring
-                     text-neutral-600 hover:text-neutral-800 transition-all duration-200"
+          type="button"
+          onClick={disabled ? undefined : onBack}
+          disabled={disabled}
+          className={`p-2 hover:bg-neutral-100 rounded-full btn-press focus-ring
+                     text-neutral-600 hover:text-neutral-800 transition-all duration-200 ${lockedClass}`}
           aria-label={TEXT_CONSTANTS.REGISTRATION_COMPONENTS.BACK_TO_LOGIN}
         >
           <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/src/components/registration/RegistrationModal.tsx
+++ b/src/components/registration/RegistrationModal.tsx
@@ -26,6 +26,7 @@ interface RegistrationModalProps {
 export default function RegistrationModal({ isOpen, onClose, onSwitch, onRegistrationSuccess }: RegistrationModalProps) {
   const [personalNumber, setPersonalNumber] = useState('');
   const [currentStep, setCurrentStep] = useState<RegistrationStep>('personal-number');
+  const [isSubmittingRegistration, setIsSubmittingRegistration] = useState(false);
   const registrationCompleteRef = useRef(false);
 
   // Cleanup orphan Firebase Auth user when the user abandons the flow.
@@ -86,6 +87,9 @@ export default function RegistrationModal({ isOpen, onClose, onSwitch, onRegistr
   if (!isOpen) return null;
 
   const handleClose = () => {
+    // Block close while account creation (linkEmailPassword + register API)
+    // is in flight — closing mid-link would leave a half-linked auth user.
+    if (isSubmittingRegistration) return;
     void cleanupOrphanAuthUser();
     setPersonalNumber('');
     setCurrentStep('personal-number');
@@ -93,6 +97,7 @@ export default function RegistrationModal({ isOpen, onClose, onSwitch, onRegistr
   };
 
   const handleSwitchToLogin = () => {
+    if (isSubmittingRegistration) return;
     void cleanupOrphanAuthUser();
     setPersonalNumber('');
     setCurrentStep('personal-number');
@@ -111,6 +116,7 @@ export default function RegistrationModal({ isOpen, onClose, onSwitch, onRegistr
 
   // Dynamic back navigation based on current step
   const handleBackNavigation = () => {
+    if (isSubmittingRegistration) return;
     switch (currentStep) {
       case 'personal-number':
         handleSwitchToLogin(); // Go to login
@@ -132,10 +138,12 @@ export default function RegistrationModal({ isOpen, onClose, onSwitch, onRegistr
 
   return (
     <>
-      {/* Backdrop - Blur Only */}
-      <div 
+      {/* Backdrop - Blur Only. Disable click-to-close while account is being
+          created so the user cannot abandon the linkEmailPassword + register
+          API call mid-flight. */}
+      <div
         className="fixed inset-0 z-50 backdrop-enter backdrop-blur-sm bg-black/20"
-        onClick={handleClose}
+        onClick={isSubmittingRegistration ? undefined : handleClose}
       />
       
       {/* reCAPTCHA host — kept at modal level so the DOM node persists across
@@ -152,6 +160,7 @@ export default function RegistrationModal({ isOpen, onClose, onSwitch, onRegistr
           <RegistrationHeader
             onBack={handleBackNavigation}
             onClose={handleClose}
+            disabled={isSubmittingRegistration}
           />
           
           {/* Progress Stepper */}
@@ -166,6 +175,7 @@ export default function RegistrationModal({ isOpen, onClose, onSwitch, onRegistr
             onStepChange={handleStepChange}
             currentStep={currentStep}
             onRegistrationSuccess={handleRegistrationComplete}
+            onSubmittingChange={setIsSubmittingRegistration}
           />
           
           <RegistrationFooter showRegistrationNote={currentStep === 'personal-number'} />

--- a/src/constants/text.ts
+++ b/src/constants/text.ts
@@ -85,6 +85,7 @@ export const TEXT_CONSTANTS = {
     INVALID_EMAIL: 'כתובת אימייל לא תקינה.',
     REQUIRES_RECENT_LOGIN: 'הפעולה דורשת התחברות מחדש. אנא התחבר ונסה שוב.',
     REGISTRATION_ABANDONED_FALLBACK: 'הרישום בוטל. ייתכן שיהיה צורך לפנות למנהל כדי להסיר את החשבון.',
+    OTP_SESSION_EXPIRED: 'תוקף אימות הטלפון פג. חזור לתחילת הרישום ונסה שוב.',
 
     // Email verification (soft)
     EMAIL_VERIFICATION_BANNER: 'אנא אמת את כתובת האימייל שלך כדי לאפשר איפוס סיסמה.',


### PR DESCRIPTION
…der during account creation

Three regressions surfaced by real-world OTP testing.

1) Race signing user out on OTP confirm.
   confirmation.confirm(code) fires onAuthStateChanged synchronously
   around its resolve, faster than the post-resolve callback chain that
   was setting registrationInProgress. AuthContext then saw "no profile,
   no flag" and signed the user out, so the account step's
   auth.currentUser was null and "Create Account" silently bailed.
   Fix: set the flag from a mount-time useEffect inside
   OTPVerificationStep, BEFORE any confirm can run. The post-resolve
   call in handleOTPVerifySuccess remains as an idempotent safety net.
   Also: replace the generic OTP_INTERNAL_ERROR fallback in the account
   step with a dedicated OTP_SESSION_EXPIRED message so the failure is
   visible if the race ever does bypass the mount-time set.

2) Sluggish verify -> OTP transition.
   handleVerifyPersonalNumber awaited sendOtpToPhone before changing
   step, so the user sat on the personal-number screen for ~1s and the
   SMS arrived before the UI moved. Now: transition to the OTP step
   immediately, set isSendingOTP, then await sendOtpToPhone.
   OTPVerificationStep accepts new isSending + sendError props and
   shows a "שולח קוד..." spinner row with the input + verify + resend
   buttons disabled until the verifier resolves. Resend follows the
   same pattern.

3) Lock header during account creation.
   While linkEmailPassword + sendEmailVerification + /api/auth/register
   are in flight, the user must not be able to abandon. RegistrationHeader
   accepts a disabled prop (disables Close + Back, opacity-50,
   pointer-events-none). Backdrop click is suppressed.
   handleClose / handleBackNavigation short-circuit defensively when
   isSubmittingRegistration is true. Form exposes its submitting state
   to the modal via onSubmittingChange.

Plus PersonalDetailsStep alignment: gender + birthdate row now matches the name rows. min-w-0 on grid cells prevents <input type="date"> intrinsic min-content from pushing past 1fr; Select className uses Tailwind ! modifiers to defeat the components-layer input-base px-4/rounded-xl since the project's cn() has no tailwind-merge.