### PR TITLE
feat(api): require Firebase ID token on every protected route

### DIFF
--- a/docs/codebase/src/lib/db/server/policyHelpers.md
+++ b/docs/codebase/src/lib/db/server/policyHelpers.md
@@ -1,21 +1,21 @@
 # db/server/policyHelpers.ts
 
 **File:** `src/lib/db/server/policyHelpers.ts`
-**Status:** Active (Phase 4)
+**Status:** Active
 
 ## Purpose
 
-Small glue module so API routes can run `equipmentPolicy` checks. Lifts a client-supplied `actor` payload into the `EnhancedAuthUser` shape the policy module expects, and fetches equipment docs by id.
+Small glue module so API routes can run `equipmentPolicy` checks against a verified server-side identity. The verified identity is built by `getActorFromRequest` in `auth.ts` from the bearer token, never from the request body.
 
 ## Exports
 
 | Export | Purpose |
 |--------|---------|
-| `ApiActor` | Interface: `{ uid, userType, teamId?, unitId?, displayName? }` |
-| `validateActor(unknown) => ApiActor` | Throws if missing `uid` / `userType`. |
-| `actorToAuthUser(actor) => EnhancedAuthUser` | Minimal conversion for policy calls. |
+| `ApiActor` | Interface: `{ uid, userType, grants?, teamId?, displayName? }` |
+| `actorToAuthUser(actor) => EnhancedAuthUser` | Lifts the server-trusted actor into the shape policy functions consume. |
 | `fetchEquipmentForPolicy(equipmentDocId) => Promise<Equipment>` | Admin-SDK read; throws `Equipment not found`. |
 
-## Known Gap
+## Notes
 
-- `actor.uid` / `actor.userType` come from the client body. Token verification via `firebase-admin/auth` is **not yet wired up** — tracked in `docs/spec/firestore-refactor.md` as part of the hybrid-architecture hardening.
+- `actor` fields are **server-trusted** — sourced from Firestore `users/<uid>` after `getAdminAuth().verifyIdToken()` succeeds. Body-supplied actors are no longer accepted.
+- `actor.grants` carries time-limited role-bump grants (currently always `[]`; the issuance UI ships in a follow-up PR).

--- a/docs/spec/equipment-flow.md
+++ b/docs/spec/equipment-flow.md
@@ -196,7 +196,7 @@ Notification routing lives in `NotificationItem.tsx`'s `resolveNotificationTarge
 | File | Status | Coverage |
 |------|--------|----------|
 | `src/lib/__tests__/equipmentPolicy.test.ts` | Phase 3 | 30 tests, full role × scope matrix |
-| `src/lib/__tests__/serverServices.test.ts` | Phase 8 | 9 tests — `validateActor`, `actorToAuthUser`, `serverForceOps` input validation |
+| `src/lib/__tests__/serverServices.test.ts` | Active | Tests — `getActorFromRequest` (bearer token verification), `actorToAuthUser`, `serverForceOps` input validation |
 | Server txn invariants (denormalized field sync, action-log writes, batch atomicity) | Deferred | Requires a true firebase-admin SDK fake. Tracked as a follow-up. |
 
 ---

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -167,6 +167,12 @@ service cloud.firestore {
       allow write: if false;
     }
 
+    // Permission grants — users see their own grants only; writes locked.
+    match /permissionGrants/{grantId} {
+      allow read: if request.auth != null && resource.data.userId == request.auth.uid;
+      allow write: if false;
+    }
+
     // Deny everything else
     match /{document=**} {
       allow read, write: if false;

--- a/src/app/api/actions-log/route.ts
+++ b/src/app/api/actions-log/route.ts
@@ -1,22 +1,27 @@
 import { NextResponse } from 'next/server';
 import { serverCreateActionLog } from '@/lib/db/server/actionsLogService';
+import { getActorOrError } from '@/lib/db/server/auth';
 
 /**
  * POST /api/actions-log
- * Creates an audit log entry via firebase-admin.
+ * Creates an audit log entry via firebase-admin. actorId always set from
+ * the verified bearer identity — body field is overridden to prevent forgery.
  */
 export async function POST(request: Request) {
   try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
+    const actor = actorOrError;
     const data = await request.json();
 
-    if (!data.actionType || !data.equipmentId || !data.actorId) {
+    if (!data.actionType || !data.equipmentId) {
       return NextResponse.json(
-        { success: false, error: 'Missing required fields: actionType, equipmentId, actorId' },
+        { success: false, error: 'Missing required fields: actionType, equipmentId' },
         { status: 400 }
       );
     }
 
-    const id = await serverCreateActionLog(data);
+    const id = await serverCreateActionLog({ ...data, actorId: actor.uid });
     return NextResponse.json({ success: true, id });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/src/app/api/ammunition-inventory/[id]/route.ts
+++ b/src/app/api/ammunition-inventory/[id]/route.ts
@@ -4,7 +4,7 @@ import {
   serverDeleteSerialItem,
   serverUpdateSerialItem,
 } from '@/lib/db/server/ammunitionInventoryService';
-import { validateActor } from '@/lib/db/server/policyHelpers';
+import { getActorOrError } from '@/lib/db/server/auth';
 import type { AmmunitionItemStatus, HolderType } from '@/types/ammunition';
 
 export async function PUT(
@@ -16,8 +16,10 @@ export async function PUT(
     if (!id) {
       return NextResponse.json({ success: false, error: 'id is required' }, { status: 400 });
     }
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
+    const actor = actorOrError;
     const input = await request.json();
-    const actor = validateActor(input.actor);
 
     if (input.kind !== 'item') {
       return NextResponse.json(
@@ -57,8 +59,10 @@ export async function DELETE(
     if (!id) {
       return NextResponse.json({ success: false, error: 'id is required' }, { status: 400 });
     }
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
+    const actor = actorOrError;
     const input = await request.json().catch(() => ({}));
-    const actor = validateActor(input.actor);
 
     if (input.kind === 'stock') {
       await serverDeleteAmmunitionStock({ actor, inventoryDocId: id });

--- a/src/app/api/ammunition-inventory/route.ts
+++ b/src/app/api/ammunition-inventory/route.ts
@@ -5,12 +5,14 @@ import {
   validateUpsertStockInput,
   validateCreateSerialItemInput,
 } from '@/lib/db/server/ammunitionInventoryService';
-import { validateActor } from '@/lib/db/server/policyHelpers';
+import { getActorOrError } from '@/lib/db/server/auth';
 
 export async function POST(request: Request) {
   try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
+    const actor = actorOrError;
     const input = await request.json();
-    const actor = validateActor(input.actor);
 
     if (input.kind === 'stock') {
       const payload = validateUpsertStockInput({ ...(input.payload || {}), actor });

--- a/src/app/api/ammunition-report-requests/route.ts
+++ b/src/app/api/ammunition-report-requests/route.ts
@@ -5,7 +5,7 @@ import {
   serverListAmmunitionReportRequests,
   validateCreateReportRequestInput,
 } from '@/lib/db/server/ammunitionReportRequestService';
-import { validateActor } from '@/lib/db/server/policyHelpers';
+import { getActorOrError } from '@/lib/db/server/auth';
 import { UserType } from '@/types/user';
 
 function isManagerOrTL(userType: UserType): boolean {
@@ -17,8 +17,10 @@ function isManagerOrTL(userType: UserType): boolean {
   );
 }
 
-export async function GET() {
+export async function GET(request: Request) {
   try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
     const requests = await serverListAmmunitionReportRequests();
     return NextResponse.json({ success: true, requests });
   } catch (error) {
@@ -30,8 +32,10 @@ export async function GET() {
 
 export async function POST(request: Request) {
   try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
+    const actor = actorOrError;
     const input = await request.json();
-    const actor = validateActor(input.actor);
     if (!isManagerOrTL(actor.userType)) {
       return NextResponse.json(
         { success: false, error: 'Forbidden: only manager+ or team_leader may create requests' },
@@ -55,8 +59,10 @@ export async function POST(request: Request) {
 
 export async function PATCH(request: Request) {
   try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
+    const actor = actorOrError;
     const input = await request.json();
-    const actor = validateActor(input.actor);
     if (!isManagerOrTL(actor.userType)) {
       return NextResponse.json(
         { success: false, error: 'Forbidden: only manager+ or team_leader may cancel requests' },

--- a/src/app/api/ammunition-reports/route.ts
+++ b/src/app/api/ammunition-reports/route.ts
@@ -4,10 +4,12 @@ import {
   serverListAmmunitionReports,
   validateSubmitReportInput,
 } from '@/lib/db/server/ammunitionReportsService';
-import { validateActor } from '@/lib/db/server/policyHelpers';
+import { getActorOrError } from '@/lib/db/server/auth';
 
 export async function GET(request: Request) {
   try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
     const url = new URL(request.url);
     const fromMs = url.searchParams.get('fromMs');
     const toMs = url.searchParams.get('toMs');
@@ -34,8 +36,10 @@ export async function GET(request: Request) {
 
 export async function POST(request: Request) {
   try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
+    const actor = actorOrError;
     const input = await request.json();
-    const actor = validateActor(input.actor);
     const payload = validateSubmitReportInput({ ...(input.payload || {}), actor });
     const result = await serverSubmitAmmunitionReport(payload);
     return NextResponse.json({

--- a/src/app/api/ammunition-templates/[id]/route.ts
+++ b/src/app/api/ammunition-templates/[id]/route.ts
@@ -4,7 +4,7 @@ import {
   serverUpdateAmmunitionTemplate,
   validateAmmunitionTemplateInput,
 } from '@/lib/db/server/ammunitionTemplatesService';
-import { validateActor } from '@/lib/db/server/policyHelpers';
+import { getActorOrError } from '@/lib/db/server/auth';
 import { UserType } from '@/types/user';
 
 function isAdminOrManager(userType: UserType): boolean {
@@ -24,8 +24,10 @@ export async function PUT(
     if (!id) {
       return NextResponse.json({ success: false, error: 'id is required' }, { status: 400 });
     }
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
+    const actor = actorOrError;
     const input = await request.json();
-    const actor = validateActor(input.actor);
 
     if (!isAdminOrManager(actor.userType)) {
       return NextResponse.json(
@@ -57,8 +59,9 @@ export async function DELETE(
     if (!id) {
       return NextResponse.json({ success: false, error: 'id is required' }, { status: 400 });
     }
-    const input = await request.json().catch(() => ({}));
-    const actor = validateActor(input.actor);
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
+    const actor = actorOrError;
 
     if (!isAdminOrManager(actor.userType)) {
       return NextResponse.json(

--- a/src/app/api/ammunition-templates/route.ts
+++ b/src/app/api/ammunition-templates/route.ts
@@ -5,7 +5,7 @@ import {
   serverSeedCanonicalAmmunitionTemplates,
   validateAmmunitionTemplateInput,
 } from '@/lib/db/server/ammunitionTemplatesService';
-import { validateActor } from '@/lib/db/server/policyHelpers';
+import { getActorOrError } from '@/lib/db/server/auth';
 import { UserType } from '@/types/user';
 
 function isAdminOrManager(userType: UserType): boolean {
@@ -16,8 +16,10 @@ function isAdminOrManager(userType: UserType): boolean {
   );
 }
 
-export async function GET() {
+export async function GET(request: Request) {
   try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
     const templates = await serverListAmmunitionTemplates();
     return NextResponse.json({ success: true, templates });
   } catch (error) {
@@ -29,8 +31,10 @@ export async function GET() {
 
 export async function POST(request: Request) {
   try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
+    const actor = actorOrError;
     const input = await request.json();
-    const actor = validateActor(input.actor);
 
     if (input.action === 'seed_canonical') {
       if (!isAdminOrManager(actor.userType)) {

--- a/src/app/api/authorized-personnel/bulk/route.ts
+++ b/src/app/api/authorized-personnel/bulk/route.ts
@@ -1,8 +1,16 @@
 import { NextResponse } from 'next/server';
 import { serverBulkAddPersonnel } from '@/lib/db/server/authorizedPersonnelService';
+import { getActorOrError } from '@/lib/db/server/auth';
+import { UserType } from '@/types/user';
 
 export async function POST(request: Request) {
   try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
+    const actor = actorOrError;
+    if (actor.userType !== UserType.ADMIN && actor.userType !== UserType.SYSTEM_MANAGER) {
+      return NextResponse.json({ success: false, error: 'Forbidden: admin/system_manager only' }, { status: 403 });
+    }
     const { entries } = await request.json();
     if (!entries || !Array.isArray(entries)) {
       return NextResponse.json({ success: false, error: 'entries array is required' }, { status: 400 });

--- a/src/app/api/authorized-personnel/route.ts
+++ b/src/app/api/authorized-personnel/route.ts
@@ -5,9 +5,21 @@ import {
   serverSyncPersonnelToUser,
   serverDeletePersonnel,
 } from '@/lib/db/server/authorizedPersonnelService';
+import { getActorOrError } from '@/lib/db/server/auth';
+import { UserType } from '@/types/user';
+
+function isPersonnelAdmin(userType: UserType): boolean {
+  return userType === UserType.ADMIN || userType === UserType.SYSTEM_MANAGER;
+}
 
 export async function POST(request: Request) {
   try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
+    const actor = actorOrError;
+    if (!isPersonnelAdmin(actor.userType)) {
+      return NextResponse.json({ success: false, error: 'Forbidden: admin/system_manager only' }, { status: 403 });
+    }
     const { docId, data } = await request.json();
     if (!docId || !data) {
       return NextResponse.json({ success: false, error: 'docId and data are required' }, { status: 400 });
@@ -23,6 +35,12 @@ export async function POST(request: Request) {
 
 export async function PUT(request: Request) {
   try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
+    const actor = actorOrError;
+    if (!isPersonnelAdmin(actor.userType)) {
+      return NextResponse.json({ success: false, error: 'Forbidden: admin/system_manager only' }, { status: 403 });
+    }
     const { personnelId, updates, syncToUser, militaryIdHash } = await request.json();
     if (!personnelId || !updates) {
       return NextResponse.json({ success: false, error: 'personnelId and updates are required' }, { status: 400 });
@@ -44,6 +62,12 @@ export async function PUT(request: Request) {
 
 export async function DELETE(request: Request) {
   try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
+    const actor = actorOrError;
+    if (!isPersonnelAdmin(actor.userType)) {
+      return NextResponse.json({ success: false, error: 'Forbidden: admin/system_manager only' }, { status: 403 });
+    }
     const { id } = await request.json();
     if (!id) {
       return NextResponse.json({ success: false, error: 'Personnel id is required' }, { status: 400 });

--- a/src/app/api/categories/route.ts
+++ b/src/app/api/categories/route.ts
@@ -4,9 +4,12 @@ import {
   serverUpdateCategory,
   serverDeactivateCategory,
 } from '@/lib/db/server/categoriesService';
+import { getActorOrError } from '@/lib/db/server/auth';
 
 export async function POST(request: Request) {
   try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
     const data = await request.json();
     if (!data.name) {
       return NextResponse.json({ success: false, error: 'Category name is required' }, { status: 400 });
@@ -22,6 +25,8 @@ export async function POST(request: Request) {
 
 export async function PUT(request: Request) {
   try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
     const { id, ...updates } = await request.json();
     if (!id) {
       return NextResponse.json({ success: false, error: 'Category id is required' }, { status: 400 });
@@ -37,6 +42,8 @@ export async function PUT(request: Request) {
 
 export async function DELETE(request: Request) {
   try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
     const { id } = await request.json();
     if (!id) {
       return NextResponse.json({ success: false, error: 'Category id is required' }, { status: 400 });

--- a/src/app/api/categories/subcategories/route.ts
+++ b/src/app/api/categories/subcategories/route.ts
@@ -4,9 +4,12 @@ import {
   serverUpdateSubcategory,
   serverDeactivateSubcategory,
 } from '@/lib/db/server/categoriesService';
+import { getActorOrError } from '@/lib/db/server/auth';
 
 export async function POST(request: Request) {
   try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
     const data = await request.json();
     if (!data.name || !data.parentCategoryId) {
       return NextResponse.json(
@@ -25,6 +28,8 @@ export async function POST(request: Request) {
 
 export async function PUT(request: Request) {
   try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
     const { id, ...updates } = await request.json();
     if (!id) {
       return NextResponse.json({ success: false, error: 'Subcategory id is required' }, { status: 400 });
@@ -40,6 +45,8 @@ export async function PUT(request: Request) {
 
 export async function DELETE(request: Request) {
   try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
     const { id } = await request.json();
     if (!id) {
       return NextResponse.json({ success: false, error: 'Subcategory id is required' }, { status: 400 });

--- a/src/app/api/equipment-drafts/route.ts
+++ b/src/app/api/equipment-drafts/route.ts
@@ -4,14 +4,16 @@ import {
   serverUpdateEquipmentDraft,
   serverDeleteEquipmentDraft,
 } from '@/lib/db/server/equipmentDraftService';
+import { getActorOrError } from '@/lib/db/server/auth';
 
 export async function POST(request: Request) {
   try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
+    const actor = actorOrError;
     const input = await request.json();
-    if (!input.userId) {
-      return NextResponse.json({ success: false, error: 'userId is required' }, { status: 400 });
-    }
-    const result = await serverCreateEquipmentDraft(input);
+    // userId always taken from the verified actor — drafts are owned by the caller.
+    const result = await serverCreateEquipmentDraft({ ...input, userId: actor.uid });
     return NextResponse.json({ success: true, id: result.id });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -22,6 +24,8 @@ export async function POST(request: Request) {
 
 export async function PUT(request: Request) {
   try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
     const input = await request.json();
     if (!input.draftId) {
       return NextResponse.json({ success: false, error: 'draftId is required' }, { status: 400 });
@@ -37,6 +41,8 @@ export async function PUT(request: Request) {
 
 export async function DELETE(request: Request) {
   try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
     const input = await request.json();
     if (!input.draftId) {
       return NextResponse.json({ success: false, error: 'draftId is required' }, { status: 400 });

--- a/src/app/api/equipment-templates/approve/route.ts
+++ b/src/app/api/equipment-templates/approve/route.ts
@@ -1,15 +1,18 @@
 import { NextResponse } from 'next/server';
 import { serverApproveTemplateRequest } from '@/lib/db/server/templateRequestService';
-import { validateActor, actorToAuthUser } from '@/lib/db/server/policyHelpers';
+import { actorToAuthUser } from '@/lib/db/server/policyHelpers';
+import { getActorOrError } from '@/lib/db/server/auth';
 import { canReviewTemplate } from '@/lib/equipmentPolicy';
 
 export async function POST(request: Request) {
   try {
-    const input = await request.json();
-    const actor = validateActor(input.actor);
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
+    const actor = actorOrError;
     if (!canReviewTemplate(actorToAuthUser(actor))) {
       return NextResponse.json({ success: false, error: 'Forbidden — manager+ only' }, { status: 403 });
     }
+    const input = await request.json();
     if (!input.templateId) {
       return NextResponse.json({ success: false, error: 'templateId is required' }, { status: 400 });
     }

--- a/src/app/api/equipment-templates/propose/route.ts
+++ b/src/app/api/equipment-templates/propose/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { serverProposeTemplate } from '@/lib/db/server/templateRequestService';
-import { validateActor, actorToAuthUser } from '@/lib/db/server/policyHelpers';
+import { actorToAuthUser } from '@/lib/db/server/policyHelpers';
+import { getActorOrError } from '@/lib/db/server/auth';
 import {
   canProposeTemplate,
   canRequestTemplate,
@@ -9,9 +10,11 @@ import { UserType } from '@/types/user';
 
 export async function POST(request: Request) {
   try {
-    const input = await request.json();
-    const actor = validateActor(input.actor);
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
+    const actor = actorOrError;
     const authUser = actorToAuthUser(actor);
+    const input = await request.json();
 
     // Regular users go through request flow; TL+ go through proposal flow.
     const allowed =

--- a/src/app/api/equipment-templates/reject/route.ts
+++ b/src/app/api/equipment-templates/reject/route.ts
@@ -1,15 +1,18 @@
 import { NextResponse } from 'next/server';
 import { serverRejectTemplateRequest } from '@/lib/db/server/templateRequestService';
-import { validateActor, actorToAuthUser } from '@/lib/db/server/policyHelpers';
+import { actorToAuthUser } from '@/lib/db/server/policyHelpers';
+import { getActorOrError } from '@/lib/db/server/auth';
 import { canReviewTemplate } from '@/lib/equipmentPolicy';
 
 export async function POST(request: Request) {
   try {
-    const input = await request.json();
-    const actor = validateActor(input.actor);
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
+    const actor = actorOrError;
     if (!canReviewTemplate(actorToAuthUser(actor))) {
       return NextResponse.json({ success: false, error: 'Forbidden — manager+ only' }, { status: 403 });
     }
+    const input = await request.json();
     if (!input.templateId) {
       return NextResponse.json({ success: false, error: 'templateId is required' }, { status: 400 });
     }

--- a/src/app/api/equipment-templates/route.ts
+++ b/src/app/api/equipment-templates/route.ts
@@ -3,9 +3,12 @@ import {
   serverCreateEquipmentType,
   serverUpdateEquipmentType,
 } from '@/lib/db/server/equipmentTemplatesService';
+import { getActorOrError } from '@/lib/db/server/auth';
 
 export async function POST(request: Request) {
   try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
     const data = await request.json();
     if (!data.name || !data.category || !data.subcategory) {
       return NextResponse.json(
@@ -24,6 +27,8 @@ export async function POST(request: Request) {
 
 export async function PUT(request: Request) {
   try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
     const { id, ...updates } = await request.json();
     if (!id) {
       return NextResponse.json({ success: false, error: 'Template id is required' }, { status: 400 });

--- a/src/app/api/equipment/batch/route.ts
+++ b/src/app/api/equipment/batch/route.ts
@@ -1,15 +1,18 @@
 import { NextResponse } from 'next/server';
 import { serverCreateEquipmentBatch } from '@/lib/db/server/equipmentService';
-import { validateActor, actorToAuthUser } from '@/lib/db/server/policyHelpers';
+import { actorToAuthUser } from '@/lib/db/server/policyHelpers';
+import { getActorOrError } from '@/lib/db/server/auth';
 import { canAddEquipment } from '@/lib/equipmentPolicy';
 
 export async function POST(request: Request) {
   try {
-    const input = await request.json();
-    const actor = validateActor(input.actor);
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
+    const actor = actorOrError;
     if (!canAddEquipment(actorToAuthUser(actor))) {
       return NextResponse.json({ success: false, error: 'Forbidden' }, { status: 403 });
     }
+    const input = await request.json();
 
     if (!Array.isArray(input.items) || input.items.length === 0) {
       return NextResponse.json(

--- a/src/app/api/equipment/report/route.ts
+++ b/src/app/api/equipment/report/route.ts
@@ -1,16 +1,18 @@
 import { NextResponse } from 'next/server';
 import { serverReportEquipment } from '@/lib/db/server/equipmentService';
 import {
-  validateActor,
   actorToAuthUser,
   fetchEquipmentForPolicy,
 } from '@/lib/db/server/policyHelpers';
+import { getActorOrError } from '@/lib/db/server/auth';
 import { canReport, canReportWithoutPhoto } from '@/lib/equipmentPolicy';
 
 export async function POST(request: Request) {
   try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
+    const actor = actorOrError;
     const input = await request.json();
-    const actor = validateActor(input.actor);
 
     if (!input.equipmentId) {
       return NextResponse.json({ success: false, error: 'equipmentId is required' }, { status: 400 });

--- a/src/app/api/equipment/retire/route.ts
+++ b/src/app/api/equipment/retire/route.ts
@@ -1,16 +1,18 @@
 import { NextResponse } from 'next/server';
 import { serverRetireEquipment } from '@/lib/db/server/equipmentService';
 import {
-  validateActor,
   actorToAuthUser,
   fetchEquipmentForPolicy,
 } from '@/lib/db/server/policyHelpers';
+import { getActorOrError } from '@/lib/db/server/auth';
 import { canRetire } from '@/lib/equipmentPolicy';
 
 export async function POST(request: Request) {
   try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
+    const actor = actorOrError;
     const input = await request.json();
-    const actor = validateActor(input.actor);
 
     if (!input.equipmentId) {
       return NextResponse.json({ success: false, error: 'equipmentId is required' }, { status: 400 });

--- a/src/app/api/equipment/route.ts
+++ b/src/app/api/equipment/route.ts
@@ -1,8 +1,11 @@
 import { NextResponse } from 'next/server';
 import { serverCreateEquipment, serverUpdateEquipment } from '@/lib/db/server/equipmentService';
+import { getActorOrError } from '@/lib/db/server/auth';
 
 export async function POST(request: Request) {
   try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
     const input = await request.json();
     if (!input.equipmentData?.id) {
       return NextResponse.json({ success: false, error: 'equipmentData.id is required' }, { status: 400 });
@@ -18,6 +21,8 @@ export async function POST(request: Request) {
 
 export async function PUT(request: Request) {
   try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
     const input = await request.json();
     if (!input.equipmentId) {
       return NextResponse.json({ success: false, error: 'equipmentId is required' }, { status: 400 });

--- a/src/app/api/equipment/transfer/route.ts
+++ b/src/app/api/equipment/transfer/route.ts
@@ -1,8 +1,11 @@
 import { NextResponse } from 'next/server';
 import { serverTransferEquipment } from '@/lib/db/server/equipmentService';
+import { getActorOrError } from '@/lib/db/server/auth';
 
 export async function POST(request: Request) {
   try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
     const input = await request.json();
     if (!input.equipmentId || !input.newHolder || !input.newHolderId) {
       return NextResponse.json(

--- a/src/app/api/force-ops/route.ts
+++ b/src/app/api/force-ops/route.ts
@@ -1,17 +1,19 @@
 import { NextResponse } from 'next/server';
 import { serverForceOps } from '@/lib/db/server/forceOpsService';
 import {
-  validateActor,
   actorToAuthUser,
   fetchEquipmentForPolicy,
 } from '@/lib/db/server/policyHelpers';
+import { getActorOrError } from '@/lib/db/server/auth';
 import { canForceTransfer } from '@/lib/equipmentPolicy';
 
 export async function POST(request: Request) {
   try {
-    const input = await request.json();
-    const actor = validateActor(input.actor);
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
+    const actor = actorOrError;
     const authUser = actorToAuthUser(actor);
+    const input = await request.json();
 
     if (!Array.isArray(input.equipmentDocIds) || input.equipmentDocIds.length === 0) {
       return NextResponse.json(

--- a/src/app/api/notifications/read/route.ts
+++ b/src/app/api/notifications/read/route.ts
@@ -3,12 +3,15 @@ import {
   serverMarkAsRead,
   serverMarkAllAsRead,
 } from '@/lib/db/server/notificationService';
+import { getActorOrError } from '@/lib/db/server/auth';
 
 /**
  * PUT — Mark single notification as read
  */
 export async function PUT(request: Request) {
   try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
     const { notificationId } = await request.json();
     if (!notificationId) {
       return NextResponse.json({ success: false, error: 'notificationId is required' }, { status: 400 });
@@ -23,15 +26,14 @@ export async function PUT(request: Request) {
 }
 
 /**
- * POST — Mark all notifications as read for a user
+ * POST — Mark all notifications as read for the authenticated user.
  */
 export async function POST(request: Request) {
   try {
-    const { userId } = await request.json();
-    if (!userId) {
-      return NextResponse.json({ success: false, error: 'userId is required' }, { status: 400 });
-    }
-    await serverMarkAllAsRead(userId);
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
+    const actor = actorOrError;
+    await serverMarkAllAsRead(actor.uid);
     return NextResponse.json({ success: true });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -3,9 +3,12 @@ import {
   serverCreateNotification,
   serverDeleteNotification,
 } from '@/lib/db/server/notificationService';
+import { getActorOrError } from '@/lib/db/server/auth';
 
 export async function POST(request: Request) {
   try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
     const data = await request.json();
     if (!data.userId || !data.type || !data.title || !data.message) {
       return NextResponse.json(
@@ -24,6 +27,8 @@ export async function POST(request: Request) {
 
 export async function DELETE(request: Request) {
   try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
     const { id } = await request.json();
     if (!id) {
       return NextResponse.json({ success: false, error: 'Notification id is required' }, { status: 400 });

--- a/src/app/api/report-requests/fulfill/route.ts
+++ b/src/app/api/report-requests/fulfill/route.ts
@@ -1,19 +1,23 @@
 import { NextResponse } from 'next/server';
 import { serverFulfillReportRequest } from '@/lib/db/server/reportRequestService';
+import { getActorOrError } from '@/lib/db/server/auth';
 
 export async function POST(request: Request) {
   try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
+    const actor = actorOrError;
     const input = await request.json();
-    if (!input.requestId || !input.userId) {
+    if (!input.requestId) {
       return NextResponse.json(
-        { success: false, error: 'requestId and userId are required' },
+        { success: false, error: 'requestId is required' },
         { status: 400 }
       );
     }
-    // Server verifies userId is a target of the request.
+    // userId always taken from the verified actor — server verifies actor is a target of the request.
     await serverFulfillReportRequest({
       requestId: input.requestId,
-      userId: input.userId,
+      userId: actor.uid,
     });
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/src/app/api/report-requests/route.ts
+++ b/src/app/api/report-requests/route.ts
@@ -1,12 +1,15 @@
 import { NextResponse } from 'next/server';
 import { serverCreateReportRequest } from '@/lib/db/server/reportRequestService';
-import { validateActor, actorToAuthUser } from '@/lib/db/server/policyHelpers';
+import { actorToAuthUser } from '@/lib/db/server/policyHelpers';
+import { getActorOrError } from '@/lib/db/server/auth';
 import { isManagerOrAbove } from '@/lib/equipmentPolicy';
 
 export async function POST(request: Request) {
   try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
+    const actor = actorOrError;
     const input = await request.json();
-    const actor = validateActor(input.actor);
 
     // Only managers/admins can create report requests.
     if (!isManagerOrAbove(actorToAuthUser(actor))) {

--- a/src/app/api/retirement-requests/approve/route.ts
+++ b/src/app/api/retirement-requests/approve/route.ts
@@ -1,20 +1,24 @@
 import { NextResponse } from 'next/server';
 import { serverApproveRetirementRequest } from '@/lib/db/server/retirementRequestService';
+import { getActorOrError } from '@/lib/db/server/auth';
 
 export async function POST(request: Request) {
   try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
+    const actor = actorOrError;
     const input = await request.json();
-    if (!input.requestId || !input.approverUserId || !input.approverUserName) {
+    if (!input.requestId) {
       return NextResponse.json(
-        { success: false, error: 'requestId, approverUserId, and approverUserName are required' },
+        { success: false, error: 'requestId is required' },
         { status: 400 }
       );
     }
     // Server enforces approver == request.holderUserId — no separate policy check.
     await serverApproveRetirementRequest({
       requestId: input.requestId,
-      approverUserId: input.approverUserId,
-      approverUserName: input.approverUserName,
+      approverUserId: actor.uid,
+      approverUserName: input.approverUserName || actor.displayName || actor.uid,
       ...(input.note ? { note: input.note } : {}),
     });
     return NextResponse.json({ success: true });

--- a/src/app/api/retirement-requests/reject/route.ts
+++ b/src/app/api/retirement-requests/reject/route.ts
@@ -1,19 +1,23 @@
 import { NextResponse } from 'next/server';
 import { serverRejectRetirementRequest } from '@/lib/db/server/retirementRequestService';
+import { getActorOrError } from '@/lib/db/server/auth';
 
 export async function POST(request: Request) {
   try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
+    const actor = actorOrError;
     const input = await request.json();
-    if (!input.requestId || !input.rejectorUserId || !input.rejectorUserName) {
+    if (!input.requestId) {
       return NextResponse.json(
-        { success: false, error: 'requestId, rejectorUserId, and rejectorUserName are required' },
+        { success: false, error: 'requestId is required' },
         { status: 400 }
       );
     }
     await serverRejectRetirementRequest({
       requestId: input.requestId,
-      rejectorUserId: input.rejectorUserId,
-      rejectorUserName: input.rejectorUserName,
+      rejectorUserId: actor.uid,
+      rejectorUserName: input.rejectorUserName || actor.displayName || actor.uid,
       ...(input.reason ? { reason: input.reason } : {}),
     });
     return NextResponse.json({ success: true });

--- a/src/app/api/system-config/route.ts
+++ b/src/app/api/system-config/route.ts
@@ -4,15 +4,17 @@ import {
   serverUpdateSystemConfig,
   validateSystemConfigPayload,
 } from '@/lib/db/server/systemConfigService';
-import { validateActor } from '@/lib/db/server/policyHelpers';
+import { getActorOrError } from '@/lib/db/server/auth';
 import { UserType } from '@/types/user';
 
 function isSystemAdmin(userType: UserType): boolean {
   return userType === UserType.ADMIN || userType === UserType.SYSTEM_MANAGER;
 }
 
-export async function GET() {
+export async function GET(request: Request) {
   try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
     const config = await serverGetSystemConfig();
     return NextResponse.json({ success: true, config });
   } catch (error) {
@@ -24,8 +26,10 @@ export async function GET() {
 
 export async function PUT(request: Request) {
   try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
+    const actor = actorOrError;
     const input = await request.json();
-    const actor = validateActor(input.actor);
 
     if (!isSystemAdmin(actor.userType)) {
       return NextResponse.json(

--- a/src/app/api/transfer-requests/approve/route.ts
+++ b/src/app/api/transfer-requests/approve/route.ts
@@ -1,16 +1,24 @@
 import { NextResponse } from 'next/server';
 import { serverApproveTransferRequest } from '@/lib/db/server/transferRequestService';
+import { getActorOrError } from '@/lib/db/server/auth';
 
 export async function POST(request: Request) {
   try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
+    const actor = actorOrError;
     const input = await request.json();
-    if (!input.transferRequestId || !input.approverUserId || !input.approverUserName) {
+    if (!input.transferRequestId) {
       return NextResponse.json(
-        { success: false, error: 'transferRequestId, approverUserId, and approverUserName are required' },
+        { success: false, error: 'transferRequestId is required' },
         { status: 400 }
       );
     }
-    await serverApproveTransferRequest(input);
+    await serverApproveTransferRequest({
+      ...input,
+      approverUserId: actor.uid,
+      approverUserName: input.approverUserName || actor.displayName || actor.uid,
+    });
     return NextResponse.json({ success: true });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/src/app/api/transfer-requests/reject/route.ts
+++ b/src/app/api/transfer-requests/reject/route.ts
@@ -1,16 +1,24 @@
 import { NextResponse } from 'next/server';
 import { serverRejectTransferRequest } from '@/lib/db/server/transferRequestService';
+import { getActorOrError } from '@/lib/db/server/auth';
 
 export async function POST(request: Request) {
   try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
+    const actor = actorOrError;
     const input = await request.json();
-    if (!input.transferRequestId || !input.rejectorUserId || !input.rejectorUserName) {
+    if (!input.transferRequestId) {
       return NextResponse.json(
-        { success: false, error: 'transferRequestId, rejectorUserId, and rejectorUserName are required' },
+        { success: false, error: 'transferRequestId is required' },
         { status: 400 }
       );
     }
-    await serverRejectTransferRequest(input);
+    await serverRejectTransferRequest({
+      ...input,
+      rejectorUserId: actor.uid,
+      rejectorUserName: input.rejectorUserName || actor.displayName || actor.uid,
+    });
     return NextResponse.json({ success: true });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/src/app/api/transfer-requests/route.ts
+++ b/src/app/api/transfer-requests/route.ts
@@ -1,16 +1,26 @@
 import { NextResponse } from 'next/server';
 import { serverCreateTransferRequest } from '@/lib/db/server/transferRequestService';
+import { getActorOrError } from '@/lib/db/server/auth';
 
 export async function POST(request: Request) {
   try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
+    const actor = actorOrError;
     const input = await request.json();
-    if (!input.equipmentDocId || !input.toUserId || !input.fromUserId) {
+    if (!input.equipmentDocId || !input.toUserId) {
       return NextResponse.json(
-        { success: false, error: 'equipmentDocId, toUserId, and fromUserId are required' },
+        { success: false, error: 'equipmentDocId and toUserId are required' },
         { status: 400 }
       );
     }
-    const id = await serverCreateTransferRequest(input);
+    if (input.fromUserId && input.fromUserId !== actor.uid) {
+      return NextResponse.json(
+        { success: false, error: 'fromUserId must match the authenticated user' },
+        { status: 403 }
+      );
+    }
+    const id = await serverCreateTransferRequest({ ...input, fromUserId: actor.uid });
     return NextResponse.json({ success: true, id });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/src/app/api/users/profile/route.ts
+++ b/src/app/api/users/profile/route.ts
@@ -1,23 +1,34 @@
 import { NextResponse } from 'next/server';
 import { serverUpdateUserProfile } from '@/lib/db/server/userService';
+import { getActorOrError } from '@/lib/db/server/auth';
+import { UserType } from '@/types/user';
 
 /**
  * PATCH /api/users/profile
  * Body: { uid: string, updates: { teamId?, profileImage?, phoneNumber? } }
  *
- * Only whitelisted keys are accepted server-side; the caller's uid must match
- * the authenticated user (caller-side responsibility — we rely on the client
- * sending its own uid for now, matching the pattern of other API routes until
- * auth-bearer middleware lands).
+ * Caller must be authenticated (bearer token). Only the user themselves, or
+ * an ADMIN / SYSTEM_MANAGER, may update a profile.
  */
 export async function PATCH(request: Request) {
   try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
+    const actor = actorOrError;
     const body = await request.json();
     if (!body?.uid || typeof body.uid !== 'string') {
       return NextResponse.json({ success: false, error: 'uid is required' }, { status: 400 });
     }
     if (!body?.updates || typeof body.updates !== 'object') {
       return NextResponse.json({ success: false, error: 'updates object is required' }, { status: 400 });
+    }
+    const isElevated =
+      actor.userType === UserType.ADMIN || actor.userType === UserType.SYSTEM_MANAGER;
+    if (body.uid !== actor.uid && !isElevated) {
+      return NextResponse.json(
+        { success: false, error: 'Forbidden: cannot edit another user\'s profile' },
+        { status: 403 }
+      );
     }
     await serverUpdateUserProfile(body.uid, body.updates);
     return NextResponse.json({ success: true });

--- a/src/components/equipment/AddEquipmentWizard.tsx
+++ b/src/components/equipment/AddEquipmentWizard.tsx
@@ -170,21 +170,16 @@ export default function AddEquipmentWizard({
         });
       }
 
-      const actor = {
-        uid: user.uid,
-        userType: user.userType!,
-        teamId: user.teamId,
-        displayName:
-          user.displayName || [user.firstName, user.lastName].filter(Boolean).join(' ') || undefined,
-      };
-      const signerName = actor.displayName || actor.uid;
+      const signerName =
+        user.displayName ||
+        [user.firstName, user.lastName].filter(Boolean).join(' ') ||
+        user.uid;
       const result = await EquipmentService.Items.createEquipmentBatch(
         items,
         signerName,
-        actor.uid,
+        user.uid,
         signerName,
-        actor.uid,
-        actor,
+        user.uid,
       );
       if (!result.success) throw new Error(result.message);
 

--- a/src/components/equipment/RequestNewTemplateFlow.tsx
+++ b/src/components/equipment/RequestNewTemplateFlow.tsx
@@ -5,7 +5,6 @@ import { AlertCircle, CheckCircle } from 'lucide-react';
 import TemplateForm, { TemplateFormValues } from './TemplateForm';
 import { proposeTemplate } from '@/lib/templateRequestService';
 import { useAuth } from '@/contexts/AuthContext';
-import type { ApiActor } from '@/lib/equipmentService';
 
 export interface RequestNewTemplateFlowProps {
   capturedSerialNumber?: string;
@@ -36,15 +35,10 @@ export default function RequestNewTemplateFlow({
     }
     setError(null);
     setSubmitting(true);
-    const actor: ApiActor = {
-      uid: enhancedUser.uid,
-      userType: enhancedUser.userType,
-      teamId: enhancedUser.teamId,
-      displayName:
-        enhancedUser.displayName ||
-        [enhancedUser.firstName, enhancedUser.lastName].filter(Boolean).join(' ') ||
-        undefined,
-    };
+    const proposerUserName =
+      enhancedUser.displayName ||
+      [enhancedUser.firstName, enhancedUser.lastName].filter(Boolean).join(' ') ||
+      enhancedUser.uid;
 
     try {
       const draftPayload =
@@ -58,8 +52,7 @@ export default function RequestNewTemplateFlow({
           : undefined;
 
       const result = await proposeTemplate({
-        actor,
-        proposerUserName: actor.displayName || enhancedUser.uid,
+        proposerUserName,
         name: values.name,
         category: values.category,
         subcategory: values.subcategory,

--- a/src/components/management/tabs/ForceOperationsTab.tsx
+++ b/src/components/management/tabs/ForceOperationsTab.tsx
@@ -11,7 +11,7 @@ import { getActionLogsByType } from '@/lib/actionsLogService';
 import { ActionType, type ActionsLog, type Equipment } from '@/types/equipment';
 import UserSearchInput from '@/components/users/UserSearchInput';
 import type { UserSearchResult } from '@/lib/userService';
-import type { ApiActor } from '@/lib/equipmentService';
+import { apiFetch } from '@/lib/apiFetch';
 
 type Kind = 'holder' | 'signer' | 'both';
 
@@ -83,21 +83,13 @@ export default function ForceOperationsTab() {
     if (err) { setFeedback({ ok: false, msg: err }); return; }
     setSubmitting(true);
     try {
-      const actor: ApiActor = {
-        uid: enhancedUser.uid,
-        userType: enhancedUser.userType!,
-        teamId: enhancedUser.teamId,
-        displayName:
-          enhancedUser.displayName ||
-          [enhancedUser.firstName, enhancedUser.lastName].filter(Boolean).join(' ') ||
-          undefined,
-      };
-      const actorUserName = actor.displayName || actor.uid;
-      const res = await fetch('/api/force-ops', {
+      const actorUserName =
+        enhancedUser.displayName ||
+        [enhancedUser.firstName, enhancedUser.lastName].filter(Boolean).join(' ') ||
+        enhancedUser.uid;
+      const res = await apiFetch('/api/force-ops', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          actor,
           actorUserName,
           equipmentDocIds: Array.from(selectedIds),
           kind,

--- a/src/components/management/tabs/ReportRequestTab.tsx
+++ b/src/components/management/tabs/ReportRequestTab.tsx
@@ -16,7 +16,6 @@ import {
 } from '@/lib/reportRequestService';
 import UserSearchInput from '@/components/users/UserSearchInput';
 import type { UserSearchResult } from '@/lib/userService';
-import type { ApiActor } from '@/lib/equipmentService';
 
 export default function ReportRequestTab() {
   const labels = TEXT_CONSTANTS.FEATURES.EQUIPMENT.REPORT_REQUEST;
@@ -70,22 +69,15 @@ export default function ReportRequestTab() {
     if (!enhancedUser) return;
     setSubmitting(true);
     try {
-      const actor: ApiActor = {
-        uid: enhancedUser.uid,
-        userType: enhancedUser.userType!,
-        teamId: enhancedUser.teamId,
-        displayName:
-          enhancedUser.displayName ||
-          [enhancedUser.firstName, enhancedUser.lastName].filter(Boolean).join(' ') ||
-          undefined,
-      };
-      const requestedByUserName = actor.displayName || actor.uid;
+      const requestedByUserName =
+        enhancedUser.displayName ||
+        [enhancedUser.firstName, enhancedUser.lastName].filter(Boolean).join(' ') ||
+        enhancedUser.uid;
 
       const targetUserIds = computeTargetUserIds(scope, target, itemTargets?.holderIds ?? []);
       if (targetUserIds.length === 0) throw new Error(labels.TARGET_REQUIRED);
 
       await createReportRequest({
-        actor,
         scope,
         targetUserIds,
         targetEquipmentDocIds: scope === ReportRequestScope.ITEMS ? itemTargets!.ids : undefined,

--- a/src/components/management/tabs/TemplatesTab.tsx
+++ b/src/components/management/tabs/TemplatesTab.tsx
@@ -12,7 +12,6 @@ import {
   proposeTemplate,
   rejectTemplateRequest,
 } from '@/lib/templateRequestService';
-import type { ApiActor } from '@/lib/equipmentService';
 import TemplateForm, { TemplateFormValues } from '@/components/equipment/TemplateForm';
 
 type DialogState =
@@ -21,21 +20,6 @@ type DialogState =
   | { kind: 'propose' }
   | { kind: 'review'; template: EquipmentType }
   | { kind: 'reject'; template: EquipmentType };
-
-function buildActor(
-  user: ReturnType<typeof useAuth>['enhancedUser']
-): ApiActor | null {
-  if (!user || !user.userType) return null;
-  return {
-    uid: user.uid,
-    userType: user.userType,
-    teamId: user.teamId,
-    displayName:
-      user.displayName ||
-      [user.firstName, user.lastName].filter(Boolean).join(' ') ||
-      undefined,
-  };
-}
 
 export default function TemplatesTab() {
   const { enhancedUser } = useAuth();
@@ -130,12 +114,10 @@ export default function TemplatesTab() {
   };
 
   const handlePropose = async (values: TemplateFormValues) => {
-    const actor = buildActor(enhancedUser);
-    if (!actor || !enhancedUser) return;
+    if (!enhancedUser) return;
     setSubmitting(true);
     try {
       await proposeTemplate({
-        actor,
         proposerUserName:
           [enhancedUser.firstName, enhancedUser.lastName].filter(Boolean).join(' ') ||
           enhancedUser.uid,
@@ -159,12 +141,10 @@ export default function TemplatesTab() {
   };
 
   const handleReview = async (template: EquipmentType, values: TemplateFormValues) => {
-    const actor = buildActor(enhancedUser);
-    if (!actor || !enhancedUser) return;
+    if (!enhancedUser) return;
     setSubmitting(true);
     try {
       await approveTemplateRequest({
-        actor,
         templateId: template.id,
         approverUserName:
           [enhancedUser.firstName, enhancedUser.lastName].filter(Boolean).join(' ') ||
@@ -191,12 +171,10 @@ export default function TemplatesTab() {
   };
 
   const handleReject = async () => {
-    const actor = buildActor(enhancedUser);
-    if (!actor || dialog.kind !== 'reject' || !enhancedUser) return;
+    if (dialog.kind !== 'reject' || !enhancedUser) return;
     setSubmitting(true);
     try {
       await rejectTemplateRequest({
-        actor,
         templateId: dialog.template.id,
         rejectorUserName:
           [enhancedUser.firstName, enhancedUser.lastName].filter(Boolean).join(' ') ||

--- a/src/contexts/NotificationContext.tsx
+++ b/src/contexts/NotificationContext.tsx
@@ -11,6 +11,7 @@ import {
   Timestamp 
 } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
+import { apiFetch } from '@/lib/apiFetch';
 import { useAuth } from '@/contexts/AuthContext';
 import { 
   Notification, 
@@ -89,9 +90,8 @@ export function NotificationProvider({ children }: NotificationProviderProps) {
   // Mark single notification as read (via server API route)
   const markAsRead = useCallback(async (notificationId: string) => {
     try {
-      await fetch('/api/notifications/read', {
+      await apiFetch('/api/notifications/read', {
         method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ notificationId }),
       });
       // Real-time listener will update the state automatically
@@ -105,10 +105,9 @@ export function NotificationProvider({ children }: NotificationProviderProps) {
     if (!user?.uid) return;
 
     try {
-      await fetch('/api/notifications/read', {
+      await apiFetch('/api/notifications/read', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ userId: user.uid }),
+        body: JSON.stringify({}),
       });
       // Real-time listener will update the state automatically
     } catch (error) {
@@ -119,9 +118,8 @@ export function NotificationProvider({ children }: NotificationProviderProps) {
   // Delete notification (via server API route)
   const deleteNotification = useCallback(async (notificationId: string) => {
     try {
-      await fetch('/api/notifications', {
+      await apiFetch('/api/notifications', {
         method: 'DELETE',
-        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ id: notificationId }),
       });
       // Real-time listener will update the state automatically

--- a/src/hooks/useAmmunitionInventory.ts
+++ b/src/hooks/useAmmunitionInventory.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import { useAuth } from '@/contexts/AuthContext';
+import { apiFetch } from '@/lib/apiFetch';
 import {
   listAmmunitionStock,
   listSerialAmmunitionItems,
@@ -13,7 +13,6 @@ import type {
   BruceState,
   HolderType,
 } from '@/types/ammunition';
-import type { ApiActor } from '@/lib/equipmentService';
 
 export interface UpsertStockPayload {
   templateId: string;
@@ -50,23 +49,7 @@ export interface UseAmmunitionInventoryReturn {
   deleteSerialItem: (serial: string) => Promise<boolean>;
 }
 
-function buildActor(
-  user: ReturnType<typeof useAuth>['enhancedUser']
-): ApiActor | null {
-  if (!user || !user.userType) return null;
-  return {
-    uid: user.uid,
-    userType: user.userType,
-    teamId: user.teamId,
-    displayName:
-      user.displayName ||
-      [user.firstName, user.lastName].filter(Boolean).join(' ') ||
-      undefined,
-  };
-}
-
 export function useAmmunitionInventory(): UseAmmunitionInventoryReturn {
-  const { enhancedUser } = useAuth();
   const [stock, setStock] = useState<AmmunitionStock[]>([]);
   const [items, setItems] = useState<AmmunitionItem[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -95,13 +78,10 @@ export function useAmmunitionInventory(): UseAmmunitionInventoryReturn {
 
   const upsertStock = useCallback(
     async (payload: UpsertStockPayload) => {
-      const actor = buildActor(enhancedUser);
-      if (!actor) return false;
       try {
-        const res = await fetch('/api/ammunition-inventory', {
+        const res = await apiFetch('/api/ammunition-inventory', {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ actor, kind: 'stock', payload }),
+          body: JSON.stringify({ kind: 'stock', payload }),
         });
         const json = await res.json();
         if (!res.ok || !json.success) throw new Error(json.error || 'עדכון מלאי נכשל');
@@ -112,18 +92,15 @@ export function useAmmunitionInventory(): UseAmmunitionInventoryReturn {
         return false;
       }
     },
-    [enhancedUser, refresh]
+    [refresh]
   );
 
   const deleteStock = useCallback(
     async (id: string) => {
-      const actor = buildActor(enhancedUser);
-      if (!actor) return false;
       try {
-        const res = await fetch(`/api/ammunition-inventory/${encodeURIComponent(id)}`, {
+        const res = await apiFetch(`/api/ammunition-inventory/${encodeURIComponent(id)}`, {
           method: 'DELETE',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ actor, kind: 'stock' }),
+          body: JSON.stringify({ kind: 'stock' }),
         });
         const json = await res.json();
         if (!res.ok || !json.success) throw new Error(json.error || 'מחיקת מלאי נכשלה');
@@ -134,18 +111,15 @@ export function useAmmunitionInventory(): UseAmmunitionInventoryReturn {
         return false;
       }
     },
-    [enhancedUser, refresh]
+    [refresh]
   );
 
   const createSerialItem = useCallback(
     async (payload: CreateSerialItemPayload) => {
-      const actor = buildActor(enhancedUser);
-      if (!actor) return false;
       try {
-        const res = await fetch('/api/ammunition-inventory', {
+        const res = await apiFetch('/api/ammunition-inventory', {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ actor, kind: 'item', payload }),
+          body: JSON.stringify({ kind: 'item', payload }),
         });
         const json = await res.json();
         if (!res.ok || !json.success) throw new Error(json.error || 'יצירת פריט נכשלה');
@@ -156,18 +130,15 @@ export function useAmmunitionInventory(): UseAmmunitionInventoryReturn {
         return false;
       }
     },
-    [enhancedUser, refresh]
+    [refresh]
   );
 
   const updateSerialItem = useCallback(
     async (serial: string, payload: UpdateSerialItemPayload) => {
-      const actor = buildActor(enhancedUser);
-      if (!actor) return false;
       try {
-        const res = await fetch(`/api/ammunition-inventory/${encodeURIComponent(serial)}`, {
+        const res = await apiFetch(`/api/ammunition-inventory/${encodeURIComponent(serial)}`, {
           method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ actor, kind: 'item', payload }),
+          body: JSON.stringify({ kind: 'item', payload }),
         });
         const json = await res.json();
         if (!res.ok || !json.success) throw new Error(json.error || 'עדכון פריט נכשל');
@@ -178,18 +149,15 @@ export function useAmmunitionInventory(): UseAmmunitionInventoryReturn {
         return false;
       }
     },
-    [enhancedUser, refresh]
+    [refresh]
   );
 
   const deleteSerialItem = useCallback(
     async (serial: string) => {
-      const actor = buildActor(enhancedUser);
-      if (!actor) return false;
       try {
-        const res = await fetch(`/api/ammunition-inventory/${encodeURIComponent(serial)}`, {
+        const res = await apiFetch(`/api/ammunition-inventory/${encodeURIComponent(serial)}`, {
           method: 'DELETE',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ actor, kind: 'item' }),
+          body: JSON.stringify({ kind: 'item' }),
         });
         const json = await res.json();
         if (!res.ok || !json.success) throw new Error(json.error || 'מחיקת פריט נכשלה');
@@ -200,7 +168,7 @@ export function useAmmunitionInventory(): UseAmmunitionInventoryReturn {
         return false;
       }
     },
-    [enhancedUser, refresh]
+    [refresh]
   );
 
   return {

--- a/src/hooks/useAmmunitionReportRequests.ts
+++ b/src/hooks/useAmmunitionReportRequests.ts
@@ -2,11 +2,11 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
+import { apiFetch } from '@/lib/apiFetch';
 import type {
   AmmunitionReportRequest,
   AmmunitionReportRequestScope,
 } from '@/types/ammunition';
-import type { ApiActor } from '@/lib/equipmentService';
 
 export interface CreateRequestPayload {
   scope: AmmunitionReportRequestScope;
@@ -26,21 +26,6 @@ export interface UseAmmunitionReportRequestsReturn {
   cancel: (requestId: string) => Promise<boolean>;
 }
 
-function buildActor(
-  user: ReturnType<typeof useAuth>['enhancedUser']
-): ApiActor | null {
-  if (!user || !user.userType) return null;
-  return {
-    uid: user.uid,
-    userType: user.userType,
-    teamId: user.teamId,
-    displayName:
-      user.displayName ||
-      [user.firstName, user.lastName].filter(Boolean).join(' ') ||
-      undefined,
-  };
-}
-
 export function useAmmunitionReportRequests(): UseAmmunitionReportRequestsReturn {
   const { enhancedUser } = useAuth();
   const [requests, setRequests] = useState<AmmunitionReportRequest[]>([]);
@@ -51,7 +36,7 @@ export function useAmmunitionReportRequests(): UseAmmunitionReportRequestsReturn
     setIsLoading(true);
     setError(null);
     try {
-      const res = await fetch('/api/ammunition-report-requests');
+      const res = await apiFetch('/api/ammunition-report-requests');
       const json = await res.json();
       if (!res.ok || !json.success) throw new Error(json.error || 'שגיאה בטעינת בקשות');
       setRequests(json.requests || []);
@@ -68,15 +53,16 @@ export function useAmmunitionReportRequests(): UseAmmunitionReportRequestsReturn
 
   const create = useCallback(
     async (payload: CreateRequestPayload) => {
-      const actor = buildActor(enhancedUser);
-      if (!actor) return { ok: false };
       try {
-        const res = await fetch('/api/ammunition-report-requests', {
+        const displayName =
+          enhancedUser?.displayName ||
+          [enhancedUser?.firstName, enhancedUser?.lastName].filter(Boolean).join(' ') ||
+          enhancedUser?.uid ||
+          '';
+        const res = await apiFetch('/api/ammunition-report-requests', {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
-            actor,
-            actorUserName: actor.displayName || actor.uid,
+            actorUserName: displayName,
             payload,
           }),
         });
@@ -94,13 +80,10 @@ export function useAmmunitionReportRequests(): UseAmmunitionReportRequestsReturn
 
   const cancel = useCallback(
     async (requestId: string) => {
-      const actor = buildActor(enhancedUser);
-      if (!actor) return false;
       try {
-        const res = await fetch('/api/ammunition-report-requests', {
+        const res = await apiFetch('/api/ammunition-report-requests', {
           method: 'PATCH',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ actor, action: 'cancel', requestId }),
+          body: JSON.stringify({ action: 'cancel', requestId }),
         });
         const json = await res.json();
         if (!res.ok || !json.success) throw new Error(json.error || 'ביטול נכשל');
@@ -111,7 +94,7 @@ export function useAmmunitionReportRequests(): UseAmmunitionReportRequestsReturn
         return false;
       }
     },
-    [enhancedUser, refresh]
+    [refresh]
   );
 
   return { requests, isLoading, error, refresh, create, cancel };

--- a/src/hooks/useAmmunitionReports.ts
+++ b/src/hooks/useAmmunitionReports.ts
@@ -1,13 +1,12 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import { useAuth } from '@/contexts/AuthContext';
+import { apiFetch } from '@/lib/apiFetch';
 import {
   listAmmunitionReports,
   type ListReportsFilter,
 } from '@/lib/ammunition/reportsService';
 import type { AmmunitionReport, BruceState } from '@/types/ammunition';
-import type { ApiActor } from '@/lib/equipmentService';
 
 export interface SubmitReportPayload {
   templateId: string;
@@ -30,23 +29,7 @@ export interface UseAmmunitionReportsReturn {
   submit: (payload: SubmitReportPayload) => Promise<{ ok: boolean; reportId?: string }>;
 }
 
-function buildActor(
-  user: ReturnType<typeof useAuth>['enhancedUser']
-): ApiActor | null {
-  if (!user || !user.userType) return null;
-  return {
-    uid: user.uid,
-    userType: user.userType,
-    teamId: user.teamId,
-    displayName:
-      user.displayName ||
-      [user.firstName, user.lastName].filter(Boolean).join(' ') ||
-      undefined,
-  };
-}
-
 export function useAmmunitionReports(initialFilter: ListReportsFilter = {}): UseAmmunitionReportsReturn {
-  const { enhancedUser } = useAuth();
   const [reports, setReports] = useState<AmmunitionReport[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -70,13 +53,10 @@ export function useAmmunitionReports(initialFilter: ListReportsFilter = {}): Use
 
   const submit = useCallback(
     async (payload: SubmitReportPayload) => {
-      const actor = buildActor(enhancedUser);
-      if (!actor) return { ok: false };
       try {
-        const res = await fetch('/api/ammunition-reports', {
+        const res = await apiFetch('/api/ammunition-reports', {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ actor, payload }),
+          body: JSON.stringify({ payload }),
         });
         const json = await res.json();
         if (!res.ok || !json.success) {
@@ -89,7 +69,7 @@ export function useAmmunitionReports(initialFilter: ListReportsFilter = {}): Use
         return { ok: false };
       }
     },
-    [enhancedUser, refresh]
+    [refresh]
   );
 
   return { reports, isLoading, error, refresh, submit };

--- a/src/hooks/useAmmunitionTemplates.ts
+++ b/src/hooks/useAmmunitionTemplates.ts
@@ -1,9 +1,8 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import { useAuth } from '@/contexts/AuthContext';
+import { apiFetch } from '@/lib/apiFetch';
 import type { AmmunitionType } from '@/types/ammunition';
-import type { ApiActor } from '@/lib/equipmentService';
 
 export interface CreateAmmunitionTemplatePayload {
   name: string;
@@ -28,23 +27,7 @@ export interface UseAmmunitionTemplatesReturn {
   seedCanonical: () => Promise<{ created: number; skipped: number } | null>;
 }
 
-function buildActor(
-  user: ReturnType<typeof useAuth>['enhancedUser']
-): ApiActor | null {
-  if (!user || !user.userType) return null;
-  return {
-    uid: user.uid,
-    userType: user.userType,
-    teamId: user.teamId,
-    displayName:
-      user.displayName ||
-      [user.firstName, user.lastName].filter(Boolean).join(' ') ||
-      undefined,
-  };
-}
-
 export function useAmmunitionTemplates(): UseAmmunitionTemplatesReturn {
-  const { enhancedUser } = useAuth();
   const [templates, setTemplates] = useState<AmmunitionType[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -53,7 +36,7 @@ export function useAmmunitionTemplates(): UseAmmunitionTemplatesReturn {
     setIsLoading(true);
     setError(null);
     try {
-      const res = await fetch('/api/ammunition-templates');
+      const res = await apiFetch('/api/ammunition-templates');
       const json = await res.json();
       if (!res.ok || !json.success) {
         throw new Error(json.error || 'שגיאה בטעינת תבניות תחמושת');
@@ -72,13 +55,10 @@ export function useAmmunitionTemplates(): UseAmmunitionTemplatesReturn {
 
   const create = useCallback(
     async (payload: CreateAmmunitionTemplatePayload) => {
-      const actor = buildActor(enhancedUser);
-      if (!actor) return false;
       try {
-        const res = await fetch('/api/ammunition-templates', {
+        const res = await apiFetch('/api/ammunition-templates', {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ actor, payload }),
+          body: JSON.stringify({ payload }),
         });
         const json = await res.json();
         if (!res.ok || !json.success) {
@@ -91,18 +71,15 @@ export function useAmmunitionTemplates(): UseAmmunitionTemplatesReturn {
         return false;
       }
     },
-    [enhancedUser, refresh]
+    [refresh]
   );
 
   const update = useCallback(
     async (id: string, payload: CreateAmmunitionTemplatePayload) => {
-      const actor = buildActor(enhancedUser);
-      if (!actor) return false;
       try {
-        const res = await fetch(`/api/ammunition-templates/${id}`, {
+        const res = await apiFetch(`/api/ammunition-templates/${id}`, {
           method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ actor, payload }),
+          body: JSON.stringify({ payload }),
         });
         const json = await res.json();
         if (!res.ok || !json.success) {
@@ -115,18 +92,15 @@ export function useAmmunitionTemplates(): UseAmmunitionTemplatesReturn {
         return false;
       }
     },
-    [enhancedUser, refresh]
+    [refresh]
   );
 
   const remove = useCallback(
     async (id: string) => {
-      const actor = buildActor(enhancedUser);
-      if (!actor) return false;
       try {
-        const res = await fetch(`/api/ammunition-templates/${id}`, {
+        const res = await apiFetch(`/api/ammunition-templates/${id}`, {
           method: 'DELETE',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ actor }),
+          body: JSON.stringify({}),
         });
         const json = await res.json();
         if (!res.ok || !json.success) {
@@ -139,17 +113,14 @@ export function useAmmunitionTemplates(): UseAmmunitionTemplatesReturn {
         return false;
       }
     },
-    [enhancedUser, refresh]
+    [refresh]
   );
 
   const seedCanonical = useCallback(async () => {
-    const actor = buildActor(enhancedUser);
-    if (!actor) return null;
     try {
-      const res = await fetch('/api/ammunition-templates', {
+      const res = await apiFetch('/api/ammunition-templates', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ actor, action: 'seed_canonical' }),
+        body: JSON.stringify({ action: 'seed_canonical' }),
       });
       const json = await res.json();
       if (!res.ok || !json.success) {
@@ -161,7 +132,7 @@ export function useAmmunitionTemplates(): UseAmmunitionTemplatesReturn {
       setError(e instanceof Error ? e.message : 'שגיאה לא צפויה');
       return null;
     }
-  }, [enhancedUser, refresh]);
+  }, [refresh]);
 
   return { templates, isLoading, error, refresh, create, update, remove, seedCanonical };
 }

--- a/src/hooks/useEquipment.ts
+++ b/src/hooks/useEquipment.ts
@@ -9,7 +9,7 @@ import {
   EquipmentAction,
   ApprovalType
 } from '@/types/equipment';
-import { EquipmentService, type ApiActor } from '@/lib/equipmentService';
+import { EquipmentService } from '@/lib/equipmentService';
 import { TEXT_CONSTANTS } from '@/constants/text';
 import { Timestamp, serverTimestamp } from 'firebase/firestore';
 import { auth } from '@/lib/firebase';
@@ -72,16 +72,14 @@ export function useEquipment(options: UseEquipmentOptions = {}): UseEquipmentRet
   const [typesLoading, setTypesLoading] = useState(false);
   const [typesError, setTypesError] = useState<string | null>(null);
 
-  const buildActor = useCallback((): ApiActor | null => {
+  const buildActorIdentity = useCallback((): { uid: string; displayName: string } | null => {
     if (!enhancedUser?.uid || !enhancedUser.userType) return null;
     return {
       uid: enhancedUser.uid,
-      userType: enhancedUser.userType,
-      teamId: enhancedUser.teamId,
       displayName:
         enhancedUser.displayName ||
         [enhancedUser.firstName, enhancedUser.lastName].filter(Boolean).join(' ') ||
-        undefined,
+        enhancedUser.uid,
     };
   }, [enhancedUser]);
 
@@ -255,11 +253,11 @@ export function useEquipment(options: UseEquipmentOptions = {}): UseEquipmentRet
   const reportEquipment = useCallback(async (
     equipmentId: string, photoUrl: string | null, note?: string
   ): Promise<boolean> => {
-    const actor = buildActor();
-    if (!actor) { setError(TEXT_CONSTANTS.ERRORS.CONNECTION_ERROR); return false; }
+    const identity = buildActorIdentity();
+    if (!identity) { setError(TEXT_CONSTANTS.ERRORS.CONNECTION_ERROR); return false; }
     try {
       const result = await EquipmentService.Items.reportEquipment(
-        equipmentId, photoUrl, actor, actor.displayName || actor.uid, note
+        equipmentId, photoUrl, identity.displayName, note
       );
       if (result.success) { await refreshEquipment(); return true; }
       setError(result.message);
@@ -269,16 +267,16 @@ export function useEquipment(options: UseEquipmentOptions = {}): UseEquipmentRet
       setError(TEXT_CONSTANTS.ERRORS.UNEXPECTED_ERROR);
       return false;
     }
-  }, [refreshEquipment, buildActor]);
+  }, [refreshEquipment, buildActorIdentity]);
 
   const retireEquipment = useCallback(async (
     equipmentId: string, reason: string
   ): Promise<{ success: boolean; kind?: 'immediate' | 'request'; error?: string }> => {
-    const actor = buildActor();
-    if (!actor) return { success: false, error: TEXT_CONSTANTS.ERRORS.CONNECTION_ERROR };
+    const identity = buildActorIdentity();
+    if (!identity) return { success: false, error: TEXT_CONSTANTS.ERRORS.CONNECTION_ERROR };
     try {
       const result = await EquipmentService.Items.retireEquipment(
-        equipmentId, actor, actor.displayName || actor.uid, reason
+        equipmentId, identity.displayName, reason
       );
       if (result.success) {
         await refreshEquipment();
@@ -290,18 +288,17 @@ export function useEquipment(options: UseEquipmentOptions = {}): UseEquipmentRet
       console.error('Error retiring equipment:', err);
       return { success: false, error: TEXT_CONSTANTS.ERRORS.UNEXPECTED_ERROR };
     }
-  }, [refreshEquipment, buildActor]);
+  }, [refreshEquipment, buildActorIdentity]);
 
   const createEquipmentBatch = useCallback(async (
     items: Array<Omit<Equipment, 'createdAt' | 'updatedAt' | 'trackingHistory'>>,
     notes?: string
   ): Promise<boolean> => {
-    const actor = buildActor();
-    if (!actor) { setError(TEXT_CONSTANTS.ERRORS.CONNECTION_ERROR); return false; }
-    const signerName = actor.displayName || actor.uid;
+    const identity = buildActorIdentity();
+    if (!identity) { setError(TEXT_CONSTANTS.ERRORS.CONNECTION_ERROR); return false; }
     try {
       const result = await EquipmentService.Items.createEquipmentBatch(
-        items, signerName, actor.uid, signerName, actor.uid, actor, notes
+        items, identity.displayName, identity.uid, identity.displayName, identity.uid, notes
       );
       if (result.success) { await refreshEquipment(); return true; }
       setError(result.message);
@@ -311,7 +308,7 @@ export function useEquipment(options: UseEquipmentOptions = {}): UseEquipmentRet
       setError(TEXT_CONSTANTS.ERRORS.UNEXPECTED_ERROR);
       return false;
     }
-  }, [refreshEquipment, buildActor]);
+  }, [refreshEquipment, buildActorIdentity]);
 
   const addEquipmentType = useCallback(async (
     equipmentTypeData: Omit<EquipmentType, 'createdAt' | 'updatedAt'>

--- a/src/hooks/useSystemConfig.ts
+++ b/src/hooks/useSystemConfig.ts
@@ -1,9 +1,8 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import { useAuth } from '@/contexts/AuthContext';
+import { apiFetch } from '@/lib/apiFetch';
 import type { SystemConfig } from '@/types/ammunition';
-import type { ApiActor } from '@/lib/equipmentService';
 
 export interface SystemConfigSavePayload {
   ammoNotificationRecipientUserId?: string;
@@ -18,23 +17,7 @@ export interface UseSystemConfigReturn {
   refresh: () => Promise<void>;
 }
 
-function buildActor(
-  user: ReturnType<typeof useAuth>['enhancedUser']
-): ApiActor | null {
-  if (!user || !user.userType) return null;
-  return {
-    uid: user.uid,
-    userType: user.userType,
-    teamId: user.teamId,
-    displayName:
-      user.displayName ||
-      [user.firstName, user.lastName].filter(Boolean).join(' ') ||
-      undefined,
-  };
-}
-
 export function useSystemConfig(): UseSystemConfigReturn {
-  const { enhancedUser } = useAuth();
   const [config, setConfig] = useState<SystemConfig | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -43,7 +26,7 @@ export function useSystemConfig(): UseSystemConfigReturn {
     setIsLoading(true);
     setError(null);
     try {
-      const res = await fetch('/api/system-config', { method: 'GET' });
+      const res = await apiFetch('/api/system-config', { method: 'GET' });
       const json = await res.json();
       if (!res.ok || !json.success) {
         throw new Error(json.error || 'שגיאה בטעינת הגדרות מערכת');
@@ -62,17 +45,11 @@ export function useSystemConfig(): UseSystemConfigReturn {
 
   const save = useCallback(
     async (payload: SystemConfigSavePayload) => {
-      const actor = buildActor(enhancedUser);
-      if (!actor) {
-        setError('דרושה התחברות');
-        return false;
-      }
       setError(null);
       try {
-        const res = await fetch('/api/system-config', {
+        const res = await apiFetch('/api/system-config', {
           method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ actor, payload }),
+          body: JSON.stringify({ payload }),
         });
         const json = await res.json();
         if (!res.ok || !json.success) {
@@ -85,7 +62,7 @@ export function useSystemConfig(): UseSystemConfigReturn {
         return false;
       }
     },
-    [enhancedUser]
+    []
   );
 
   return { config, isLoading, error, save, refresh };

--- a/src/lib/__tests__/serverServices.test.ts
+++ b/src/lib/__tests__/serverServices.test.ts
@@ -1,5 +1,5 @@
 /**
- * Phase 8 — light contract tests for the server-side services and helpers.
+ * Light contract tests for the server-side services and helpers.
  *
  * The Firebase Admin SDK is heavy to fake for full transactional behavior, so
  * these tests focus on **input validation** + **pure helpers**. Deeper
@@ -8,7 +8,6 @@
  */
 
 // ─── Mocks for firebase-admin chain ────────────────────────────────────────
-// firebase-admin/firestore — stub Timestamp + FieldValue so imports resolve.
 jest.mock('firebase-admin/firestore', () => ({
   Timestamp: {
     now: () => ({ toDate: () => new Date(), seconds: 0, nanoseconds: 0 }),
@@ -27,16 +26,32 @@ jest.mock('firebase-admin/app', () => ({
   applicationDefault: () => ({}),
 }));
 
-// admin DB factory — server services call getAdminDb(). Validation paths
-// throw before reaching it; deeper tests would replace this with an
-// in-memory fake.
-jest.mock('@/lib/db/admin', () => ({
-  getAdminDb: jest.fn(() => {
-    throw new Error('Test reached admin DB without setting up a fake');
-  }),
+// next/server uses native Request which isn't available in jsdom.
+jest.mock('next/server', () => ({
+  NextResponse: {
+    json: (body: unknown, init?: { status?: number }) => ({
+      status: init?.status ?? 200,
+      body,
+    }),
+  },
 }));
 
-// Side-effect helpers — make them no-ops so happy-path tests don't fan out.
+const mockVerifyIdToken = jest.fn();
+const mockGetUserDoc = jest.fn();
+
+jest.mock('@/lib/db/admin', () => ({
+  getAdminDb: jest.fn(() => ({
+    collection: () => ({
+      doc: () => ({
+        get: mockGetUserDoc,
+      }),
+    }),
+  })),
+  getAdminAuth: jest.fn(() => ({
+    verifyIdToken: mockVerifyIdToken,
+  })),
+}));
+
 jest.mock('@/lib/db/server/actionsLogService', () => ({
   serverCreateActionLog: jest.fn(async () => 'log-id'),
 }));
@@ -45,47 +60,90 @@ jest.mock('@/lib/db/server/notificationService', () => ({
   serverCreateBatchNotifications: jest.fn(async () => undefined),
 }));
 
-import { validateActor, actorToAuthUser, type ApiActor } from '@/lib/db/server/policyHelpers';
+import { actorToAuthUser, type ApiActor } from '@/lib/db/server/policyHelpers';
+import { getActorFromRequest, AuthError } from '@/lib/db/server/auth';
 import { serverForceOps } from '@/lib/db/server/forceOpsService';
 import { UserType } from '@/types/user';
 
-describe('policyHelpers.validateActor', () => {
-  it('accepts a well-formed actor', () => {
-    const actor = validateActor({
-      uid: 'u1',
-      userType: UserType.MANAGER,
-      teamId: 'team-a',
-      displayName: 'Alice',
+// Minimal Request stub that exposes the headers API used by getActorFromRequest.
+function buildRequest(headers: Record<string, string> = {}): Request {
+  const headerMap = new Map(Object.entries(headers).map(([k, v]) => [k.toLowerCase(), v]));
+  return {
+    headers: {
+      get: (name: string) => headerMap.get(name.toLowerCase()) ?? null,
+    },
+  } as unknown as Request;
+}
+
+describe('auth.getActorFromRequest', () => {
+  beforeEach(() => {
+    mockVerifyIdToken.mockReset();
+    mockGetUserDoc.mockReset();
+  });
+
+  it('throws AuthError 401 when Authorization header is missing', async () => {
+    await expect(getActorFromRequest(buildRequest())).rejects.toMatchObject({
+      status: 401,
     });
+  });
+
+  it('throws AuthError 401 when header lacks Bearer prefix', async () => {
+    await expect(
+      getActorFromRequest(buildRequest({ Authorization: 'token-only' }))
+    ).rejects.toMatchObject({ status: 401 });
+  });
+
+  it('throws AuthError 401 when verifyIdToken rejects', async () => {
+    mockVerifyIdToken.mockRejectedValue(new Error('expired'));
+    await expect(
+      getActorFromRequest(buildRequest({ Authorization: 'Bearer xxx' }))
+    ).rejects.toMatchObject({ status: 401 });
+  });
+
+  it('throws AuthError 403 when user profile not found', async () => {
+    mockVerifyIdToken.mockResolvedValue({ uid: 'u1' });
+    mockGetUserDoc.mockResolvedValue({ exists: false, data: () => undefined });
+    await expect(
+      getActorFromRequest(buildRequest({ Authorization: 'Bearer xxx' }))
+    ).rejects.toMatchObject({ status: 403 });
+  });
+
+  it('throws AuthError 403 when userType is missing on profile', async () => {
+    mockVerifyIdToken.mockResolvedValue({ uid: 'u1' });
+    mockGetUserDoc.mockResolvedValue({
+      exists: true,
+      data: () => ({ teamId: 'team-a' }),
+    });
+    await expect(
+      getActorFromRequest(buildRequest({ Authorization: 'Bearer xxx' }))
+    ).rejects.toMatchObject({ status: 403 });
+  });
+
+  it('returns ApiActor with verified userType + teamId', async () => {
+    mockVerifyIdToken.mockResolvedValue({ uid: 'u1' });
+    mockGetUserDoc.mockResolvedValue({
+      exists: true,
+      data: () => ({ userType: UserType.MANAGER, teamId: 'team-a', displayName: 'Alice' }),
+    });
+    const actor = await getActorFromRequest(
+      buildRequest({ Authorization: 'Bearer good-token' })
+    );
     expect(actor.uid).toBe('u1');
     expect(actor.userType).toBe(UserType.MANAGER);
     expect(actor.teamId).toBe('team-a');
     expect(actor.displayName).toBe('Alice');
+    expect(actor.grants).toEqual([]);
   });
 
-  it('throws when actor is missing entirely', () => {
-    expect(() => validateActor(undefined)).toThrow(/actor is required/);
-    expect(() => validateActor(null)).toThrow(/actor is required/);
-    expect(() => validateActor('not-an-object')).toThrow(/actor is required/);
-  });
-
-  it('throws when uid is missing', () => {
-    expect(() => validateActor({ userType: UserType.USER })).toThrow(/actor\.uid/);
-  });
-
-  it('throws when userType is missing', () => {
-    expect(() => validateActor({ uid: 'u1' })).toThrow(/actor\.userType/);
-  });
-
-  it('strips optional fields when undefined', () => {
-    const actor = validateActor({ uid: 'u1', userType: UserType.USER });
-    expect(actor.teamId).toBeUndefined();
-    expect(actor.displayName).toBeUndefined();
+  it('AuthError exposes status property', () => {
+    const err = new AuthError('x', 401);
+    expect(err.status).toBe(401);
+    expect(err).toBeInstanceOf(Error);
   });
 });
 
 describe('policyHelpers.actorToAuthUser', () => {
-  it('preserves identity fields', () => {
+  it('forwards identity + grants (defaulting empty)', () => {
     const actor: ApiActor = {
       uid: 'u1',
       userType: UserType.TEAM_LEADER,
@@ -97,6 +155,26 @@ describe('policyHelpers.actorToAuthUser', () => {
     expect(user.userType).toBe(UserType.TEAM_LEADER);
     expect(user.teamId).toBe('team-b');
     expect(user.displayName).toBe('Bob');
+    expect(user.grants).toEqual([]);
+  });
+
+  it('preserves explicit grants', () => {
+    const actor: ApiActor = {
+      uid: 'u1',
+      userType: UserType.USER,
+      grants: [
+        {
+          id: 'g1',
+          grantedRole: UserType.TEAM_LEADER,
+          scope: 'team',
+          scopeTeamId: 'team-x',
+          expiresAtMs: Date.now() + 1000,
+        },
+      ],
+    };
+    const user = actorToAuthUser(actor);
+    expect(user.grants).toHaveLength(1);
+    expect(user.grants?.[0].grantedRole).toBe(UserType.TEAM_LEADER);
   });
 });
 
@@ -120,10 +198,5 @@ describe('serverForceOps — input validation', () => {
     await expect(
       serverForceOps({ ...baseInput, reason: '' })
     ).rejects.toThrow(/reason is required/);
-  });
-
-  it('reaches the admin DB when input is well-formed (proves validation passed)', async () => {
-    // The mocked getAdminDb throws a sentinel error. Reaching it means validation passed.
-    await expect(serverForceOps(baseInput)).rejects.toThrow(/Test reached admin DB/);
   });
 });

--- a/src/lib/actionsLogService.ts
+++ b/src/lib/actionsLogService.ts
@@ -14,6 +14,7 @@ import {
   Timestamp
 } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
+import { apiFetch } from '@/lib/apiFetch';
 import { ActionsLog, ActionType } from '@/types/equipment';
 import { COLLECTIONS } from '@/lib/db/collections';
 
@@ -22,9 +23,8 @@ import { COLLECTIONS } from '@/lib/db/collections';
  * Delegates to API route (firebase-admin) for the write.
  */
 export async function createActionLog(actionData: Omit<ActionsLog, 'id' | 'timestamp'>): Promise<string> {
-  const response = await fetch('/api/actions-log', {
+  const response = await apiFetch('/api/actions-log', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(actionData),
   });
 

--- a/src/lib/adminUtils.ts
+++ b/src/lib/adminUtils.ts
@@ -1,4 +1,5 @@
 import { db } from '@/lib/firebase';
+import { apiFetch } from '@/lib/apiFetch';
 import { doc, getDoc, collection, query, getDocs, Timestamp } from 'firebase/firestore';
 import {
   AdminConfig,
@@ -350,9 +351,8 @@ export class AdminFirestoreService {
       };
 
       // Add to Firestore via server API route (firebase-admin)
-      const addResponse = await fetch('/api/authorized-personnel', {
+      const addResponse = await apiFetch('/api/authorized-personnel', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ docId: hash, data: personnelDoc }),
       });
       const addResult = await addResponse.json();
@@ -503,9 +503,8 @@ export class AdminFirestoreService {
         (processedUpdates.firstName || processedUpdates.lastName || processedUpdates.rank || processedUpdates.phoneNumber || processedUpdates.userType || processedUpdates.status);
 
       // Update via server API route (firebase-admin)
-      const updateResponse = await fetch('/api/authorized-personnel', {
+      const updateResponse = await apiFetch('/api/authorized-personnel', {
         method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           personnelId,
           updates: processedUpdates,
@@ -624,9 +623,8 @@ export class AdminFirestoreService {
     }
 
     try {
-      const bulkResponse = await fetch('/api/authorized-personnel/bulk', {
+      const bulkResponse = await apiFetch('/api/authorized-personnel/bulk', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ entries }),
       });
       const bulkResult = await bulkResponse.json();
@@ -683,9 +681,8 @@ export class AdminFirestoreService {
    */
   static async deleteAuthorizedPersonnel(id: string): Promise<PersonnelOperationResult> {
     try {
-      const deleteResponse = await fetch('/api/authorized-personnel', {
+      const deleteResponse = await apiFetch('/api/authorized-personnel', {
         method: 'DELETE',
-        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ id }),
       });
       const deleteResult = await deleteResponse.json();
@@ -761,9 +758,8 @@ export class AdminFirestoreService {
         };
       }
 
-      const updateResponse = await fetch('/api/authorized-personnel', {
+      const updateResponse = await apiFetch('/api/authorized-personnel', {
         method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ personnelId: militaryIdHash, updates: { registered } }),
       });
       const updateResult = await updateResponse.json();

--- a/src/lib/apiFetch.ts
+++ b/src/lib/apiFetch.ts
@@ -1,0 +1,27 @@
+import { auth } from './firebase';
+
+/**
+ * Authenticated fetch wrapper. Attaches the current user's Firebase ID token
+ * as `Authorization: Bearer <token>`. Use for every call to a protected
+ * `/api/...` route. Public auth routes (`/api/auth/register`,
+ * `/api/auth/verify-military-id`, `/api/auth/check-email-verified`) and
+ * `/api/sheets` use plain `fetch` instead.
+ *
+ * Throws `Error('Not authenticated')` if there is no signed-in user.
+ */
+export async function apiFetch(
+  input: RequestInfo | URL,
+  init: RequestInit = {}
+): Promise<Response> {
+  const user = auth.currentUser;
+  if (!user) {
+    throw new Error('Not authenticated');
+  }
+  const idToken = await user.getIdToken();
+  const headers = new Headers(init.headers);
+  headers.set('Authorization', `Bearer ${idToken}`);
+  if (init.body && !headers.has('Content-Type')) {
+    headers.set('Content-Type', 'application/json');
+  }
+  return fetch(input, { ...init, headers });
+}

--- a/src/lib/categories/repository.ts
+++ b/src/lib/categories/repository.ts
@@ -11,11 +11,12 @@ import {
   where
 } from 'firebase/firestore';
 import { db } from '../firebase';
-import { 
-  Category, 
-  Subcategory, 
-  CategoriesQueryOptions, 
-  SubcategoriesQueryOptions 
+import { apiFetch } from '../apiFetch';
+import {
+  Category,
+  Subcategory,
+  CategoriesQueryOptions,
+  SubcategoriesQueryOptions
 } from './types';
 import { COLLECTIONS } from './constants';
 
@@ -219,9 +220,8 @@ export class CategoriesRepository {
   static async createCategory(
     categoryData: Omit<Category, 'id' | 'subcategories' | 'createdAt' | 'updatedAt'>
   ): Promise<string> {
-    const response = await fetch('/api/categories', {
+    const response = await apiFetch('/api/categories', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(categoryData),
     });
     const result = await response.json();
@@ -236,9 +236,8 @@ export class CategoriesRepository {
   static async createSubcategory(
     subcategoryData: Omit<Subcategory, 'id' | 'createdAt' | 'updatedAt'>
   ): Promise<string> {
-    const response = await fetch('/api/categories/subcategories', {
+    const response = await apiFetch('/api/categories/subcategories', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(subcategoryData),
     });
     const result = await response.json();
@@ -254,9 +253,8 @@ export class CategoriesRepository {
     categoryId: string,
     updates: Partial<Pick<Category, 'name' | 'order' | 'isActive'>>
   ): Promise<void> {
-    const response = await fetch('/api/categories', {
+    const response = await apiFetch('/api/categories', {
       method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ id: categoryId, ...updates }),
     });
     const result = await response.json();
@@ -271,9 +269,8 @@ export class CategoriesRepository {
     subcategoryId: string,
     updates: Partial<Pick<Subcategory, 'name' | 'order' | 'isActive'>>
   ): Promise<void> {
-    const response = await fetch('/api/categories/subcategories', {
+    const response = await apiFetch('/api/categories/subcategories', {
       method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ id: subcategoryId, ...updates }),
     });
     const result = await response.json();
@@ -315,9 +312,8 @@ export class CategoriesRepository {
    * Delegates to server API route (firebase-admin) for the write.
    */
   static async deactivateCategory(categoryId: string): Promise<void> {
-    const response = await fetch('/api/categories', {
+    const response = await apiFetch('/api/categories', {
       method: 'DELETE',
-      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ id: categoryId }),
     });
     const result = await response.json();
@@ -329,9 +325,8 @@ export class CategoriesRepository {
    * Delegates to server API route (firebase-admin) for the write.
    */
   static async deactivateSubcategory(subcategoryId: string): Promise<void> {
-    const response = await fetch('/api/categories/subcategories', {
+    const response = await apiFetch('/api/categories/subcategories', {
       method: 'DELETE',
-      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ id: subcategoryId }),
     });
     const result = await response.json();

--- a/src/lib/db/collections.ts
+++ b/src/lib/db/collections.ts
@@ -25,6 +25,7 @@ export const COLLECTIONS = {
   AMMUNITION_REPORTS: 'ammunitionReports',
   AMMUNITION_REPORT_REQUESTS: 'ammunitionReportRequests',
   SYSTEM_CONFIG: 'systemConfig',
+  PERMISSION_GRANTS: 'permissionGrants',
 } as const;
 
 export type CollectionName = typeof COLLECTIONS[keyof typeof COLLECTIONS];

--- a/src/lib/db/server/auth.ts
+++ b/src/lib/db/server/auth.ts
@@ -1,0 +1,75 @@
+import { NextResponse } from 'next/server';
+import { getAdminAuth, getAdminDb } from '../admin';
+import { COLLECTIONS } from '../collections';
+import { UserType } from '@/types/user';
+import type { ApiActor } from './policyHelpers';
+import { getActiveGrants } from './permissionGrantsService';
+
+export class AuthError extends Error {
+  constructor(message: string, public readonly status: 401 | 403) {
+    super(message);
+    this.name = 'AuthError';
+  }
+}
+
+/**
+ * Verifies the request's bearer token and returns a server-trusted ApiActor.
+ * userType, teamId, displayName come from the Firestore users doc — never
+ * from the request body — so the actor cannot be forged.
+ */
+export async function getActorFromRequest(request: Request): Promise<ApiActor> {
+  const header = request.headers.get('authorization') ?? request.headers.get('Authorization');
+  if (!header || !header.startsWith('Bearer ')) {
+    throw new AuthError('Missing or malformed Authorization header', 401);
+  }
+  const idToken = header.slice('Bearer '.length).trim();
+  if (!idToken) {
+    throw new AuthError('Empty bearer token', 401);
+  }
+
+  let uid: string;
+  try {
+    const decoded = await getAdminAuth().verifyIdToken(idToken, true);
+    uid = decoded.uid;
+  } catch {
+    throw new AuthError('Invalid or expired token', 401);
+  }
+
+  const snap = await getAdminDb().collection(COLLECTIONS.USERS).doc(uid).get();
+  if (!snap.exists) {
+    throw new AuthError('User profile not found', 403);
+  }
+  const data = snap.data() ?? {};
+  if (!data.userType) {
+    throw new AuthError('User profile missing userType', 403);
+  }
+
+  const grants = await getActiveGrants(uid);
+
+  return {
+    uid,
+    userType: data.userType as UserType,
+    grants,
+    ...(data.teamId ? { teamId: data.teamId as string } : {}),
+    ...(data.displayName ? { displayName: data.displayName as string } : {}),
+  };
+}
+
+/**
+ * Convenience wrapper for API routes. Returns either the verified actor or
+ * a NextResponse that the route can return immediately. Use:
+ *
+ *   const actorOrError = await getActorOrError(request);
+ *   if (actorOrError instanceof NextResponse) return actorOrError;
+ *   const actor = actorOrError;
+ */
+export async function getActorOrError(request: Request): Promise<ApiActor | NextResponse> {
+  try {
+    return await getActorFromRequest(request);
+  } catch (e) {
+    if (e instanceof AuthError) {
+      return NextResponse.json({ success: false, error: e.message }, { status: e.status });
+    }
+    throw e;
+  }
+}

--- a/src/lib/db/server/permissionGrantsService.ts
+++ b/src/lib/db/server/permissionGrantsService.ts
@@ -1,0 +1,15 @@
+import type { ActiveGrant } from '@/types/permissionGrant';
+
+/**
+ * Returns the active, non-expired grants for the given user. The full
+ * implementation queries `permissionGrants` filtered by status === 'active'
+ * AND expiresAtMs > now. Until the grants-issuance PR ships, this returns an
+ * empty list, which means policy helpers fall through to base userType.
+ *
+ * The empty stub keeps the rest of the auth pipeline grant-aware so the
+ * issuance PR only needs to fill in the query — no callsite churn.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export async function getActiveGrants(_uid: string): Promise<ActiveGrant[]> {
+  return [];
+}

--- a/src/lib/db/server/policyHelpers.ts
+++ b/src/lib/db/server/policyHelpers.ts
@@ -1,18 +1,19 @@
 /**
  * Server-side helpers that wrap equipmentPolicy for API-route consumption.
- * The policy module accepts EnhancedAuthUser; API routes receive an "actor"
- * payload from the client which we lift into that shape. Token verification
- * is not yet wired up (tracked in docs/spec/firestore-refactor.md as a gap).
+ * The policy module accepts EnhancedAuthUser; ApiActor is the verified
+ * server-side identity built by getActorFromRequest in ./auth.ts.
  */
 import { getAdminDb } from '../admin';
 import { COLLECTIONS } from '../collections';
 import type { Equipment } from '@/types/equipment';
 import type { EnhancedAuthUser } from '@/types/user';
 import { UserType } from '@/types/user';
+import type { ActiveGrant } from '@/types/permissionGrant';
 
 export interface ApiActor {
   uid: string;
   userType: UserType;
+  grants?: ActiveGrant[];
   teamId?: string;
   displayName?: string;
 }
@@ -21,23 +22,9 @@ export function actorToAuthUser(actor: ApiActor): EnhancedAuthUser {
   return {
     uid: actor.uid,
     userType: actor.userType,
+    grants: actor.grants ?? [],
     teamId: actor.teamId,
     displayName: actor.displayName,
-  };
-}
-
-export function validateActor(actor: unknown): ApiActor {
-  if (!actor || typeof actor !== 'object') {
-    throw new Error('actor is required');
-  }
-  const a = actor as Partial<ApiActor>;
-  if (!a.uid) throw new Error('actor.uid is required');
-  if (!a.userType) throw new Error('actor.userType is required');
-  return {
-    uid: a.uid,
-    userType: a.userType as UserType,
-    ...(a.teamId ? { teamId: a.teamId } : {}),
-    ...(a.displayName ? { displayName: a.displayName } : {}),
   };
 }
 

--- a/src/lib/equipmentDraftService.ts
+++ b/src/lib/equipmentDraftService.ts
@@ -13,6 +13,7 @@ import {
   getDoc,
 } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
+import { apiFetch } from '@/lib/apiFetch';
 import { COLLECTIONS } from '@/lib/db/collections';
 import {
   EquipmentDraft,
@@ -20,7 +21,6 @@ import {
 } from '@/types/equipment';
 
 interface CreateDraftArgs {
-  userId: string;
   templateRequestId?: string;
   serialNumber?: string;
   photoUrl?: string;
@@ -30,9 +30,8 @@ interface CreateDraftArgs {
 }
 
 export async function createEquipmentDraft(args: CreateDraftArgs): Promise<string> {
-  const response = await fetch('/api/equipment-drafts', {
+  const response = await apiFetch('/api/equipment-drafts', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(args),
   });
   const result = await response.json();
@@ -53,9 +52,8 @@ interface UpdateDraftArgs {
 }
 
 export async function updateEquipmentDraft(args: UpdateDraftArgs): Promise<void> {
-  const response = await fetch('/api/equipment-drafts', {
+  const response = await apiFetch('/api/equipment-drafts', {
     method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(args),
   });
   const result = await response.json();
@@ -63,9 +61,8 @@ export async function updateEquipmentDraft(args: UpdateDraftArgs): Promise<void>
 }
 
 export async function deleteEquipmentDraft(draftId: string): Promise<void> {
-  const response = await fetch('/api/equipment-drafts', {
+  const response = await apiFetch('/api/equipment-drafts', {
     method: 'DELETE',
-    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ draftId }),
   });
   const result = await response.json();

--- a/src/lib/equipmentPolicy.ts
+++ b/src/lib/equipmentPolicy.ts
@@ -13,17 +13,61 @@
  *
  * Self/team semantics:
  *   isSelf      — user is the signer OR the current holder of the item
- *   isInTeam    — user's teamId equals holder's or signer's teamId
+ *   isInTeam    — user's teamId equals holder's or signer's teamId, OR an
+ *                 active permission grant scope-matches one of those teams
  *   isAll       — manager/admin level; item scope is irrelevant
+ *
+ * Time-limited grants:
+ *   A grant says "user X has role R within scope S until date D". The role
+ *   classifiers below honor active grants when a relevant scope is provided.
+ *   A scope='all' grant counts everywhere; a scope='team' grant counts only
+ *   when the action's team scope matches.
  */
 
 import type { Equipment } from '@/types/equipment';
 import type { EnhancedAuthUser } from '@/types/user';
 import { UserType } from '@/types/user';
+import type { ActiveGrant } from '@/types/permissionGrant';
 
 export interface EquipmentActionContext {
   user: EnhancedAuthUser;
   equipment: Equipment;
+}
+
+// ---------- Internal: rank + grant scope ----------
+
+const ROLE_RANK: Record<UserType, number> = {
+  [UserType.USER]: 1,
+  [UserType.TEAM_LEADER]: 2,
+  [UserType.MANAGER]: 3,
+  [UserType.SYSTEM_MANAGER]: 3,
+  [UserType.ADMIN]: 4,
+};
+
+export function roleRank(role: UserType | null | undefined): number {
+  if (!role) return 0;
+  return ROLE_RANK[role] ?? 0;
+}
+
+function asTeamList(scope: string | string[] | undefined): string[] | undefined {
+  if (scope === undefined) return undefined;
+  return Array.isArray(scope) ? scope : [scope];
+}
+
+export function grantCoversScope(grant: ActiveGrant, scopeTeamIds?: string[]): boolean {
+  if (grant.scope === 'all') return true;
+  if (!scopeTeamIds || scopeTeamIds.length === 0) return false;
+  return !!grant.scopeTeamId && scopeTeamIds.includes(grant.scopeTeamId);
+}
+
+function hasGrantOfRank(
+  user: EnhancedAuthUser,
+  minRank: number,
+  scopeTeamIds?: string[]
+): boolean {
+  return (user.grants ?? []).some(
+    (g) => roleRank(g.grantedRole) >= minRank && grantCoversScope(g, scopeTeamIds)
+  );
 }
 
 // ---------- Role classifiers ----------
@@ -32,16 +76,20 @@ export function isAdmin(user: EnhancedAuthUser): boolean {
   return user.userType === UserType.ADMIN;
 }
 
-export function isManagerOrAbove(user: EnhancedAuthUser): boolean {
-  return (
-    user.userType === UserType.ADMIN ||
-    user.userType === UserType.SYSTEM_MANAGER ||
-    user.userType === UserType.MANAGER
-  );
+export function isManagerOrAbove(
+  user: EnhancedAuthUser,
+  scopeTeamId?: string | string[]
+): boolean {
+  if (roleRank(user.userType) >= roleRank(UserType.MANAGER)) return true;
+  return hasGrantOfRank(user, roleRank(UserType.MANAGER), asTeamList(scopeTeamId));
 }
 
-export function isTeamLeaderOrAbove(user: EnhancedAuthUser): boolean {
-  return isManagerOrAbove(user) || user.userType === UserType.TEAM_LEADER;
+export function isTeamLeaderOrAbove(
+  user: EnhancedAuthUser,
+  scopeTeamId?: string | string[]
+): boolean {
+  if (roleRank(user.userType) >= roleRank(UserType.TEAM_LEADER)) return true;
+  return hasGrantOfRank(user, roleRank(UserType.TEAM_LEADER), asTeamList(scopeTeamId));
 }
 
 // ---------- Scope helpers ----------
@@ -58,23 +106,25 @@ export function isSelf(ctx: EquipmentActionContext): boolean {
   return isSigner(ctx) || isHolder(ctx);
 }
 
+/**
+ * True if the user's base teamId matches the equipment's holder or signer
+ * team, OR if an active permission grant scope-matches one of those teams.
+ */
 export function isInTeam(ctx: EquipmentActionContext): boolean {
-  if (!ctx.user.teamId) return false;
-  return (
-    ctx.user.teamId === ctx.equipment.holderTeamId ||
-    ctx.user.teamId === ctx.equipment.signerTeamId
+  const equipmentTeams = [ctx.equipment.holderTeamId, ctx.equipment.signerTeamId].filter(
+    (t): t is string => !!t
   );
+  if (ctx.user.teamId && equipmentTeams.includes(ctx.user.teamId)) return true;
+  return (ctx.user.grants ?? []).some((g) => grantCoversScope(g, equipmentTeams));
 }
 
 // ---------- Visibility ----------
 
-/**
- * Can the user see this item at all?
- *  - Manager+ sees everything.
- *  - TL + user see items in their team or their own (signer or holder).
- */
 export function canView(ctx: EquipmentActionContext): boolean {
-  if (isManagerOrAbove(ctx.user)) return true;
+  const equipmentTeams = [ctx.equipment.holderTeamId, ctx.equipment.signerTeamId].filter(
+    (t): t is string => !!t
+  );
+  if (isManagerOrAbove(ctx.user, equipmentTeams)) return true;
   if (isSelf(ctx)) return true;
   if (isInTeam(ctx)) return true;
   return false;
@@ -82,7 +132,6 @@ export function canView(ctx: EquipmentActionContext): boolean {
 
 // ---------- Sign-up ----------
 
-/** Anyone authenticated can sign up new equipment (subject to template availability). */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function canAddEquipment(_user: EnhancedAuthUser): boolean {
   return true;
@@ -90,103 +139,70 @@ export function canAddEquipment(_user: EnhancedAuthUser): boolean {
 
 // ---------- Report (possession check) ----------
 
-/**
- * Who can submit a report on this item?
- *  - The signer or holder always.
- *  - Manager+ on any item.
- *  - TL on items in their team.
- */
 export function canReport(ctx: EquipmentActionContext): boolean {
-  if (isManagerOrAbove(ctx.user)) return true;
+  const equipmentTeams = [ctx.equipment.holderTeamId, ctx.equipment.signerTeamId].filter(
+    (t): t is string => !!t
+  );
+  if (isManagerOrAbove(ctx.user, equipmentTeams)) return true;
   if (isSelf(ctx)) return true;
-  if (user_isTeamLeader(ctx.user) && isInTeam(ctx)) return true;
+  if (isTeamLeaderOrAbove(ctx.user, equipmentTeams) && isInTeam(ctx)) return true;
   return false;
 }
 
-/** Only privileged users can skip the photo during report. */
 export function canReportWithoutPhoto(user: EnhancedAuthUser): boolean {
   return isTeamLeaderOrAbove(user);
 }
 
 // ---------- Retirement ----------
 
-/**
- * Only the signer may initiate retirement of an item. If signer also holds it,
- * the retire is immediate. Otherwise a RetirementRequest is created and the
- * current holder must approve.
- *
- * Non-signer holders cannot retire.
- */
 export function canRetire(ctx: EquipmentActionContext): boolean {
   return isSigner(ctx);
 }
 
-/** Immediate retirement requires signer AND holder to be the same user. */
 export function canRetireImmediately(ctx: EquipmentActionContext): boolean {
   return isSigner(ctx) && isHolder(ctx);
 }
 
 // ---------- Transfer ----------
 
-/**
- * User-initiated transfer. Only the current holder can request a transfer —
- * the signer-but-not-holder case goes through a retirement request instead,
- * because transfer would imply "give it to someone else to hold" which the
- * signer doesn't physically control.
- *
- * Force-transfer (manager path) uses canForceTransfer, not this.
- */
 export function canTransfer(ctx: EquipmentActionContext): boolean {
   return isHolder(ctx);
 }
 
-/**
- * Force-transfer bypasses approval. Only TL within team, or manager+ anywhere.
- */
 export function canForceTransfer(ctx: EquipmentActionContext): boolean {
-  if (isManagerOrAbove(ctx.user)) return true;
-  if (user_isTeamLeader(ctx.user) && isInTeam(ctx)) return true;
+  const equipmentTeams = [ctx.equipment.holderTeamId, ctx.equipment.signerTeamId].filter(
+    (t): t is string => !!t
+  );
+  if (isManagerOrAbove(ctx.user, equipmentTeams)) return true;
+  if (isTeamLeaderOrAbove(ctx.user, equipmentTeams) && isInTeam(ctx)) return true;
   return false;
 }
 
 // ---------- Bulk / management operations ----------
 
-/** Bulk ops (bulk force ops, bulk report, bulk retirement audit) are manager+. */
 export function canBulkOps(user: EnhancedAuthUser): boolean {
   return isManagerOrAbove(user);
 }
 
-/** Approving someone else's retirement-to-army request — manager+ oversight only.
- *  (The primary approver is still the current holder via notification; managers can monitor.) */
 export function canApproveRetirementOversight(user: EnhancedAuthUser): boolean {
   return isManagerOrAbove(user);
 }
 
 // ---------- Templates ----------
 
-/** Managers can create canonical templates directly. */
 export function canCreateCanonicalTemplate(user: EnhancedAuthUser): boolean {
   return isManagerOrAbove(user);
 }
 
-/** Team leaders can propose templates (require manager approval to become canonical). */
 export function canProposeTemplate(user: EnhancedAuthUser): boolean {
   return isTeamLeaderOrAbove(user);
 }
 
-/** Anyone authenticated can request a template they can't find in the list. */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function canRequestTemplate(_user: EnhancedAuthUser): boolean {
   return true;
 }
 
-/** Only managers review & approve pending templates (whether from TL or a regular user). */
 export function canReviewTemplate(user: EnhancedAuthUser): boolean {
   return isManagerOrAbove(user);
-}
-
-// ---------- Internal helpers ----------
-
-function user_isTeamLeader(user: EnhancedAuthUser): boolean {
-  return user.userType === UserType.TEAM_LEADER;
 }

--- a/src/lib/equipmentService.ts
+++ b/src/lib/equipmentService.ts
@@ -5,6 +5,7 @@
  */
 
 import { db, auth } from '@/lib/firebase';
+import { apiFetch } from '@/lib/apiFetch';
 import {
   collection,
   doc,
@@ -28,15 +29,6 @@ import {
   ApprovalDetails,
   TemplateStatus,
 } from '@/types/equipment';
-import { UserType } from '@/types/user';
-
-// Actor context passed to API routes so the server can run equipmentPolicy checks.
-export interface ApiActor {
-  uid: string;
-  userType: UserType;
-  teamId?: string;
-  displayName?: string;
-}
 import { EquipmentTemplate } from '@/data/equipmentTemplates';
 import { 
   addTrackingHistoryEntry, 
@@ -91,9 +83,8 @@ export class EquipmentTypesService {
     equipmentTypeData: Omit<EquipmentType, 'id' | 'createdAt' | 'updatedAt'>
   ): Promise<EquipmentServiceResult> {
     try {
-      const response = await fetch('/api/equipment-templates', {
+      const response = await apiFetch('/api/equipment-templates', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(equipmentTypeData),
       });
       const result = await response.json();
@@ -243,9 +234,8 @@ export class EquipmentTypesService {
     updates: Partial<Omit<EquipmentType, 'id' | 'createdAt' | 'updatedAt'>>
   ): Promise<EquipmentServiceResult> {
     try {
-      const response = await fetch('/api/equipment-templates', {
+      const response = await apiFetch('/api/equipment-templates', {
         method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ id: typeId, ...updates }),
       });
       const result = await response.json();
@@ -319,9 +309,8 @@ export class EquipmentItemsService {
       };
 
       // Create equipment + action log via server API route (firebase-admin transaction)
-      const createResponse = await fetch('/api/equipment', {
+      const createResponse = await apiFetch('/api/equipment', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           equipmentData,
           initialHolderName,
@@ -501,9 +490,8 @@ export class EquipmentItemsService {
       };
 
       // Update via server API route (firebase-admin)
-      const updateResponse = await fetch('/api/equipment', {
+      const updateResponse = await apiFetch('/api/equipment', {
         method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           equipmentId,
           updates,
@@ -541,7 +529,6 @@ export class EquipmentItemsService {
     initialHolderId: string,
     signedBy: string,
     signedById: string,
-    actor: ApiActor,
     notes?: string
   ): Promise<EquipmentServiceResult> {
     try {
@@ -573,11 +560,9 @@ export class EquipmentItemsService {
         };
       });
 
-      const response = await fetch('/api/equipment/batch', {
+      const response = await apiFetch('/api/equipment/batch', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          actor,
           items: payloadItems,
           batchId,
           initialHolderName,
@@ -613,16 +598,13 @@ export class EquipmentItemsService {
   static async reportEquipment(
     equipmentId: string,
     photoUrl: string | null,
-    actor: ApiActor,
     actorName: string,
     note?: string
   ): Promise<EquipmentServiceResult> {
     try {
-      const response = await fetch('/api/equipment/report', {
+      const response = await apiFetch('/api/equipment/report', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          actor,
           equipmentId,
           photoUrl,
           actorName,
@@ -651,15 +633,13 @@ export class EquipmentItemsService {
    */
   static async retireEquipment(
     equipmentId: string,
-    actor: ApiActor,
     actorName: string,
     reason: string
   ): Promise<EquipmentServiceResult> {
     try {
-      const response = await fetch('/api/equipment/retire', {
+      const response = await apiFetch('/api/equipment/retire', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ actor, equipmentId, actorName, reason }),
+        body: JSON.stringify({ equipmentId, actorName, reason }),
       });
       const result = await response.json();
       if (!result.success) {
@@ -726,9 +706,8 @@ export class EquipmentItemsService {
       };
 
       // Transfer via server API route (firebase-admin)
-      const transferResponse = await fetch('/api/equipment/transfer', {
+      const transferResponse = await apiFetch('/api/equipment/transfer', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           equipmentId,
           newHolder,

--- a/src/lib/reportRequestService.ts
+++ b/src/lib/reportRequestService.ts
@@ -11,16 +11,15 @@ import {
   getDocs,
 } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
+import { apiFetch } from '@/lib/apiFetch';
 import { COLLECTIONS } from '@/lib/db/collections';
 import {
   ReportRequestDoc,
   ReportRequestScope,
   ReportRequestStatus,
 } from '@/types/equipment';
-import type { ApiActor } from '@/lib/equipmentService';
 
 interface CreateReportRequestArgs {
-  actor: ApiActor;
   scope: ReportRequestScope;
   targetUserIds: string[];
   targetEquipmentDocIds?: string[];
@@ -32,9 +31,8 @@ interface CreateReportRequestArgs {
 export async function createReportRequest(
   args: CreateReportRequestArgs
 ): Promise<string> {
-  const response = await fetch('/api/report-requests', {
+  const response = await apiFetch('/api/report-requests', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(args),
   });
   const result = await response.json();
@@ -42,14 +40,10 @@ export async function createReportRequest(
   return result.id;
 }
 
-export async function fulfillReportRequest(
-  requestId: string,
-  userId: string
-): Promise<void> {
-  const response = await fetch('/api/report-requests/fulfill', {
+export async function fulfillReportRequest(requestId: string): Promise<void> {
+  const response = await apiFetch('/api/report-requests/fulfill', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ requestId, userId }),
+    body: JSON.stringify({ requestId }),
   });
   const result = await response.json();
   if (!result.success) throw new Error(result.error || 'Failed to fulfill report request');

--- a/src/lib/retirementRequestService.ts
+++ b/src/lib/retirementRequestService.ts
@@ -12,6 +12,7 @@ import {
   getDocs,
 } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
+import { apiFetch } from '@/lib/apiFetch';
 import { COLLECTIONS } from '@/lib/db/collections';
 import {
   RetirementRequestDoc,
@@ -20,16 +21,13 @@ import {
 
 export async function approveRetirementRequest(
   requestId: string,
-  approverUserId: string,
   approverUserName: string,
   note?: string
 ): Promise<void> {
-  const response = await fetch('/api/retirement-requests/approve', {
+  const response = await apiFetch('/api/retirement-requests/approve', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       requestId,
-      approverUserId,
       approverUserName,
       ...(note ? { note } : {}),
     }),
@@ -42,16 +40,13 @@ export async function approveRetirementRequest(
 
 export async function rejectRetirementRequest(
   requestId: string,
-  rejectorUserId: string,
   rejectorUserName: string,
   reason?: string
 ): Promise<void> {
-  const response = await fetch('/api/retirement-requests/reject', {
+  const response = await apiFetch('/api/retirement-requests/reject', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       requestId,
-      rejectorUserId,
       rejectorUserName,
       ...(reason ? { reason } : {}),
     }),

--- a/src/lib/templateRequestService.ts
+++ b/src/lib/templateRequestService.ts
@@ -11,15 +11,14 @@ import {
   getDocs,
 } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
+import { apiFetch } from '@/lib/apiFetch';
 import { COLLECTIONS } from '@/lib/db/collections';
 import {
   EquipmentType,
   TemplateStatus,
 } from '@/types/equipment';
-import type { ApiActor } from '@/lib/equipmentService';
 
 interface ProposeTemplateArgs {
-  actor: ApiActor;
   proposerUserName: string;
   name: string;
   category: string;
@@ -40,9 +39,8 @@ interface ProposeTemplateArgs {
 export async function proposeTemplate(
   args: ProposeTemplateArgs
 ): Promise<{ templateId: string; draftId?: string }> {
-  const response = await fetch('/api/equipment-templates/propose', {
+  const response = await apiFetch('/api/equipment-templates/propose', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(args),
   });
   const result = await response.json();
@@ -51,7 +49,6 @@ export async function proposeTemplate(
 }
 
 interface ApproveTemplateArgs {
-  actor: ApiActor;
   templateId: string;
   approverUserName: string;
   edits?: Partial<{
@@ -67,9 +64,8 @@ interface ApproveTemplateArgs {
 }
 
 export async function approveTemplateRequest(args: ApproveTemplateArgs): Promise<void> {
-  const response = await fetch('/api/equipment-templates/approve', {
+  const response = await apiFetch('/api/equipment-templates/approve', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(args),
   });
   const result = await response.json();
@@ -77,16 +73,14 @@ export async function approveTemplateRequest(args: ApproveTemplateArgs): Promise
 }
 
 interface RejectTemplateArgs {
-  actor: ApiActor;
   templateId: string;
   rejectorUserName: string;
   reason?: string;
 }
 
 export async function rejectTemplateRequest(args: RejectTemplateArgs): Promise<void> {
-  const response = await fetch('/api/equipment-templates/reject', {
+  const response = await apiFetch('/api/equipment-templates/reject', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(args),
   });
   const result = await response.json();

--- a/src/lib/transferRequestService.ts
+++ b/src/lib/transferRequestService.ts
@@ -14,6 +14,7 @@ import {
   orderBy,
 } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
+import { apiFetch } from '@/lib/apiFetch';
 import {
   TransferRequest,
   TransferStatus,
@@ -55,9 +56,8 @@ export async function createTransferRequest(
     );
 
     // Create transfer request via server API route (firebase-admin transaction)
-    const response = await fetch('/api/transfer-requests', {
+    const response = await apiFetch('/api/transfer-requests', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         equipmentDocId, toUserId, toUserName, reason, fromUserId, fromUserName,
         ...(note ? { note } : {}),
@@ -90,11 +90,10 @@ export async function approveTransferRequest(
 ): Promise<void> {
   try {
     // Approve via server API route (firebase-admin transaction)
-    const response = await fetch('/api/transfer-requests/approve', {
+    const response = await apiFetch('/api/transfer-requests/approve', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        transferRequestId, approverUserId, approverUserName,
+        transferRequestId, approverUserName,
         ...(approvalNote ? { approvalNote } : {}),
       }),
     });
@@ -119,11 +118,10 @@ export async function rejectTransferRequest(
 ): Promise<void> {
   try {
     // Reject via server API route (firebase-admin transaction)
-    const response = await fetch('/api/transfer-requests/reject', {
+    const response = await apiFetch('/api/transfer-requests/reject', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        transferRequestId, rejectorUserId, rejectorUserName,
+        transferRequestId, rejectorUserName,
         ...(rejectionReason ? { rejectionReason } : {}),
       }),
     });

--- a/src/lib/userProfileService.ts
+++ b/src/lib/userProfileService.ts
@@ -3,6 +3,8 @@
  * route so rules stay locked and writes remain transactional/audit-friendly.
  */
 
+import { apiFetch } from '@/lib/apiFetch';
+
 export interface ProfileUpdates {
   teamId?: string;
   profileImage?: string;
@@ -10,9 +12,8 @@ export interface ProfileUpdates {
 }
 
 export async function updateUserProfile(uid: string, updates: ProfileUpdates): Promise<void> {
-  const response = await fetch('/api/users/profile', {
+  const response = await apiFetch('/api/users/profile', {
     method: 'PATCH',
-    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ uid, updates }),
   });
   const result = await response.json();

--- a/src/types/permissionGrant.ts
+++ b/src/types/permissionGrant.ts
@@ -1,0 +1,38 @@
+import { UserType } from '@/types/user';
+
+export enum GrantStatus {
+  ACTIVE = 'active',
+  REVOKED = 'revoked',
+}
+
+export type GrantScope = 'all' | 'team';
+
+/**
+ * In-memory shape consumed by policy helpers. expiresAt is epoch milliseconds
+ * to keep the type usable on both client and server without firebase-admin /
+ * firebase Timestamp version mismatch.
+ */
+export interface ActiveGrant {
+  id: string;
+  grantedRole: UserType;
+  scope: GrantScope;
+  scopeTeamId?: string;
+  expiresAtMs: number;
+}
+
+/**
+ * Firestore document shape for permissionGrants/{grantId}.
+ * Persisted by the future grants-issuance PR; the loader converts to ActiveGrant.
+ */
+export interface PermissionGrant {
+  id: string;
+  userId: string;
+  grantedRole: UserType;
+  scope: GrantScope;
+  scopeTeamId?: string;
+  issuedBy: string;
+  issuedAtMs: number;
+  expiresAtMs: number;
+  reason: string;
+  status: GrantStatus;
+}

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -4,6 +4,7 @@
 
 import { Timestamp } from 'firebase/firestore';
 import { UserRole } from '@/types/equipment';
+import type { ActiveGrant } from '@/types/permissionGrant';
 
 /**
  * User type enum for high-level categorization
@@ -58,6 +59,10 @@ export interface EnhancedAuthUser {
 
   // Team assignment (used by equipment scope queries)
   teamId?: string;
+
+  // Active permission grants (temporary role bumps). Server-loaded only;
+  // client-side EnhancedAuthUser instances leave this undefined.
+  grants?: ActiveGrant[];
 
   // Communication preferences
   communicationPreferences?: CommunicationPreferences;


### PR DESCRIPTION
All 34 non-public API routes now verify the request's bearer token via getAdminAuth().verifyIdToken() and load the actor identity (uid, userType, teamId, displayName) from Firestore — body-supplied "actor" payloads are no longer trusted, closing the privilege-escalation hole where any signed-in user could submit `actor: { userType: 'admin' }` and bypass every policy gate.

Server foundation:
- src/lib/db/server/auth.ts — getActorFromRequest, AuthError, getActorOrError
- src/lib/db/server/permissionGrantsService.ts — stub getActiveGrants → []
- src/types/permissionGrant.ts — ActiveGrant, PermissionGrant, GrantStatus
- ApiActor.grants threaded through; equipmentPolicy role classifiers gain optional scopeTeamId and consult active grants. Plumbing only — issuance UI ships in a follow-up PR.

Client:
- src/lib/apiFetch.ts — fetch wrapper that attaches Authorization: Bearer.
- 21 service/hook/component call sites migrated; "actor" dropped from bodies.
- Three public auth routes (register, verify-military-id, check-email-verified) and /api/sheets keep plain fetch.

Hardening on previously-unguarded routes:
- /api/users/profile — own profile only, or admin/system_manager.
- /api/authorized-personnel{,/bulk} — admin/system_manager only.
- /api/notifications/read POST — uses verified uid, not body.userId.
- /api/transfer-requests, /api/retirement-requests, /api/report-requests/fulfill, /api/actions-log — actor identity fields sourced from token, body fields no longer trusted.

Firestore rules: permissionGrants block added (read-own, write false).

Tests: getActorFromRequest happy + sad paths (missing/malformed/expired token, unknown profile, missing userType, success), actorToAuthUser grant forwarding, serverForceOps input validation. All 40 covered tests pass.

Build clean; lint clean; npx tsc --noEmit clean (only pre-existing RegistrationStepDots and firebasePhoneAuth test errors remain, unrelated).