### PR TITLE
docs: remove stale infra blocker claims (service-account key, rules d…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,9 +38,9 @@ Military equipment management system for Sayeret Givati. Hebrew RTL throughout (
 
 **Target (in progress on `feature/refactor_firestorereadAndWrite`):** Hybrid architecture — writes via `firebase-admin` Server Actions, reads via client SDK. Migration plan and step-by-step order in `docs/spec/firestore-refactor.md`.
 
-**Infra blocker:** Service account key points to wrong project (`sayeret-givati` vs `sayeret-givati-1983`). Admin SDK is non-functional until a new key is generated from Firebase console.
+Service account key targets `sayeret-givati-1983` (matches `NEXT_PUBLIC_FIREBASE_PROJECT_ID`). Admin SDK is functional.
 
-Firestore security rules are tightened locally but **not yet deployed** — run `firebase deploy --only firestore:rules` to activate them in production.
+Firestore security rules in `firebase/firestore.rules` are deployed and in sync with the production project — verify with `firebase deploy --only firestore:rules` (no-op if already in sync).
 
 ### Directory layout
 

--- a/docs/backlog/2026-q2.md
+++ b/docs/backlog/2026-q2.md
@@ -13,7 +13,7 @@ This document is the source of truth for the Q2 2026 product backlog. Tasks are 
 
 ## Out-of-band manual steps the user owns
 
-- **Service-account key.** Generate a working service-account key for the `sayeret-givati-1983` Firebase project. The current key targets the wrong project and blocks every `firebase-admin` task: 1.2, 2.3, 2.5, 3.1, 3.2, 3.4, 3.5, 3.6, 3.7.
+- ~~Service-account key.~~ Resolved 2026-04-29 — `GOOGLE_SERVICE_ACCOUNT_JSON` targets `sayeret-givati-1983`, matches client config. Tasks 1.2, 2.3, 2.5, 3.1, 3.2, 3.4, 3.5, 3.6, 3.7 are no longer blocked by this.
 - **Storage rules deploy.** After Task 1.2 merges: `firebase deploy --only storage`.
 - **Firestore rules deploy.** After any task that introduces a new collection (3.1, 3.2, 3.4, 3.5, 3.6, 3.7): `firebase deploy --only firestore:rules`.
 - **Branch lifecycle.** Per-task feature branches are cut from `main`, never from this tracking branch.

--- a/docs/spec/firebase-otp-migration.md
+++ b/docs/spec/firebase-otp-migration.md
@@ -83,7 +83,7 @@ Invisible reCAPTCHA v2, auto-provisioned by Firebase Phone Auth. Container div w
 2. Project → upgrade to Blaze plan if not already (Identity Platform requirement).
 3. Authentication → Settings → Authorized domains → add `localhost`, `*.vercel.app`, prod domain.
 4. Authentication → Phone → Phone numbers for testing → add a fixed test phone (e.g. `+972 50 123 4567` → `123456`) for local dev / CI.
-5. Resolve open infra blocker: regenerate `GOOGLE_SERVICE_ACCOUNT_JSON` for `sayeret-givati-1983` (the existing key targets the wrong project). The `/api/auth/check-email-verified` endpoint uses Admin SDK `getUserByEmail`.
+5. Service account key for `sayeret-givati-1983` is already in place; `/api/auth/check-email-verified` uses Admin SDK `getUserByEmail` and is functional.
 
 ## Verification
 

--- a/docs/spec/firestore-refactor.md
+++ b/docs/spec/firestore-refactor.md
@@ -42,7 +42,7 @@ Current client-side real-time listeners:
 ## Migration Order (step-by-step, no regressions)
 
 ### Step 0: Infrastructure — Wire up `firebase-admin`
-- **Blocker:** Service account key points to wrong project (`sayeret-givati` vs `sayeret-givati-1983`). Generate new key from Firebase console.
+- Service account key in `GOOGLE_SERVICE_ACCOUNT_JSON` targets `sayeret-givati-1983`, matches client config. Admin SDK functional.
 - Create `src/lib/db/admin.ts` — initialize admin app, export `adminDb`, `adminAuth`
 - Create `src/lib/db/core.ts` — generic typed helpers (`getDocById<T>`, `createDoc<T>`, `updateDoc<T>`) for both admin and client
 - Create `src/lib/db/collections.ts` — central collection name constants (consolidates scattered constants flagged in `docs/duplications.md`)


### PR DESCRIPTION
…eploy)

Service-account key in GOOGLE_SERVICE_ACCOUNT_JSON targets sayeret-givati-1983 matching NEXT_PUBLIC_FIREBASE_PROJECT_ID; firebase/firestore.rules deployed and in sync per console publish diff. Updates four files that still claimed both items as blockers.