### PR TITLE
feat(permissions): add time-limited grants UI, issuance + revocation API

### DIFF
--- a/docs/codebase/src/app/api/permission-grants/README.md
+++ b/docs/codebase/src/app/api/permission-grants/README.md
@@ -1,0 +1,47 @@
+# /api/permission-grants
+
+Bearer-token-gated CRUD for `permissionGrants/{grantId}`. Issuance and
+revocation are restricted to ADMIN + SYSTEM_MANAGER; everyone is denied at
+401 if they reach the route without a verified token.
+
+## Routes
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET`  | `/api/permission-grants?status=&userId=&includeExpired=` | List grants newest first (max 200). ADMIN/SM only. |
+| `POST` | `/api/permission-grants` | Issue a new grant (delegates to `serverIssueGrant`). |
+| `POST` | `/api/permission-grants/{id}/revoke` | Revoke an active grant (delegates to `serverRevokeGrant`). |
+
+## Request shapes
+
+### POST /api/permission-grants
+```ts
+{
+  userId: string;
+  userDisplayName?: string;
+  grantedRole: 'team_leader' | 'manager' | 'system_manager';
+  scope: 'all' | 'team';
+  scopeTeamId?: string;       // required when scope === 'team'
+  durationMs?: number;        // OR
+  expiresAtMs?: number;       // exact epoch ms
+  reason: string;
+}
+```
+
+Returns `{ success: true, id }` or a `GrantValidationError`-mapped 4xx.
+
+### POST /api/permission-grants/{id}/revoke
+Optional body `{ reason?: string }`. Returns `{ success: true }`.
+
+## Auth
+
+All three routes use `getActorOrError(request)` — bearer token required. The
+service layer enforces the ADMIN/SM gate and returns 403 from inside
+`GrantValidationError` for non-issuers; the GET route additionally checks
+`isGrantIssuer` itself before listing.
+
+## Error mapping
+
+`GrantValidationError` carries a numeric `status` (400 for input issues, 403
+for authorization issues). Both routes catch it and return `NextResponse.json`
+with that status. Anything else falls through to a 500.

--- a/docs/codebase/src/lib/db/server/permissionGrantsService.md
+++ b/docs/codebase/src/lib/db/server/permissionGrantsService.md
@@ -1,0 +1,46 @@
+# db/server/permissionGrantsService.ts
+
+**File:** `src/lib/db/server/permissionGrantsService.ts`
+**Status:** Active
+
+## Purpose
+
+Server-side persistence and lifecycle for time-limited permission grants. A
+grant elevates a single user's effective role within a scope (a single team or
+all teams) until a hard expiry. Issuance is gated to ADMIN and SYSTEM_MANAGER;
+duration is capped at 7 days. The active-grant loader is consumed by
+`auth.getActorFromRequest` to make the verified `ApiActor` grant-aware before
+policy checks run.
+
+## Exports
+
+| Export | Purpose |
+|--------|---------|
+| `getActiveGrants(uid)` | Returns active, non-expired grants for one user — drives `equipmentPolicy` elevation. |
+| `serverIssueGrant(input)` | Validates issuer, role, scope, reason, and duration; persists a new grant; notifies the grantee. Throws `GrantValidationError`. |
+| `serverRevokeGrant(input)` | Flips status to `revoked` and stamps `revokedBy/revokedAtMs/revokeReason`. ADMIN+SM only. |
+| `serverListGrants(filter)` | Admin list endpoint backing — newest first, up to 200 records, with computed `isExpired` flag. |
+| `isGrantIssuer(userType)` | Boolean classifier: ADMIN or SYSTEM_MANAGER only. |
+| `GrantValidationError` | Named error with `status` (400 or 403) for API routes to map cleanly. |
+
+## Firebase Operations
+
+- `permissionGrants/{grantId}` — `set` on issue, `update` on revoke, `where`-filtered queries on read/list.
+- `notifications` — one create per issued grant (failures are swallowed; the grant write is the source of truth).
+
+## Validation rules baked into `serverIssueGrant`
+
+- Issuer must be ADMIN or SYSTEM_MANAGER.
+- Issuer cannot grant a role to themselves.
+- `grantedRole` must be one of TEAM_LEADER, MANAGER, SYSTEM_MANAGER. ADMIN bumps are not allowed via grants.
+- `scope === 'team'` requires `scopeTeamId`; `scope === 'all'` requires the issuer be ADMIN.
+- `reason` is required (trimmed, non-empty).
+- `expiresAtMs` must be a future timestamp at most 7 days out.
+- An overlapping active grant for the same user + role + scope is rejected (idempotent UX — no silent duplicates).
+
+## Notes
+
+- Audit fields live on the grant doc itself (`issuedBy/issuedAtMs/revokedBy/revokedAtMs/revokeReason`). There is **no** `actionsLog` entry — `actionsLog` is equipment-coupled.
+- `expiresAtMs` is epoch milliseconds (not Firestore Timestamp) so the policy layer can use it on both client and server without mismatched Timestamp types.
+- "Expired" status is computed at read time by comparing `expiresAtMs` to `Date.now()`. The stored `status` only flips from `active` to `revoked` via `serverRevokeGrant`.
+- `getActiveGrants('')` returns `[]` defensively — the caller in `auth.ts` always passes a verified uid, but the cheap guard saves a Firestore round-trip if anything ever changes.

--- a/docs/firebase-operations.md
+++ b/docs/firebase-operations.md
@@ -34,6 +34,7 @@ All Firestore operations in the codebase, organized by collection.
 | `ammunitionReports` | `COLLECTIONS.AMMUNITION_REPORTS = 'ammunitionReports'` | `src/lib/db/collections.ts` (Phase 4 — server: `src/lib/db/server/ammunitionReportsService.ts`; client: `src/lib/ammunition/reportsService.ts`) |
 | `ammunitionReportRequests` | `COLLECTIONS.AMMUNITION_REPORT_REQUESTS = 'ammunitionReportRequests'` | `src/lib/db/collections.ts` (Phase 6 — server: `src/lib/db/server/ammunitionReportRequestService.ts`) |
 | `systemConfig` | `COLLECTIONS.SYSTEM_CONFIG = 'systemConfig'` | `src/lib/db/collections.ts` — single doc `main`. Fields: `ammoNotificationRecipientUserId` (Phase 1 ammunition), `teams: string[]` (registration team dropdown source — admin tab editable). |
+| `permissionGrants` | `COLLECTIONS.PERMISSION_GRANTS = 'permissionGrants'` | `src/lib/db/collections.ts` — time-limited role bumps. Server-only writes via `src/lib/db/server/permissionGrantsService.ts`; clients read via `/api/permission-grants` GET. Rule allows users to read their own grants. |
 
 ---
 

--- a/docs/spec/management.md
+++ b/docs/spec/management.md
@@ -54,6 +54,14 @@ A role-gated management dashboard at `/management` with a sidebar navigation and
 - View and edit user role assignments
 **Status:** 🔄 Partial — UI exists, write operations may be incomplete
 
+### Permission Grants Tab (`PermissionGrantsTab.tsx`)
+- ADMIN + SYSTEM_MANAGER only.
+- List active grants and full history (active / expired / revoked) with `isExpired` and effective-status badges.
+- Issue a time-limited role bump (TEAM_LEADER / MANAGER / SYSTEM_MANAGER), scoped to a single team or to all teams. Duration capped at 7 days.
+- Revoke an active grant with optional reason.
+- Backed by `usePermissionGrants` → `/api/permission-grants` (GET / POST + `/{id}/revoke`). Server logic in `src/lib/db/server/permissionGrantsService.ts`. The grantee is notified on issue.
+**Status:** ✅ Implemented
+
 ### Data Management Tab (`DataManagementTab.tsx`, 138 lines)
 - Import / export data
 - Sync operations

--- a/docs/test-failures-2026-04-29.md
+++ b/docs/test-failures-2026-04-29.md
@@ -1,0 +1,120 @@
+# Test Failure Triage — 2026-04-29
+
+Branch: `feat/permission-grants-ui`
+Run: `npm test`
+Result: **8 suites failed, 15 passed · 58 tests failed, 36 skipped, 451 passed (545 total)**
+
+All 58 failures are **stale tests** lagging behind production refactors. No production bug detected.
+
+---
+
+## Summary by suite
+
+| Suite | Failures | Root cause |
+|---|---:|---|
+| `RegistrationStepDots.test.tsx` | 4 | Old Tailwind colors (`bg-blue-500`, `bg-green-500`, `bg-gray-300`) |
+| `RegistrationSuccessStep.test.tsx` | 3 | Old Tailwind colors (`from-green-600`, `from-green-400`) |
+| `RegistrationForm.test.tsx` | 3 | Old colors (`from-green-600`, `border-red-500`) |
+| `AccountDetailsStep.test.tsx` | 4 | Old colors (`border-red-500`, `bg-gray-800`) |
+| `RegistrationDetailsStep.test.tsx` | 11 | Removed testid `gender-select` (Headless UI Listbox now) + old colors |
+| `PersonalDetailsStep.test.tsx` | 24 | Incomplete `TEXT_CONSTANTS` mock + removed `gender-select` testid |
+| `RegistrationFlow.integration.test.tsx` | 8 | Incomplete `TEXT_CONSTANTS` mock |
+| `adminUtils.test.ts` | 1 | Mocks `writeBatch`, prod now uses `apiFetch('/api/authorized-personnel/bulk')` |
+
+---
+
+## Root causes
+
+### 1. Design-system token migration (15 failures)
+
+Tests assert old Tailwind palette classes. Production migrated to semantic tokens per `tailwind.config.js` and `CLAUDE.md` design rules.
+
+| Old (test expects) | New (component renders) |
+|---|---|
+| `bg-blue-500`, `ring-blue-200` | `bg-primary-500`, `ring-primary-*` |
+| `bg-green-500`, `from-green-600 to-green-700`, `from-green-400 to-green-600` | `bg-success-500`, `from-success-600 to-success-700`, `from-success-400 to-success-600` |
+| `border-red-500` | `border-danger-500` |
+| `bg-gray-300`, `bg-gray-800` | `bg-neutral-300`, `bg-neutral-800` |
+
+**Affected**: `RegistrationStepDots`, `RegistrationSuccessStep`, `RegistrationForm`, `AccountDetailsStep`, parts of `RegistrationDetailsStep`.
+
+**Fix**: replace old class assertions with token-based classes. Per `CLAUDE.md`, design tokens are the source of truth — tests must match.
+
+---
+
+### 2. `TEXT_CONSTANTS` mock missing `REGISTRATION_COMPONENTS` (32 failures)
+
+Production `RegistrationHeader.tsx:38` reads `TEXT_CONSTANTS.REGISTRATION_COMPONENTS.BACK_TO_LOGIN`. Other components read `REGISTRATION_COMPONENTS.ENTER_FIRST_NAME`, etc. Tests mock `@/constants/text` but only stub the `AUTH` namespace, so `REGISTRATION_COMPONENTS` is `undefined` and any property access throws `TypeError: Cannot read properties of undefined`.
+
+Files:
+- `PersonalDetailsStep.test.tsx:15-23`
+- `RegistrationFlow.integration.test.tsx:20-…`
+- (Likely more — audit all `jest.mock('@/constants/text', …)` blocks)
+
+**Fix options**:
+- **A (preferred)**: drop the partial mock — import the real `TEXT_CONSTANTS`. The constants file has no side effects.
+- **B**: extend the mock to include every namespace the component tree touches (`REGISTRATION_COMPONENTS`, `AUTH`, `ARIA_LABELS`, etc.). Brittle — breaks every time a new key is added.
+
+---
+
+### 3. `gender-select` testid removed (~10 failures)
+
+`PersonalDetailsStep` / `RegistrationDetailsStep` now render a Headless UI `<Listbox>` button (`role="listbox" aria-label="מין"`) instead of a native `<select data-testid="gender-select">`. Tests still call `screen.getByTestId('gender-select')` and `userEvent.selectOptions(...)`.
+
+**Fix**: query by role/label and interact via click + option selection:
+```ts
+const genderListbox = screen.getByRole('button', { name: 'מין' });
+await user.click(genderListbox);
+await user.click(screen.getByRole('option', { name: 'זכר' }));
+```
+
+(Headless UI `Listbox` is not a native `<select>` — `selectOptions` does not work.)
+
+---
+
+### 4. `adminUtils.test.ts` — bulk add re-architected (1 failure)
+
+Test: `AdminFirestoreService › addAuthorizedPersonnelBulk › should correctly categorize successful, failed, and duplicate entries`
+
+Production `addAuthorizedPersonnelBulk` (`src/lib/adminUtils.ts:544`) now performs the write through `apiFetch('/api/authorized-personnel/bulk', { method: 'POST', body: … })` instead of a client-side `writeBatch`. Test still mocks `writeBatch` and `doc`, never mocks `apiFetch`, so the fetch call rejects/returns falsy and `successful.length === 0` (expected 1).
+
+**Fix**: mock `@/lib/apiFetch` and have it return a `Response`-like object with `success: true` and no `failedIndices`:
+```ts
+jest.mock('@/lib/apiFetch', () => ({
+  apiFetch: jest.fn().mockResolvedValue({
+    json: async () => ({ success: true, failedIndices: [] }),
+  }),
+}));
+```
+Drop `writeBatch` mock setup from this test — no longer touched.
+
+---
+
+## What needs fixing — checklist
+
+### Tests to update (stale)
+- [ ] `src/components/registration/__tests__/RegistrationStepDots.test.tsx` — swap `blue-500`/`green-500`/`gray-300` → `primary-500`/`success-500`/`neutral-300`
+- [ ] `src/components/registration/__tests__/RegistrationSuccessStep.test.tsx` — swap `from-green-*`/`to-green-*` → `from-success-*`/`to-success-*`; update `.from-green-400.to-green-600` selector to success tokens
+- [ ] `src/components/registration/__tests__/RegistrationForm.test.tsx` — swap `border-red-500` → `border-danger-500`; `from-green-600` → `from-success-600`
+- [ ] `src/components/registration/__tests__/AccountDetailsStep.test.tsx` — swap `border-red-500` → `border-danger-500`; `bg-gray-800` → `bg-neutral-800`
+- [ ] `src/components/registration/__tests__/PersonalDetailsStep.test.tsx` — replace `TEXT_CONSTANTS` partial mock with real import; replace `gender-select` testid + `selectOptions` with Listbox interaction
+- [ ] `src/components/registration/__tests__/RegistrationDetailsStep.test.tsx` — same Listbox migration; same color token swaps
+- [ ] `src/components/registration/__tests__/RegistrationFlow.integration.test.tsx` — replace `TEXT_CONSTANTS` partial mock with real import
+- [ ] `src/lib/__tests__/adminUtils.test.ts` — mock `@/lib/apiFetch` for `addAuthorizedPersonnelBulk`; drop unused `writeBatch` setup in that test
+
+### Production code
+- None. All current behavior is intentional and matches the design-system + API-route migrations already shipped.
+
+---
+
+## Suggested order
+
+1. `adminUtils.test.ts` — single failure, isolated, unblocks confidence in services suite.
+2. Add real-`TEXT_CONSTANTS` mock fix to `PersonalDetailsStep` + `RegistrationFlow.integration` — knocks out 32 failures fast.
+3. Listbox migration in `PersonalDetailsStep` + `RegistrationDetailsStep` — same pattern, copy-paste.
+4. Color token sweep across the four remaining suites — mechanical find/replace.
+
+After each batch, run only the affected suite:
+```bash
+npx jest src/components/registration/__tests__/<file>.test.tsx
+```

--- a/src/app/api/permission-grants/[id]/revoke/route.ts
+++ b/src/app/api/permission-grants/[id]/revoke/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from 'next/server';
+import { getActorOrError } from '@/lib/db/server/auth';
+import {
+  GrantValidationError,
+  serverRevokeGrant,
+} from '@/lib/db/server/permissionGrantsService';
+
+interface RevokeBody {
+  reason?: unknown;
+}
+
+export async function POST(
+  request: Request,
+  context: { params: Promise<{ id: string }> }
+) {
+  try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
+    const actor = actorOrError;
+
+    const { id } = await context.params;
+
+    let body: RevokeBody = {};
+    try {
+      body = (await request.json()) as RevokeBody;
+    } catch {
+      // No body or invalid JSON → treat as empty
+    }
+
+    await serverRevokeGrant({
+      grantId: id,
+      actorUid: actor.uid,
+      actorUserType: actor.userType,
+      ...(actor.displayName ? { actorDisplayName: actor.displayName } : {}),
+      ...(typeof body.reason === 'string' ? { reason: body.reason } : {}),
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    if (error instanceof GrantValidationError) {
+      return NextResponse.json(
+        { success: false, error: error.message },
+        { status: error.status }
+      );
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('[API] permission-grants revoke failed:', message);
+    return NextResponse.json({ success: false, error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/permission-grants/route.ts
+++ b/src/app/api/permission-grants/route.ts
@@ -1,0 +1,131 @@
+import { NextResponse } from 'next/server';
+import { getActorOrError } from '@/lib/db/server/auth';
+import {
+  GrantValidationError,
+  isGrantIssuer,
+  serverIssueGrant,
+  serverListGrants,
+} from '@/lib/db/server/permissionGrantsService';
+import { GrantStatus } from '@/types/permissionGrant';
+import { UserType } from '@/types/user';
+
+export async function GET(request: Request) {
+  try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
+    const actor = actorOrError;
+
+    if (!isGrantIssuer(actor.userType)) {
+      return NextResponse.json(
+        { success: false, error: 'Forbidden: only admin or system manager may list grants' },
+        { status: 403 }
+      );
+    }
+
+    const { searchParams } = new URL(request.url);
+    const status = searchParams.get('status');
+    const userId = searchParams.get('userId');
+    const includeExpired = searchParams.get('includeExpired') === 'true';
+
+    const grants = await serverListGrants({
+      ...(userId ? { userId } : {}),
+      ...(status === GrantStatus.ACTIVE || status === GrantStatus.REVOKED
+        ? { status }
+        : {}),
+      includeExpired,
+    });
+
+    return NextResponse.json({ success: true, grants });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('[API] permission-grants GET failed:', message);
+    return NextResponse.json({ success: false, error: message }, { status: 500 });
+  }
+}
+
+interface CreateBody {
+  userId?: unknown;
+  userDisplayName?: unknown;
+  grantedRole?: unknown;
+  scope?: unknown;
+  scopeTeamId?: unknown;
+  durationMs?: unknown;
+  expiresAtMs?: unknown;
+  reason?: unknown;
+}
+
+export async function POST(request: Request) {
+  try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
+    const actor = actorOrError;
+
+    const body = (await request.json()) as CreateBody;
+
+    if (typeof body.userId !== 'string' || !body.userId) {
+      return NextResponse.json(
+        { success: false, error: 'userId is required' },
+        { status: 400 }
+      );
+    }
+    if (typeof body.grantedRole !== 'string') {
+      return NextResponse.json(
+        { success: false, error: 'grantedRole is required' },
+        { status: 400 }
+      );
+    }
+    if (body.scope !== 'all' && body.scope !== 'team') {
+      return NextResponse.json(
+        { success: false, error: "scope must be 'all' or 'team'" },
+        { status: 400 }
+      );
+    }
+    if (typeof body.reason !== 'string') {
+      return NextResponse.json(
+        { success: false, error: 'reason is required' },
+        { status: 400 }
+      );
+    }
+
+    let expiresAtMs: number;
+    if (typeof body.expiresAtMs === 'number') {
+      expiresAtMs = body.expiresAtMs;
+    } else if (typeof body.durationMs === 'number') {
+      expiresAtMs = Date.now() + body.durationMs;
+    } else {
+      return NextResponse.json(
+        { success: false, error: 'durationMs or expiresAtMs is required' },
+        { status: 400 }
+      );
+    }
+
+    const result = await serverIssueGrant({
+      userId: body.userId,
+      ...(typeof body.userDisplayName === 'string' && body.userDisplayName
+        ? { userDisplayName: body.userDisplayName }
+        : {}),
+      grantedRole: body.grantedRole as UserType,
+      scope: body.scope,
+      ...(body.scope === 'team' && typeof body.scopeTeamId === 'string'
+        ? { scopeTeamId: body.scopeTeamId }
+        : {}),
+      expiresAtMs,
+      reason: body.reason,
+      issuerUid: actor.uid,
+      issuerUserType: actor.userType,
+      ...(actor.displayName ? { issuerDisplayName: actor.displayName } : {}),
+    });
+
+    return NextResponse.json({ success: true, id: result.id });
+  } catch (error) {
+    if (error instanceof GrantValidationError) {
+      return NextResponse.json(
+        { success: false, error: error.message },
+        { status: error.status }
+      );
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('[API] permission-grants POST failed:', message);
+    return NextResponse.json({ success: false, error: message }, { status: 500 });
+  }
+}

--- a/src/components/management/tabs/PermissionGrantsTab.tsx
+++ b/src/components/management/tabs/PermissionGrantsTab.tsx
@@ -1,0 +1,467 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import { KeyRound, Plus, ShieldAlert, X, Trash2, Clock } from 'lucide-react';
+import { useAuth } from '@/contexts/AuthContext';
+import { UserType } from '@/types/user';
+import { GrantStatus, MAX_GRANT_DURATION_MS } from '@/types/permissionGrant';
+import {
+  usePermissionGrants,
+  type PermissionGrantListItem,
+} from '@/hooks/usePermissionGrants';
+import { useSystemConfig } from '@/hooks/useSystemConfig';
+import UserSearchInput from '@/components/users/UserSearchInput';
+import type { UserSearchResult } from '@/lib/userService';
+import { Select } from '@/components/ui';
+
+const ROLE_OPTIONS: { value: UserType; label: string }[] = [
+  { value: UserType.TEAM_LEADER, label: 'מפקד צוות' },
+  { value: UserType.MANAGER, label: 'מנהל' },
+  { value: UserType.SYSTEM_MANAGER, label: 'מנהל מערכת' },
+];
+
+const ROLE_LABEL: Record<string, string> = {
+  [UserType.ADMIN]: 'מנהל ראשי',
+  [UserType.SYSTEM_MANAGER]: 'מנהל מערכת',
+  [UserType.MANAGER]: 'מנהל',
+  [UserType.TEAM_LEADER]: 'מפקד צוות',
+  [UserType.USER]: 'משתמש',
+};
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+const MAX_DAYS = Math.floor(MAX_GRANT_DURATION_MS / ONE_DAY_MS);
+
+export default function PermissionGrantsTab() {
+  const { enhancedUser } = useAuth();
+  const { config } = useSystemConfig();
+  const { grants, isLoading, error, issue, revoke } = usePermissionGrants();
+  const [showIssue, setShowIssue] = useState(false);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [toast, setToast] = useState<{ kind: 'success' | 'error'; message: string } | null>(
+    null
+  );
+
+  const isIssuer =
+    enhancedUser?.userType === UserType.ADMIN ||
+    enhancedUser?.userType === UserType.SYSTEM_MANAGER;
+
+  const showToast = (kind: 'success' | 'error', message: string) => {
+    setToast({ kind, message });
+    setTimeout(() => setToast(null), 3500);
+  };
+
+  const handleRevoke = async (grant: PermissionGrantListItem) => {
+    if (!confirm(`לבטל הענקה ל-${grant.userDisplayName || grant.userId}?`)) return;
+    setBusy(grant.id);
+    const result = await revoke(grant.id);
+    setBusy(null);
+    showToast(result.ok ? 'success' : 'error', result.ok ? 'הענקה בוטלה' : result.error || 'ביטול נכשל');
+  };
+
+  return (
+    <div className="space-y-6">
+      {!isIssuer && (
+        <div className="flex items-start gap-2 p-4 rounded-lg bg-warning-50 border border-warning-200 text-warning-800 text-sm">
+          <ShieldAlert className="w-4 h-4 mt-0.5 shrink-0" />
+          <span>צפייה בלבד — רק מנהל או מנהל מערכת יכולים להעניק או לבטל תפקידים.</span>
+        </div>
+      )}
+
+      {error && (
+        <div className="p-3 rounded-lg bg-danger-50 border border-danger-200 text-danger-800 text-sm">
+          {error}
+        </div>
+      )}
+
+      <div className="bg-white rounded-lg border border-neutral-200 p-6">
+        <div className="flex items-center justify-between gap-3 mb-4">
+          <div className="flex items-center gap-2">
+            <KeyRound className="w-5 h-5 text-primary-600" />
+            <h4 className="text-lg font-medium text-neutral-900">הענקות תפקיד פעילות והיסטוריה</h4>
+          </div>
+          {isIssuer && (
+            <button
+              type="button"
+              onClick={() => setShowIssue(true)}
+              className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-primary-600 hover:bg-primary-700 text-white text-sm font-medium transition-colors"
+            >
+              <Plus className="w-4 h-4" />
+              הענקה חדשה
+            </button>
+          )}
+        </div>
+
+        {isLoading ? (
+          <div className="h-24 rounded-lg bg-neutral-100 animate-pulse" />
+        ) : grants.length === 0 ? (
+          <p className="text-sm text-neutral-500 text-center py-6">אין הענקות פעילות.</p>
+        ) : (
+          <GrantsTable
+            grants={grants}
+            isIssuer={!!isIssuer}
+            busyId={busy}
+            onRevoke={handleRevoke}
+          />
+        )}
+      </div>
+
+      {showIssue && isIssuer && (
+        <IssueGrantModal
+          teams={config?.teams ?? []}
+          onClose={() => setShowIssue(false)}
+          onSubmit={async (payload) => {
+            const result = await issue(payload);
+            if (result.ok) {
+              showToast('success', 'הענקה נוצרה');
+              setShowIssue(false);
+            } else {
+              showToast('error', result.error || 'יצירת הענקה נכשלה');
+            }
+            return result.ok;
+          }}
+        />
+      )}
+
+      {toast && (
+        <div
+          className={`fixed bottom-4 left-1/2 -translate-x-1/2 z-50 px-4 py-2 rounded-lg shadow-lg text-sm ${
+            toast.kind === 'success'
+              ? 'bg-success-100 text-success-800 border border-success-200'
+              : 'bg-danger-100 text-danger-800 border border-danger-200'
+          }`}
+        >
+          {toast.message}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface GrantsTableProps {
+  grants: PermissionGrantListItem[];
+  isIssuer: boolean;
+  busyId: string | null;
+  onRevoke: (grant: PermissionGrantListItem) => void;
+}
+
+function GrantsTable({ grants, isIssuer, busyId, onRevoke }: GrantsTableProps) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead className="bg-neutral-50 text-neutral-700">
+          <tr>
+            <Th>משתמש</Th>
+            <Th>תפקיד</Th>
+            <Th>היקף</Th>
+            <Th>פג תוקף</Th>
+            <Th>סטטוס</Th>
+            <Th>סיבה</Th>
+            <Th>הוענק על ידי</Th>
+            {isIssuer && <Th>פעולות</Th>}
+          </tr>
+        </thead>
+        <tbody>
+          {grants.map((g) => (
+            <GrantRow
+              key={g.id}
+              grant={g}
+              isIssuer={isIssuer}
+              isBusy={busyId === g.id}
+              onRevoke={onRevoke}
+            />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function Th({ children }: { children: React.ReactNode }) {
+  return <th className="text-start px-3 py-2 font-medium border-b border-neutral-200">{children}</th>;
+}
+
+function GrantRow({
+  grant,
+  isIssuer,
+  isBusy,
+  onRevoke,
+}: {
+  grant: PermissionGrantListItem;
+  isIssuer: boolean;
+  isBusy: boolean;
+  onRevoke: (g: PermissionGrantListItem) => void;
+}) {
+  const status = effectiveStatus(grant);
+  const expiresLabel = new Date(grant.expiresAtMs).toLocaleString('he-IL');
+  const canRevoke = isIssuer && grant.status === GrantStatus.ACTIVE && !grant.isExpired;
+
+  return (
+    <tr className="border-b border-neutral-100 last:border-0">
+      <Td>{grant.userDisplayName || grant.userId}</Td>
+      <Td>{ROLE_LABEL[grant.grantedRole] ?? grant.grantedRole}</Td>
+      <Td>{grant.scope === 'all' ? 'כלל הצוותים' : `צוות ${grant.scopeTeamId ?? ''}`}</Td>
+      <Td>
+        <span className="inline-flex items-center gap-1">
+          <Clock className="w-3.5 h-3.5 text-neutral-400" />
+          {expiresLabel}
+        </span>
+      </Td>
+      <Td>
+        <StatusBadge status={status} />
+      </Td>
+      <Td className="max-w-[200px] truncate" title={grant.reason}>
+        {grant.reason}
+      </Td>
+      <Td>{grant.issuedByDisplayName || grant.issuedBy}</Td>
+      {isIssuer && (
+        <Td>
+          {canRevoke && (
+            <button
+              type="button"
+              disabled={isBusy}
+              onClick={() => onRevoke(grant)}
+              className="inline-flex items-center gap-1 px-2 py-1 rounded-md text-danger-700 hover:bg-danger-50 disabled:opacity-50 transition-colors"
+            >
+              <Trash2 className="w-4 h-4" />
+              ביטול
+            </button>
+          )}
+        </Td>
+      )}
+    </tr>
+  );
+}
+
+function Td({ children, className, title }: { children: React.ReactNode; className?: string; title?: string }) {
+  return (
+    <td className={`px-3 py-2 align-top ${className ?? ''}`} title={title}>
+      {children}
+    </td>
+  );
+}
+
+type EffectiveStatus = 'active' | 'expired' | 'revoked';
+
+function effectiveStatus(grant: PermissionGrantListItem): EffectiveStatus {
+  if (grant.status === GrantStatus.REVOKED) return 'revoked';
+  if (grant.isExpired) return 'expired';
+  return 'active';
+}
+
+function StatusBadge({ status }: { status: EffectiveStatus }) {
+  const map: Record<EffectiveStatus, { text: string; cls: string }> = {
+    active: { text: 'פעיל', cls: 'bg-success-100 text-success-800 border-success-200' },
+    expired: { text: 'פג תוקף', cls: 'bg-neutral-100 text-neutral-700 border-neutral-200' },
+    revoked: { text: 'בוטל', cls: 'bg-danger-100 text-danger-800 border-danger-200' },
+  };
+  const { text, cls } = map[status];
+  return (
+    <span className={`inline-flex items-center px-2 py-0.5 text-xs rounded-full border ${cls}`}>
+      {text}
+    </span>
+  );
+}
+
+interface IssueGrantModalProps {
+  teams: string[];
+  onClose: () => void;
+  onSubmit: (payload: {
+    userId: string;
+    userDisplayName?: string;
+    grantedRole: UserType;
+    scope: 'all' | 'team';
+    scopeTeamId?: string;
+    durationMs: number;
+    reason: string;
+  }) => Promise<boolean>;
+}
+
+function IssueGrantModal({ teams, onClose, onSubmit }: IssueGrantModalProps) {
+  const [user, setUser] = useState<UserSearchResult | null>(null);
+  const [role, setRole] = useState<UserType | null>(UserType.TEAM_LEADER);
+  const [scope, setScope] = useState<'all' | 'team'>('team');
+  const [team, setTeam] = useState<string | null>(null);
+  const [days, setDays] = useState<number>(7);
+  const [reason, setReason] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const teamOptions = useMemo(
+    () => teams.map((t) => ({ value: t, label: t })),
+    [teams]
+  );
+
+  const canSubmit =
+    !!user &&
+    !!role &&
+    !!reason.trim() &&
+    days > 0 &&
+    days <= MAX_DAYS &&
+    (scope === 'all' || !!team);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!canSubmit || !user || !role) return;
+    setSubmitting(true);
+    setError(null);
+    const ok = await onSubmit({
+      userId: user.uid,
+      ...(user.displayName ? { userDisplayName: user.displayName } : {}),
+      grantedRole: role,
+      scope,
+      ...(scope === 'team' && team ? { scopeTeamId: team } : {}),
+      durationMs: days * ONE_DAY_MS,
+      reason: reason.trim(),
+    });
+    setSubmitting(false);
+    if (!ok) setError('יצירת הענקה נכשלה. בדוק שאין הענקה כפולה ושהזנה תקינה.');
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white rounded-xl shadow-xl w-full max-w-lg p-6"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-lg font-semibold text-neutral-900">הענקת תפקיד זמני</h3>
+          <button
+            type="button"
+            onClick={onClose}
+            className="p-1 rounded-md text-neutral-500 hover:bg-neutral-100"
+            aria-label="close"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-neutral-700 mb-1">משתמש</label>
+            <UserSearchInput value={user} onChange={setUser} placeholder="חפש משתמש לפי שם או אימייל" />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-neutral-700 mb-1">תפקיד</label>
+            <Select
+              value={role}
+              onChange={(v) => setRole(v as UserType | null)}
+              options={ROLE_OPTIONS}
+              ariaLabel="תפקיד"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-neutral-700 mb-1">היקף</label>
+            <div className="flex gap-2">
+              <ScopeButton active={scope === 'team'} onClick={() => setScope('team')}>
+                צוות יחיד
+              </ScopeButton>
+              <ScopeButton active={scope === 'all'} onClick={() => setScope('all')}>
+                כלל הצוותים
+              </ScopeButton>
+            </div>
+          </div>
+
+          {scope === 'team' && (
+            <div>
+              <label className="block text-sm font-medium text-neutral-700 mb-1">צוות</label>
+              {teamOptions.length === 0 ? (
+                <input
+                  type="text"
+                  value={team ?? ''}
+                  onChange={(e) => setTeam(e.target.value)}
+                  placeholder="הזן מזהה צוות"
+                  className="w-full px-3 py-2 border border-neutral-200 rounded-lg text-sm focus:ring-2 focus:ring-primary-500"
+                />
+              ) : (
+                <Select
+                  value={team}
+                  onChange={(v) => setTeam(v ?? null)}
+                  options={teamOptions}
+                  placeholder="בחר צוות"
+                  ariaLabel="צוות"
+                />
+              )}
+            </div>
+          )}
+
+          <div>
+            <label className="block text-sm font-medium text-neutral-700 mb-1">
+              תוקף (ימים, מקסימום {MAX_DAYS})
+            </label>
+            <input
+              type="number"
+              min={1}
+              max={MAX_DAYS}
+              value={days}
+              onChange={(e) => setDays(Number(e.target.value))}
+              className="w-32 px-3 py-2 border border-neutral-200 rounded-lg text-sm focus:ring-2 focus:ring-primary-500"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-neutral-700 mb-1">סיבה</label>
+            <textarea
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              rows={3}
+              placeholder="לדוגמה: מילוי מקום של מפקד צוות 7 בשבוע 5"
+              className="w-full px-3 py-2 border border-neutral-200 rounded-lg text-sm focus:ring-2 focus:ring-primary-500"
+            />
+          </div>
+
+          {error && (
+            <div className="p-2 rounded-md bg-danger-50 border border-danger-200 text-danger-800 text-sm">
+              {error}
+            </div>
+          )}
+
+          <div className="flex justify-end gap-2 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 rounded-lg text-sm text-neutral-700 hover:bg-neutral-100"
+            >
+              ביטול
+            </button>
+            <button
+              type="submit"
+              disabled={!canSubmit || submitting}
+              className="px-4 py-2 rounded-lg text-sm bg-primary-600 hover:bg-primary-700 disabled:bg-neutral-300 text-white font-medium transition-colors"
+            >
+              {submitting ? 'שומר...' : 'הענק'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+function ScopeButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`px-3 py-1.5 rounded-lg text-sm border transition-colors ${
+        active
+          ? 'bg-primary-600 text-white border-primary-600'
+          : 'bg-white text-neutral-700 border-neutral-200 hover:bg-neutral-50'
+      }`}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/management/tabs/TabContentRenderer.tsx
+++ b/src/components/management/tabs/TabContentRenderer.tsx
@@ -6,6 +6,7 @@ import EmailTab from './EmailTab';
 import UsersTab from './UsersTab';
 import SystemConfigTab from './SystemConfigTab';
 import PermissionsTab from './PermissionsTab';
+import PermissionGrantsTab from './PermissionGrantsTab';
 import AuditLogsTab from './AuditLogsTab';
 import DataManagementTab from './DataManagementTab';
 import TemplatesTab from './TemplatesTab';
@@ -35,6 +36,9 @@ export default function TabContentRenderer({ activeTab, activeTabData }: TabCont
     
     case 'permissions':
       return <PermissionsTab />;
+
+    case 'permission-grants':
+      return <PermissionGrantsTab />;
     
     case 'template-management':
       return <TemplatesTab />;

--- a/src/constants/text.ts
+++ b/src/constants/text.ts
@@ -1000,7 +1000,8 @@ export const TEXT_CONSTANTS = {
       DATA_MANAGEMENT: 'ניהול נתונים',
       AUDIT_LOGS: 'יומני ביקורת',
       SEND_EMAIL: 'שליחת אימייל',
-      AMMUNITION: 'תחמושת'
+      AMMUNITION: 'תחמושת',
+      PERMISSION_GRANTS: 'הענקות תפקיד זמניות'
     },
 
     // Tab Descriptions
@@ -1017,7 +1018,8 @@ export const TEXT_CONSTANTS = {
       DATA_MANAGEMENT: 'גיבוי, שחזור ואחזקת נתונים',
       AUDIT_LOGS: 'מעקב פעילות ויומני מערכת',
       SEND_EMAIL: 'שליחת הודעות אימייל לקבוצות משתמשים או משתמשים ספציפיים',
-      AMMUNITION: 'ניהול תבניות, מלאי, דיווחים ובקשות תחמושת'
+      AMMUNITION: 'ניהול תבניות, מלאי, דיווחים ובקשות תחמושת',
+      PERMISSION_GRANTS: 'הענקה זמנית של תפקיד למשתמש לתקופה של עד 7 ימים'
     },
     
     // Access Denied

--- a/src/hooks/useManagementTabs.ts
+++ b/src/hooks/useManagementTabs.ts
@@ -2,7 +2,7 @@
  * Hook for managing tab configuration and filtering based on permissions
  */
 import { useMemo } from 'react';
-import { Users, Shield, ArrowRightLeft, Settings, Database, UserCheck, Mail, Layers, Package, Zap, Archive, BellRing, Crosshair } from 'lucide-react';
+import { Users, Shield, ArrowRightLeft, Settings, Database, UserCheck, Mail, Layers, Package, Zap, Archive, BellRing, Crosshair, KeyRound } from 'lucide-react';
 import { MANAGEMENT } from '@/constants/text';
 import { useManagementAccess } from './useManagementAccess';
 import { useAuth } from '@/contexts/AuthContext';
@@ -52,6 +52,13 @@ const ALL_MANAGEMENT_TABS: ManagementTab[] = [
     label: MANAGEMENT.TABS.PERMISSIONS,
     icon: Shield,
     description: MANAGEMENT.TAB_DESCRIPTIONS.PERMISSIONS,
+    category: 'user-management'
+  },
+  {
+    id: 'permission-grants',
+    label: MANAGEMENT.TABS.PERMISSION_GRANTS,
+    icon: KeyRound,
+    description: MANAGEMENT.TAB_DESCRIPTIONS.PERMISSION_GRANTS,
     category: 'user-management'
   },
   {
@@ -158,6 +165,8 @@ export function useManagementTabs(): UseManagementTabsReturn {
         case 'users':
         case 'permissions':
           return permissions.canManageUsers || permissions.canManagePermissions;
+        case 'permission-grants':
+          return permissions.canManagePermissions;
         case 'template-management':
           return permissions.canManageTemplates || isTeamLeader;
         case 'equipment-creation':

--- a/src/hooks/usePermissionGrants.ts
+++ b/src/hooks/usePermissionGrants.ts
@@ -1,0 +1,117 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { apiFetch } from '@/lib/apiFetch';
+import type { GrantScope, GrantStatus } from '@/types/permissionGrant';
+import type { UserType } from '@/types/user';
+
+export interface PermissionGrantListItem {
+  id: string;
+  userId: string;
+  userDisplayName?: string;
+  grantedRole: UserType;
+  scope: GrantScope;
+  scopeTeamId?: string;
+  issuedBy: string;
+  issuedByDisplayName?: string;
+  issuedAtMs: number;
+  expiresAtMs: number;
+  reason: string;
+  status: GrantStatus;
+  revokedBy?: string;
+  revokedByDisplayName?: string;
+  revokedAtMs?: number;
+  revokeReason?: string;
+  isExpired: boolean;
+}
+
+export interface IssueGrantPayload {
+  userId: string;
+  userDisplayName?: string;
+  grantedRole: UserType;
+  scope: GrantScope;
+  scopeTeamId?: string;
+  durationMs: number;
+  reason: string;
+}
+
+export interface UsePermissionGrantsReturn {
+  grants: PermissionGrantListItem[];
+  isLoading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+  issue: (payload: IssueGrantPayload) => Promise<{ ok: boolean; error?: string }>;
+  revoke: (grantId: string, reason?: string) => Promise<{ ok: boolean; error?: string }>;
+}
+
+export function usePermissionGrants(): UsePermissionGrantsReturn {
+  const [grants, setGrants] = useState<PermissionGrantListItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const res = await apiFetch('/api/permission-grants?includeExpired=true');
+      const json = await res.json();
+      if (!res.ok || !json.success) {
+        throw new Error(json.error || 'שגיאה בטעינת הענקות');
+      }
+      setGrants(json.grants ?? []);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'שגיאה לא צפויה');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const issue = useCallback<UsePermissionGrantsReturn['issue']>(
+    async (payload) => {
+      try {
+        const res = await apiFetch('/api/permission-grants', {
+          method: 'POST',
+          body: JSON.stringify(payload),
+        });
+        const json = await res.json();
+        if (!res.ok || !json.success) {
+          return { ok: false, error: json.error || 'יצירת הענקה נכשלה' };
+        }
+        await refresh();
+        return { ok: true };
+      } catch (e) {
+        return { ok: false, error: e instanceof Error ? e.message : 'שגיאה לא צפויה' };
+      }
+    },
+    [refresh]
+  );
+
+  const revoke = useCallback<UsePermissionGrantsReturn['revoke']>(
+    async (grantId, reason) => {
+      try {
+        const res = await apiFetch(
+          `/api/permission-grants/${encodeURIComponent(grantId)}/revoke`,
+          {
+            method: 'POST',
+            body: JSON.stringify(reason ? { reason } : {}),
+          }
+        );
+        const json = await res.json();
+        if (!res.ok || !json.success) {
+          return { ok: false, error: json.error || 'ביטול נכשל' };
+        }
+        await refresh();
+        return { ok: true };
+      } catch (e) {
+        return { ok: false, error: e instanceof Error ? e.message : 'שגיאה לא צפויה' };
+      }
+    },
+    [refresh]
+  );
+
+  return { grants, isLoading, error, refresh, issue, revoke };
+}

--- a/src/lib/__tests__/permissionGrantsService.test.ts
+++ b/src/lib/__tests__/permissionGrantsService.test.ts
@@ -1,0 +1,399 @@
+/**
+ * Unit tests for permissionGrantsService — issuance, revocation, list, and
+ * the active-grant loader. The Admin SDK chain is faked with an in-memory
+ * collection map so the tests don't depend on real Firestore.
+ */
+
+jest.mock('firebase-admin/firestore', () => ({
+  FieldValue: {
+    serverTimestamp: () => 'SERVER_TIMESTAMP',
+  },
+}));
+jest.mock('firebase-admin/app', () => ({
+  initializeApp: () => ({}),
+  getApps: () => [],
+  cert: () => ({}),
+  applicationDefault: () => ({}),
+}));
+
+interface DocRecord {
+  id: string;
+  data: Record<string, unknown>;
+}
+
+const store = new Map<string, DocRecord>();
+
+const mockSet = jest.fn(async (id: string, data: Record<string, unknown>) => {
+  store.set(id, { id, data });
+});
+const mockUpdate = jest.fn(async (id: string, patch: Record<string, unknown>) => {
+  const cur = store.get(id);
+  if (!cur) throw new Error('Not found');
+  store.set(id, { id, data: { ...cur.data, ...patch } });
+});
+const mockNotify = jest.fn(async (_data?: unknown) => 'notif-id');
+
+jest.mock('@/lib/db/server/notificationService', () => ({
+  serverCreateNotification: (data: unknown) => mockNotify(data),
+}));
+
+let docCounter = 0;
+
+function buildAdminDb() {
+  function makeQuery(collectionName: string) {
+    type Filter = (rec: DocRecord) => boolean;
+    let filters: Filter[] = [];
+    let orderField: string | null = null;
+    let orderDir: 'asc' | 'desc' = 'asc';
+    let limitCount: number | null = null;
+
+    const api = {
+      where(field: string, op: string, value: unknown) {
+        filters = [
+          ...filters,
+          (rec: DocRecord) => {
+            const v = rec.data[field];
+            switch (op) {
+              case '==':
+                return v === value;
+              case '>':
+                return typeof v === 'number' && typeof value === 'number' && v > value;
+              default:
+                return false;
+            }
+          },
+        ];
+        return api;
+      },
+      orderBy(field: string, dir: 'asc' | 'desc' = 'asc') {
+        orderField = field;
+        orderDir = dir;
+        return api;
+      },
+      limit(n: number) {
+        limitCount = n;
+        return api;
+      },
+      async get() {
+        let docs = [...store.entries()]
+          .filter(([key]) => key.startsWith(`${collectionName}/`))
+          .map(([key, rec]) => ({
+            shortId: key.split('/').slice(1).join('/'),
+            data: rec.data,
+          }));
+        for (const f of filters)
+          docs = docs.filter((d) => f({ id: d.shortId, data: d.data }));
+        if (orderField) {
+          docs = [...docs].sort((a, b) => {
+            const av = a.data[orderField!] as number;
+            const bv = b.data[orderField!] as number;
+            return orderDir === 'asc' ? av - bv : bv - av;
+          });
+        }
+        if (limitCount !== null) docs = docs.slice(0, limitCount);
+        return {
+          docs: docs.map((rec) => ({
+            id: rec.shortId,
+            data: () => rec.data,
+          })),
+        };
+      },
+    };
+    return api;
+  }
+
+  return {
+    collection(name: string) {
+      return {
+        doc(id?: string) {
+          const docId = id ?? `auto-${++docCounter}`;
+          const fullKey = `${name}/${docId}`;
+          return {
+            id: docId,
+            async get() {
+              const rec = store.get(fullKey);
+              return {
+                exists: !!rec,
+                id: docId,
+                data: () => rec?.data ?? {},
+              };
+            },
+            set: (data: Record<string, unknown>) => mockSet(fullKey, data),
+            update: (patch: Record<string, unknown>) => mockUpdate(fullKey, patch),
+          };
+        },
+        ...makeQuery(name),
+      };
+    },
+  };
+}
+
+const mockAdminDb = buildAdminDb();
+
+jest.mock('@/lib/db/admin', () => ({
+  getAdminDb: () => mockAdminDb,
+  getAdminAuth: () => ({}),
+}));
+
+import {
+  GrantValidationError,
+  getActiveGrants,
+  isGrantIssuer,
+  serverIssueGrant,
+  serverListGrants,
+  serverRevokeGrant,
+} from '@/lib/db/server/permissionGrantsService';
+import { GrantStatus } from '@/types/permissionGrant';
+import { UserType } from '@/types/user';
+
+beforeEach(() => {
+  store.clear();
+  docCounter = 0;
+  mockSet.mockClear();
+  mockUpdate.mockClear();
+  mockNotify.mockClear();
+});
+
+describe('isGrantIssuer', () => {
+  it('admin and system manager are issuers; manager and TL are not', () => {
+    expect(isGrantIssuer(UserType.ADMIN)).toBe(true);
+    expect(isGrantIssuer(UserType.SYSTEM_MANAGER)).toBe(true);
+    expect(isGrantIssuer(UserType.MANAGER)).toBe(false);
+    expect(isGrantIssuer(UserType.TEAM_LEADER)).toBe(false);
+    expect(isGrantIssuer(UserType.USER)).toBe(false);
+  });
+});
+
+describe('serverIssueGrant — validation', () => {
+  const baseInput = {
+    userId: 'user-1',
+    grantedRole: UserType.TEAM_LEADER,
+    scope: 'team' as const,
+    scopeTeamId: 'team-7',
+    expiresAtMs: Date.now() + 3 * 24 * 60 * 60 * 1000,
+    reason: 'fill in for week 5',
+    issuerUid: 'admin-1',
+    issuerUserType: UserType.ADMIN,
+  };
+
+  it('rejects non-issuer', async () => {
+    await expect(
+      serverIssueGrant({ ...baseInput, issuerUserType: UserType.MANAGER })
+    ).rejects.toThrow(GrantValidationError);
+  });
+
+  it('rejects self-grant', async () => {
+    await expect(
+      serverIssueGrant({ ...baseInput, userId: baseInput.issuerUid })
+    ).rejects.toThrow(/cannot grant a role to themselves/i);
+  });
+
+  it('rejects unsupported role', async () => {
+    await expect(
+      serverIssueGrant({ ...baseInput, grantedRole: UserType.ADMIN })
+    ).rejects.toThrow(/grantedRole/);
+  });
+
+  it("rejects scope='team' without scopeTeamId", async () => {
+    await expect(
+      serverIssueGrant({ ...baseInput, scopeTeamId: undefined })
+    ).rejects.toThrow(/scopeTeamId/);
+  });
+
+  it("rejects scope='all' from non-admin issuer", async () => {
+    await expect(
+      serverIssueGrant({
+        ...baseInput,
+        scope: 'all',
+        scopeTeamId: undefined,
+        issuerUserType: UserType.SYSTEM_MANAGER,
+      })
+    ).rejects.toThrow(/admin may issue scope='all'/i);
+  });
+
+  it('rejects empty reason', async () => {
+    await expect(
+      serverIssueGrant({ ...baseInput, reason: '   ' })
+    ).rejects.toThrow(/reason is required/);
+  });
+
+  it('rejects past expiry', async () => {
+    await expect(
+      serverIssueGrant({ ...baseInput, expiresAtMs: Date.now() - 1 })
+    ).rejects.toThrow(/in the future/);
+  });
+
+  it('rejects duration over 7 days', async () => {
+    await expect(
+      serverIssueGrant({
+        ...baseInput,
+        expiresAtMs: Date.now() + 8 * 24 * 60 * 60 * 1000,
+      })
+    ).rejects.toThrow(/7-day cap/);
+  });
+
+  it('persists a valid grant and notifies the grantee', async () => {
+    const result = await serverIssueGrant(baseInput);
+    expect(result.id).toBeTruthy();
+    expect(mockSet).toHaveBeenCalledTimes(1);
+    expect(mockNotify).toHaveBeenCalledTimes(1);
+    const stored = [...store.values()][0].data;
+    expect(stored.userId).toBe('user-1');
+    expect(stored.grantedRole).toBe(UserType.TEAM_LEADER);
+    expect(stored.scopeTeamId).toBe('team-7');
+    expect(stored.status).toBe(GrantStatus.ACTIVE);
+  });
+
+  it('rejects an overlapping active grant for the same user/role/team', async () => {
+    await serverIssueGrant(baseInput);
+    await expect(serverIssueGrant(baseInput)).rejects.toThrow(/already exists/i);
+  });
+});
+
+describe('serverRevokeGrant', () => {
+  it('flips status to revoked and stamps audit fields', async () => {
+    const created = await serverIssueGrant({
+      userId: 'user-1',
+      grantedRole: UserType.TEAM_LEADER,
+      scope: 'team',
+      scopeTeamId: 'team-7',
+      expiresAtMs: Date.now() + 3 * 24 * 60 * 60 * 1000,
+      reason: 'r',
+      issuerUid: 'admin-1',
+      issuerUserType: UserType.ADMIN,
+    });
+
+    await serverRevokeGrant({
+      grantId: created.id,
+      actorUid: 'admin-1',
+      actorUserType: UserType.ADMIN,
+      reason: 'mistake',
+    });
+
+    const stored = [...store.values()][0].data;
+    expect(stored.status).toBe(GrantStatus.REVOKED);
+    expect(stored.revokedBy).toBe('admin-1');
+    expect(stored.revokeReason).toBe('mistake');
+    expect(typeof stored.revokedAtMs).toBe('number');
+  });
+
+  it('rejects revocation by non-issuer', async () => {
+    await expect(
+      serverRevokeGrant({
+        grantId: 'x',
+        actorUid: 'm',
+        actorUserType: UserType.MANAGER,
+      })
+    ).rejects.toThrow(GrantValidationError);
+  });
+
+  it('rejects revocation of a non-active grant', async () => {
+    const created = await serverIssueGrant({
+      userId: 'user-1',
+      grantedRole: UserType.TEAM_LEADER,
+      scope: 'team',
+      scopeTeamId: 'team-7',
+      expiresAtMs: Date.now() + 1000,
+      reason: 'r',
+      issuerUid: 'admin-1',
+      issuerUserType: UserType.ADMIN,
+    });
+    await serverRevokeGrant({
+      grantId: created.id,
+      actorUid: 'admin-1',
+      actorUserType: UserType.ADMIN,
+    });
+    await expect(
+      serverRevokeGrant({
+        grantId: created.id,
+        actorUid: 'admin-1',
+        actorUserType: UserType.ADMIN,
+      })
+    ).rejects.toThrow(/not active/);
+  });
+});
+
+describe('getActiveGrants', () => {
+  it('returns only active, non-expired grants for the user', async () => {
+    const now = Date.now();
+    await serverIssueGrant({
+      userId: 'user-1',
+      grantedRole: UserType.TEAM_LEADER,
+      scope: 'team',
+      scopeTeamId: 'team-7',
+      expiresAtMs: now + 60_000,
+      reason: 'r',
+      issuerUid: 'admin-1',
+      issuerUserType: UserType.ADMIN,
+    });
+    // Insert a manually-expired record straight into the store to avoid the
+    // "expiresAtMs must be in the future" guard.
+    store.set('permissionGrants/expired-1', {
+      id: 'expired-1',
+      data: {
+        userId: 'user-1',
+        grantedRole: UserType.MANAGER,
+        scope: 'all',
+        issuedBy: 'admin-1',
+        issuedAtMs: now - 10_000,
+        expiresAtMs: now - 1,
+        reason: 'old',
+        status: GrantStatus.ACTIVE,
+      },
+    });
+    // Different user — must not appear.
+    await serverIssueGrant({
+      userId: 'user-2',
+      grantedRole: UserType.TEAM_LEADER,
+      scope: 'team',
+      scopeTeamId: 'team-9',
+      expiresAtMs: now + 60_000,
+      reason: 'other',
+      issuerUid: 'admin-1',
+      issuerUserType: UserType.ADMIN,
+    });
+
+    const out = await getActiveGrants('user-1');
+    expect(out).toHaveLength(1);
+    expect(out[0].grantedRole).toBe(UserType.TEAM_LEADER);
+    expect(out[0].scopeTeamId).toBe('team-7');
+  });
+
+  it('returns [] for empty uid', async () => {
+    expect(await getActiveGrants('')).toEqual([]);
+  });
+});
+
+describe('serverListGrants', () => {
+  it('returns grants newest first with isExpired flag', async () => {
+    const now = Date.now();
+    await serverIssueGrant({
+      userId: 'user-1',
+      grantedRole: UserType.TEAM_LEADER,
+      scope: 'team',
+      scopeTeamId: 'team-7',
+      expiresAtMs: now + 60_000,
+      reason: 'fresh',
+      issuerUid: 'admin-1',
+      issuerUserType: UserType.ADMIN,
+    });
+    store.set('permissionGrants/expired', {
+      id: 'expired',
+      data: {
+        userId: 'user-1',
+        grantedRole: UserType.MANAGER,
+        scope: 'all',
+        issuedBy: 'admin-1',
+        issuedAtMs: now - 10_000,
+        expiresAtMs: now - 5_000,
+        reason: 'old',
+        status: GrantStatus.ACTIVE,
+      },
+    });
+
+    const list = await serverListGrants({ includeExpired: true });
+    expect(list.length).toBe(2);
+    const expired = list.find((g) => g.id === 'expired')!;
+    expect(expired.isExpired).toBe(true);
+  });
+});

--- a/src/lib/__tests__/permissionGrantsService.test.ts
+++ b/src/lib/__tests__/permissionGrantsService.test.ts
@@ -31,6 +31,7 @@ const mockUpdate = jest.fn(async (id: string, patch: Record<string, unknown>) =>
   if (!cur) throw new Error('Not found');
   store.set(id, { id, data: { ...cur.data, ...patch } });
 });
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mockNotify = jest.fn(async (_data?: unknown) => 'notif-id');
 
 jest.mock('@/lib/db/server/notificationService', () => ({

--- a/src/lib/__tests__/serverServices.test.ts
+++ b/src/lib/__tests__/serverServices.test.ts
@@ -59,6 +59,9 @@ jest.mock('@/lib/db/server/notificationService', () => ({
   serverCreateNotification: jest.fn(async () => 'notif-id'),
   serverCreateBatchNotifications: jest.fn(async () => undefined),
 }));
+jest.mock('@/lib/db/server/permissionGrantsService', () => ({
+  getActiveGrants: jest.fn(async () => []),
+}));
 
 import { actorToAuthUser, type ApiActor } from '@/lib/db/server/policyHelpers';
 import { getActorFromRequest, AuthError } from '@/lib/db/server/auth';

--- a/src/lib/db/server/permissionGrantsService.ts
+++ b/src/lib/db/server/permissionGrantsService.ts
@@ -1,15 +1,325 @@
-import type { ActiveGrant } from '@/types/permissionGrant';
+/**
+ * Server-side Permission Grants Service (firebase-admin).
+ *
+ * Persists, lists, and lifecycles `permissionGrants/{grantId}` documents.
+ * Issuance is gated to ADMIN + SYSTEM_MANAGER (never TL); duration is capped
+ * at MAX_GRANT_DURATION_MS (7 days). The loader `getActiveGrants` is consumed
+ * by `auth.getActorFromRequest` to elevate role classifiers per active grant.
+ */
+import { getAdminDb } from '../admin';
+import { COLLECTIONS } from '../collections';
+import { FieldValue } from 'firebase-admin/firestore';
+import { UserType } from '@/types/user';
+import {
+  GrantStatus,
+  MAX_GRANT_DURATION_MS,
+  type ActiveGrant,
+  type GrantScope,
+  type PermissionGrant,
+} from '@/types/permissionGrant';
+import { serverCreateNotification } from './notificationService';
+import { NotificationType } from '@/types/notifications';
+
+const ALLOWED_ROLES: ReadonlySet<UserType> = new Set([
+  UserType.TEAM_LEADER,
+  UserType.MANAGER,
+  UserType.SYSTEM_MANAGER,
+]);
+
+const ISSUER_ROLES: ReadonlySet<UserType> = new Set([
+  UserType.ADMIN,
+  UserType.SYSTEM_MANAGER,
+]);
+
+export class GrantValidationError extends Error {
+  constructor(message: string, public readonly status: 400 | 403 = 400) {
+    super(message);
+    this.name = 'GrantValidationError';
+  }
+}
+
+export function isGrantIssuer(userType: UserType): boolean {
+  return ISSUER_ROLES.has(userType);
+}
 
 /**
- * Returns the active, non-expired grants for the given user. The full
- * implementation queries `permissionGrants` filtered by status === 'active'
- * AND expiresAtMs > now. Until the grants-issuance PR ships, this returns an
- * empty list, which means policy helpers fall through to base userType.
- *
- * The empty stub keeps the rest of the auth pipeline grant-aware so the
- * issuance PR only needs to fill in the query — no callsite churn.
+ * Active, non-expired grants for a single user. Filtered server-side; expired
+ * grants are ignored even if their status is still 'active' (status is only
+ * flipped to 'revoked' explicitly — expiry is computed at read time).
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export async function getActiveGrants(_uid: string): Promise<ActiveGrant[]> {
-  return [];
+export async function getActiveGrants(uid: string): Promise<ActiveGrant[]> {
+  if (!uid) return [];
+  const db = getAdminDb();
+  const now = Date.now();
+  const snap = await db
+    .collection(COLLECTIONS.PERMISSION_GRANTS)
+    .where('userId', '==', uid)
+    .where('status', '==', GrantStatus.ACTIVE)
+    .where('expiresAtMs', '>', now)
+    .get();
+
+  const grants: ActiveGrant[] = [];
+  for (const doc of snap.docs) {
+    const data = doc.data() as Partial<PermissionGrant>;
+    if (!data.grantedRole || !data.scope || typeof data.expiresAtMs !== 'number') continue;
+    grants.push({
+      id: doc.id,
+      grantedRole: data.grantedRole,
+      scope: data.scope,
+      ...(data.scopeTeamId ? { scopeTeamId: data.scopeTeamId } : {}),
+      expiresAtMs: data.expiresAtMs,
+    });
+  }
+  return grants;
+}
+
+export interface IssueGrantInput {
+  userId: string;
+  userDisplayName?: string;
+  grantedRole: UserType;
+  scope: GrantScope;
+  scopeTeamId?: string;
+  expiresAtMs: number;
+  reason: string;
+  issuerUid: string;
+  issuerUserType: UserType;
+  issuerDisplayName?: string;
+}
+
+export interface IssueGrantResult {
+  id: string;
+}
+
+export async function serverIssueGrant(input: IssueGrantInput): Promise<IssueGrantResult> {
+  if (!isGrantIssuer(input.issuerUserType)) {
+    throw new GrantValidationError(
+      'Forbidden: only admin or system manager may issue grants',
+      403
+    );
+  }
+
+  if (!input.userId || typeof input.userId !== 'string') {
+    throw new GrantValidationError('userId is required');
+  }
+  if (input.userId === input.issuerUid) {
+    throw new GrantValidationError('Issuers cannot grant a role to themselves');
+  }
+  if (!ALLOWED_ROLES.has(input.grantedRole)) {
+    throw new GrantValidationError(
+      `grantedRole must be one of: ${[...ALLOWED_ROLES].join(', ')}`
+    );
+  }
+  if (input.scope !== 'all' && input.scope !== 'team') {
+    throw new GrantValidationError("scope must be 'all' or 'team'");
+  }
+  if (input.scope === 'team' && !input.scopeTeamId) {
+    throw new GrantValidationError("scopeTeamId is required when scope === 'team'");
+  }
+  if (input.scope === 'all' && input.issuerUserType !== UserType.ADMIN) {
+    throw new GrantValidationError(
+      "Only admin may issue scope='all' grants",
+      403
+    );
+  }
+  const reason = (input.reason ?? '').trim();
+  if (!reason) {
+    throw new GrantValidationError('reason is required');
+  }
+
+  const now = Date.now();
+  if (typeof input.expiresAtMs !== 'number' || !Number.isFinite(input.expiresAtMs)) {
+    throw new GrantValidationError('expiresAtMs must be a finite number');
+  }
+  if (input.expiresAtMs <= now) {
+    throw new GrantValidationError('expiresAtMs must be in the future');
+  }
+  if (input.expiresAtMs - now > MAX_GRANT_DURATION_MS) {
+    throw new GrantValidationError('Grant duration exceeds the 7-day cap');
+  }
+
+  const db = getAdminDb();
+
+  // Reject overlapping active grants for the same user+role+scope (idempotent UX).
+  const overlapQuery = await db
+    .collection(COLLECTIONS.PERMISSION_GRANTS)
+    .where('userId', '==', input.userId)
+    .where('status', '==', GrantStatus.ACTIVE)
+    .where('grantedRole', '==', input.grantedRole)
+    .where('expiresAtMs', '>', now)
+    .get();
+  const overlap = overlapQuery.docs.find((d) => {
+    const data = d.data() as Partial<PermissionGrant>;
+    if (data.scope !== input.scope) return false;
+    if (input.scope === 'team') return data.scopeTeamId === input.scopeTeamId;
+    return true;
+  });
+  if (overlap) {
+    throw new GrantValidationError(
+      'An active grant with the same role and scope already exists for this user'
+    );
+  }
+
+  const ref = db.collection(COLLECTIONS.PERMISSION_GRANTS).doc();
+  const data: Record<string, unknown> = {
+    userId: input.userId,
+    ...(input.userDisplayName ? { userDisplayName: input.userDisplayName } : {}),
+    grantedRole: input.grantedRole,
+    scope: input.scope,
+    ...(input.scope === 'team' && input.scopeTeamId
+      ? { scopeTeamId: input.scopeTeamId }
+      : {}),
+    issuedBy: input.issuerUid,
+    ...(input.issuerDisplayName ? { issuedByDisplayName: input.issuerDisplayName } : {}),
+    issuedAtMs: now,
+    expiresAtMs: input.expiresAtMs,
+    reason,
+    status: GrantStatus.ACTIVE,
+    createdAt: FieldValue.serverTimestamp(),
+  };
+  await ref.set(data);
+
+  // Notify the grantee. Failure here must not roll back the grant.
+  try {
+    await serverCreateNotification({
+      userId: input.userId,
+      type: NotificationType.SYSTEM_MESSAGE,
+      title: 'הענקת תפקיד זמני',
+      message: buildIssueNotificationMessage(input),
+    });
+  } catch (e) {
+    console.error('[permissionGrants] issue notification failed', e);
+  }
+
+  return { id: ref.id };
+}
+
+function buildIssueNotificationMessage(input: IssueGrantInput): string {
+  const roleLabel = roleLabelHebrew(input.grantedRole);
+  const scopeLabel =
+    input.scope === 'all' ? 'כלל הצוותים' : `צוות ${input.scopeTeamId}`;
+  const expires = new Date(input.expiresAtMs).toLocaleString('he-IL');
+  return `קיבלת הענקת תפקיד זמנית: ${roleLabel} (${scopeLabel}) עד ${expires}.`;
+}
+
+function roleLabelHebrew(role: UserType): string {
+  switch (role) {
+    case UserType.ADMIN:
+      return 'מנהל';
+    case UserType.SYSTEM_MANAGER:
+      return 'מנהל מערכת';
+    case UserType.MANAGER:
+      return 'מנהל';
+    case UserType.TEAM_LEADER:
+      return 'מפקד צוות';
+    default:
+      return role;
+  }
+}
+
+export interface RevokeGrantInput {
+  grantId: string;
+  actorUid: string;
+  actorUserType: UserType;
+  actorDisplayName?: string;
+  reason?: string;
+}
+
+export async function serverRevokeGrant(input: RevokeGrantInput): Promise<void> {
+  if (!isGrantIssuer(input.actorUserType)) {
+    throw new GrantValidationError(
+      'Forbidden: only admin or system manager may revoke grants',
+      403
+    );
+  }
+  if (!input.grantId) {
+    throw new GrantValidationError('grantId is required');
+  }
+  const db = getAdminDb();
+  const ref = db.collection(COLLECTIONS.PERMISSION_GRANTS).doc(input.grantId);
+  const snap = await ref.get();
+  if (!snap.exists) {
+    throw new GrantValidationError('Grant not found', 400);
+  }
+  const data = snap.data() as Partial<PermissionGrant>;
+  if (data.status !== GrantStatus.ACTIVE) {
+    throw new GrantValidationError('Grant is not active');
+  }
+  await ref.update({
+    status: GrantStatus.REVOKED,
+    revokedBy: input.actorUid,
+    ...(input.actorDisplayName ? { revokedByDisplayName: input.actorDisplayName } : {}),
+    revokedAtMs: Date.now(),
+    ...(input.reason && input.reason.trim() ? { revokeReason: input.reason.trim() } : {}),
+  });
+}
+
+export interface ListGrantsFilter {
+  userId?: string;
+  status?: GrantStatus;
+  includeExpired?: boolean;
+}
+
+export interface PermissionGrantView extends PermissionGrant {
+  isExpired: boolean;
+}
+
+/**
+ * Admin list endpoint backing for the Permission Grants tab.
+ * Returns up to 200 most-recent grants matching the filter, newest first.
+ */
+export async function serverListGrants(
+  filter: ListGrantsFilter = {}
+): Promise<PermissionGrantView[]> {
+  const db = getAdminDb();
+  let query: FirebaseFirestore.Query = db
+    .collection(COLLECTIONS.PERMISSION_GRANTS)
+    .orderBy('issuedAtMs', 'desc')
+    .limit(200);
+  if (filter.userId) {
+    query = query.where('userId', '==', filter.userId);
+  }
+  if (filter.status) {
+    query = query.where('status', '==', filter.status);
+  }
+  const snap = await query.get();
+  const now = Date.now();
+  const out: PermissionGrantView[] = [];
+  for (const doc of snap.docs) {
+    const data = doc.data() as Partial<PermissionGrant>;
+    if (
+      !data.userId ||
+      !data.grantedRole ||
+      !data.scope ||
+      typeof data.issuedAtMs !== 'number' ||
+      typeof data.expiresAtMs !== 'number' ||
+      !data.status
+    ) {
+      continue;
+    }
+    const view: PermissionGrantView = {
+      id: doc.id,
+      userId: data.userId,
+      userDisplayName: data.userDisplayName,
+      grantedRole: data.grantedRole,
+      scope: data.scope,
+      scopeTeamId: data.scopeTeamId,
+      issuedBy: data.issuedBy ?? '',
+      issuedByDisplayName: data.issuedByDisplayName,
+      issuedAtMs: data.issuedAtMs,
+      expiresAtMs: data.expiresAtMs,
+      reason: data.reason ?? '',
+      status: data.status,
+      revokedBy: data.revokedBy,
+      revokedByDisplayName: data.revokedByDisplayName,
+      revokedAtMs: data.revokedAtMs,
+      revokeReason: data.revokeReason,
+      isExpired: data.expiresAtMs <= now,
+    };
+    if (!filter.includeExpired && view.isExpired && view.status === GrantStatus.ACTIVE) {
+      // Active+expired: skip when caller asked for active only
+      if (filter.status === GrantStatus.ACTIVE) continue;
+    }
+    out.push(view);
+  }
+  return out;
 }

--- a/src/types/permissionGrant.ts
+++ b/src/types/permissionGrant.ts
@@ -22,17 +22,30 @@ export interface ActiveGrant {
 
 /**
  * Firestore document shape for permissionGrants/{grantId}.
- * Persisted by the future grants-issuance PR; the loader converts to ActiveGrant.
+ * Audit fields (issuedBy/issuedAtMs/revokedBy/revokedAtMs) live on the doc
+ * itself — there is no actionsLog entry for grant lifecycle (actionsLog is
+ * equipment-coupled).
  */
 export interface PermissionGrant {
   id: string;
   userId: string;
+  userDisplayName?: string;
   grantedRole: UserType;
   scope: GrantScope;
   scopeTeamId?: string;
   issuedBy: string;
+  issuedByDisplayName?: string;
   issuedAtMs: number;
   expiresAtMs: number;
   reason: string;
   status: GrantStatus;
+  revokedBy?: string;
+  revokedByDisplayName?: string;
+  revokedAtMs?: number;
+  revokeReason?: string;
 }
+
+/**
+ * Maximum grant duration in milliseconds. Enforced server-side at issuance.
+ */
+export const MAX_GRANT_DURATION_MS = 7 * 24 * 60 * 60 * 1000;


### PR DESCRIPTION
Builds on the bearer-token pipeline shipped in #40. Replaces the empty-stub `getActiveGrants` with a real Firestore loader and adds the issuance/revocation surface so admin and system manager can elevate a user's role within a single team or all teams for up to 7 days.

Server
- `permissionGrantsService` gains `serverIssueGrant`, `serverRevokeGrant`, `serverListGrants`, plus a real `getActiveGrants` query (active + non-expired). Issuance is gated to ADMIN + SYSTEM_MANAGER, scope='all' is admin-only, duration is hard-capped at 7 days, and a duplicate active grant for the same user/role/scope is rejected. The grantee is notified on issue.
- New routes `GET/POST /api/permission-grants` and `POST /api/permission-grants/{id}/revoke`, all bearer-gated via `getActorOrError`. `GrantValidationError` maps cleanly to 400/403.

Audit
- Audit lives on the grant doc itself (`issuedBy/issuedAtMs/revokedBy/revokedAtMs/revokeReason`) — no `actionsLog` entry, since `actionsLog` is equipment-coupled.

UI
- New "הענקות תפקיד זמניות" tab under user-management, gated to ADMIN+SM. Lists active grants and full history with effective-status badges, supports issuing via UserSearchInput + role/scope/duration form, and revoking with confirmation.

Tests
- `permissionGrantsService.test.ts` covers issuer gating, scope validation, 7-day cap, duplicate detection, notification on issue, revocation lifecycle, and the active-grant loader filter.
- `serverServices.test.ts` mocks `getActiveGrants` so the existing `getActorFromRequest` happy-path keeps passing.

Docs
- New `docs/codebase/src/lib/db/server/permissionGrantsService.md` and `docs/codebase/src/app/api/permission-grants/README.md`.
- `docs/spec/management.md` and `docs/firebase-operations.md` updated.

Out of scope (deferred to a separate PR)
- Custom-claims optimization (push userType/teamId into ID token to drop the per-request Firestore read in `getActorFromRequest`).
- 1-day expiry warning notification.