### PR TITLE
fix(onboarding): center WelcomeModal on mobile and skip gate on /admin

### DIFF
--- a/docs/codebase/src/app/components/AppShell.md
+++ b/docs/codebase/src/app/components/AppShell.md
@@ -25,3 +25,7 @@ Replaces the per-page `Header` component that was removed. Pages opt in by wrapp
 - Content row: sidebar rail (lg+) on the start side + main content column.
 - Main column: `PageHeader` + scrollable `<main>` with `children`.
 - FAB is fixed bottom-end, visible only on `<lg`.
+
+## Onboarding gate
+
+Renders `WelcomeModal` when `enhancedUser` exists, has `firstName`+`lastName`, lacks `teamId`, and no registration flow is in flight. Suppressed on `/admin/*` so admins can reach System Config and populate the teams list — otherwise the bootstrap admin (no `teamId` yet) is locked out of the only place that defines teams.

--- a/docs/codebase/src/components/onboarding/WelcomeModal.md
+++ b/docs/codebase/src/components/onboarding/WelcomeModal.md
@@ -1,0 +1,27 @@
+# WelcomeModal.tsx
+
+**File:** `src/components/onboarding/WelcomeModal.tsx`
+**Status:** Active
+
+## Purpose
+
+Mandatory post-registration onboarding modal. Surfaces whenever an authenticated user has no `teamId` — a required field for team-scoped equipment queries. Cannot be dismissed; user must save a team to proceed.
+
+Rendered conditionally by `AppShell`. Suppressed on `/admin/*` so admins can populate the teams list in System Config.
+
+## Behavior
+
+- Reads available teams from `useSystemConfig()` (`admin_config/system_admin.teams`).
+- Lets the user upload a profile image (optional) and pick a team (required).
+- On save, calls `updateUserProfile(uid, { teamId, profileImage })` then `refreshEnhancedUser()`. Modal auto-unmounts once `teamId` is populated on `enhancedUser`.
+- Disables the team `<select>` and submit button while teams are loading or the teams list is empty.
+- Locks page scroll via `useScrollLock(true)` while mounted.
+
+## Layout
+
+- Wrapper uses `modal-overlay flex items-center justify-center p-4` so the dialog is centered on every viewport (the `modal-overlay` class itself is just the fixed full-screen backdrop — flex centering must be added at the call site, matching the convention used by `AnnouncementsWidget` and `MediaWidget`).
+- Card: `bg-white rounded-2xl shadow-2xl max-w-md w-full p-6 sm:p-8`.
+
+## Adding teams
+
+The modal does not expose a way to create teams. Teams are managed by admins at `/admin` → "⚙️ הגדרות מערכת" tab (`SystemConfigPanel`), which writes to `admin_config/system_admin.teams` via `PUT /api/system-config`.

--- a/src/app/components/AppShell.tsx
+++ b/src/app/components/AppShell.tsx
@@ -40,9 +40,12 @@ export default function AppShell({
   // Require core profile fields AND no in-flight registration — prevents the
   // welcome modal flashing for an orphan auth user mid-registration, or for a
   // previously-registered user re-confirming OTP through the registration flow.
+  // Skip on /admin so admins (incl. the bootstrap admin who has no teamId yet)
+  // can reach System Config and populate the teams list.
   const hasProfile = !!enhancedUser?.firstName && !!enhancedUser?.lastName;
+  const isAdminRoute = pathname?.startsWith('/admin') ?? false;
   const needsOnboarding =
-    !!enhancedUser && hasProfile && !enhancedUser.teamId && !isRegistrationInProgress();
+    !!enhancedUser && hasProfile && !enhancedUser.teamId && !isRegistrationInProgress() && !isAdminRoute;
 
   return (
     <div className="min-h-screen bg-neutral-50 flex flex-col overflow-x-hidden">

--- a/src/components/onboarding/WelcomeModal.tsx
+++ b/src/components/onboarding/WelcomeModal.tsx
@@ -59,8 +59,8 @@ export default function WelcomeModal() {
   };
 
   return (
-    <div className="modal-overlay">
-      <div className="bg-white rounded-2xl shadow-2xl max-w-md w-full mx-4 p-6 sm:p-8">
+    <div className="modal-overlay flex items-center justify-center p-4" role="dialog" aria-modal="true">
+      <div className="bg-white rounded-2xl shadow-2xl max-w-md w-full p-6 sm:p-8">
         <div className="flex justify-center mb-4">
           <ProfileImageUpload
             userId={enhancedUser.uid}


### PR DESCRIPTION
- WelcomeModal: add `flex items-center justify-center p-4` to the modal-overlay wrapper. The shared `.modal-overlay` class is only `fixed inset-0 ...` — flex centering must be added at the call site (matches AnnouncementsWidget / MediaWidget). Drop the now-redundant `mx-4` from the inner card. Fixes left-side cutoff on mobile in RTL.
- AppShell: suppress the onboarding gate on `/admin/*`. Admin route is already auth-gated by useAdminAuth, and the only place to populate the teams list is System Config under /admin — without this, a bootstrap admin with no teamId is locked out of the page that defines teams (chicken-and-egg).
- Docs: AppShell.md gains an "Onboarding gate" section; new WelcomeModal.md documents behavior, layout, and how teams are added.