### PR TITLE
feat(phone-book): unit-wide phone directory backed by users + personnel

### DIFF
--- a/docs/codebase/src/hooks/usePhoneBook.md
+++ b/docs/codebase/src/hooks/usePhoneBook.md
@@ -1,0 +1,20 @@
+# usePhoneBook
+
+**File:** `src/hooks/usePhoneBook.ts`
+**Status:** Active (Phase 1 — Phone Book).
+
+## Purpose
+
+Reads the `phoneBook` collection via the client SDK and exposes
+`{ entries, isLoading, error, refresh }` to the page.
+
+## Notes
+
+- `useEffect` calls `refresh()` once on mount. `useCallback` deps are
+  `[]` so the identity is stable. Do not regress this pattern — the
+  recent infinite-loop bug in `useAmmunitionReports` came from a
+  default-`{}` filter param breaking the same invariant.
+- Reads are sorted by `displayName` — entries written via the
+  write-through pipeline always have a non-empty `displayName`.
+- Writes happen exclusively server-side (see
+  `docs/spec/phone-book.md` for the trigger matrix).

--- a/docs/codebase/src/lib/db/server/phoneBookService.md
+++ b/docs/codebase/src/lib/db/server/phoneBookService.md
@@ -1,0 +1,34 @@
+# phoneBookService (server)
+
+**File:** `src/lib/db/server/phoneBookService.ts`
+**Status:** Active (Phase 1 — Phone Book).
+
+## Purpose
+
+Best-effort write-through for the `phoneBook` directory. Every change to
+a `users` row or an `authorized_personnel` row that touches a
+phone-relevant field calls into this module so the directory stays in
+sync.
+
+## Exports
+
+- `serverUpsertPhoneBookFromUser(input)` — called from
+  `/api/auth/register` and `/api/users/profile` (PATCH). Doc id =
+  `militaryPersonalNumberHash`. Sets `source='users'`,
+  `isRegistered=true`, denormalizes display name, photo URL, team id,
+  and userType.
+- `serverUpsertPhoneBookFromPersonnel(input)` — called from the
+  `/api/authorized-personnel` POST/PUT/bulk handlers. Doc id =
+  `militaryPersonalNumberHash`. Defensive: never downgrades a doc that
+  is already `source='users'` back to personnel.
+- `serverDeletePhoneBookEntryByHash(hash)` — called from the
+  authorized-personnel DELETE handler. Skips entries that have a
+  `userId` (registered users keep their entry until the underlying
+  `users` row is removed).
+
+## Failure mode
+
+Every export wraps its body in a try/catch and logs to `console.error`.
+The phone book is downstream — a sync hiccup must never block the
+primary write (registration, profile update, personnel CRUD). If the
+directory drifts, run `scripts/backfill-phone-book.ts` to reconcile.

--- a/docs/spec/phone-book.md
+++ b/docs/spec/phone-book.md
@@ -1,0 +1,94 @@
+# Phone Book — Phase 1
+
+Live spec for the `/phone-book` directory. Phase 1 ships a write-through
+view backed by `users` + `authorized_personnel`. Phase 2 layers on
+non-user (external) entries and direct phone-book editing.
+
+## Domain model
+
+Firestore collection: `phoneBook`. Document shape — see
+`src/types/phoneBook.ts`. Doc id is `militaryPersonalNumberHash` for any
+person on the unit roster (registered or not). External entries (Phase 2)
+will use a random doc id and `source='external'`.
+
+```ts
+interface PhoneBookEntry {
+  id: string;
+  source: 'users' | 'authorized_personnel' | 'external';
+  userId?: string;                  // Firebase Auth UID once registered
+  militaryPersonalNumberHash?: string;
+  firstName?: string;
+  lastName?: string;
+  displayName: string;              // computed at write
+  phoneNumber?: string;
+  email?: string;
+  teamId?: string;
+  userType?: UserType;
+  photoURL?: string;
+  isRegistered: boolean;
+  createdAt: Timestamp;
+  updatedAt: Timestamp;
+}
+```
+
+## Sync pipeline (write-through)
+
+Every mutation that touches a person's phone-relevant fields triggers a
+phone-book upsert. All upserts are best-effort (try/catch + log) so the
+primary write is never blocked by a directory hiccup.
+
+| Trigger | Server hook |
+|---------|-------------|
+| `POST /api/auth/register` | `serverUpsertPhoneBookFromUser` after `userRef.set(profile)` |
+| `PATCH /api/users/profile` | `serverUpsertPhoneBookFromUser` after `serverUpdateUserProfile`, when `phoneNumber` / `teamId` / `profileImage` changed |
+| `POST /api/authorized-personnel` | `serverUpsertPhoneBookFromPersonnel` after `serverAddPersonnel` |
+| `PUT /api/authorized-personnel` | `serverUpsertPhoneBookFromPersonnel` after `serverUpdatePersonnel` |
+| `DELETE /api/authorized-personnel` | `serverDeletePhoneBookEntryByHash` after `serverDeletePersonnel` (skips entries that have a `userId`) |
+| `POST /api/authorized-personnel/bulk` | `serverUpsertPhoneBookFromPersonnel` for each non-failed entry |
+
+Order matters when registration follows a personnel-only state: the user
+upsert overwrites `source='authorized_personnel'` with `source='users'`
+and flips `isRegistered=true`. The personnel-side upsert is defensive —
+it never downgrades an entry that is already `source='users'`.
+
+## Backfill
+
+`scripts/backfill-phone-book.ts` reads both source collections via
+firebase-admin and upserts every doc. Idempotent. Invocation:
+
+```
+GOOGLE_APPLICATION_CREDENTIALS=./sa.json \
+  ts-node scripts/backfill-phone-book.ts --project sayeret-givati-1983 [--dry-run]
+```
+
+Run once before pointing client traffic at `/phone-book`.
+
+## Permissions
+
+- **Read** — any authenticated user. Encoded in `firestore.rules`.
+- **Write** — admin SDK only. Client SDK writes are denied. The
+  application surface never exposes a phone-book edit form in Phase 1.
+
+## UI
+
+`/phone-book` page (`src/app/phone-book/page.tsx`):
+
+- Search input — fuzzy match on display name + first/last + phone + email.
+- Team filter — `Select` sourced from `systemConfig.teams` plus any team
+  observed in the data.
+- Role filter — `Select` over the five `UserType` values.
+- Table columns: name (with avatar + unregistered badge) · phone (tel:
+  link) · team · role badge · email (mailto: link).
+
+Avatars use `users.photoURL` / `users.profileImage` rendered as a
+background-image span (no `<Image />` indirection). Falls back to
+initials if no photo.
+
+## Phase 2 follow-ups
+
+- Direct edit UI for `external` entries (suppliers, range officers).
+- Admin-side phone-book edit for typo correction without going through
+  `/profile`.
+- CSV export for managers.
+- Optional emergency-contact field.
+- Per-field role gating if a privacy review surfaces a need.

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -185,6 +185,14 @@ service cloud.firestore {
       allow write: if false;
     }
 
+    // Phone book — authenticated read; writes server-only via the
+    // write-through pipeline in /api/auth/register, /api/users/profile,
+    // and /api/authorized-personnel.
+    match /phoneBook/{entryId} {
+      allow read: if request.auth != null;
+      allow write: if false;
+    }
+
     // Deny everything else
     match /{document=**} {
       allow read, write: if false;

--- a/scripts/backfill-phone-book.ts
+++ b/scripts/backfill-phone-book.ts
@@ -1,0 +1,162 @@
+/**
+ * One-shot backfill for the `phoneBook` collection.
+ *
+ * Reads `users` and `authorized_personnel` via firebase-admin and upserts
+ * the corresponding `phoneBook/{militaryPersonalNumberHash}` doc. Designed
+ * to be idempotent — a second run is a no-op when source data has not
+ * changed.
+ *
+ * Doc id strategy: `militaryPersonalNumberHash`. Registered users
+ * overwrite the personnel-only entry (source = 'users', isRegistered = true).
+ *
+ * Usage:
+ *   GOOGLE_APPLICATION_CREDENTIALS=./sa.json \
+ *     ts-node scripts/backfill-phone-book.ts --project sayeret-givati-1983
+ *
+ * Flags:
+ *   --dry-run   Log the planned writes without persisting.
+ */
+import * as admin from 'firebase-admin';
+
+const args = process.argv.slice(2);
+const projectIdx = args.indexOf('--project');
+const projectId = projectIdx >= 0 ? args[projectIdx + 1] : undefined;
+const dryRun = args.includes('--dry-run');
+
+if (!projectId) {
+  console.error('Missing --project <projectId>');
+  process.exit(1);
+}
+
+admin.initializeApp({
+  credential: admin.credential.applicationDefault(),
+  projectId,
+});
+
+const db = admin.firestore();
+
+const COLLECTIONS = {
+  USERS: 'users',
+  AUTHORIZED_PERSONNEL: 'authorized_personnel',
+  PHONE_BOOK: 'phoneBook',
+} as const;
+
+interface UserRow {
+  id: string;
+  data: FirebaseFirestore.DocumentData;
+}
+
+function buildDisplayName(firstName?: string, lastName?: string, fallback?: string): string {
+  const parts = [firstName, lastName].filter((s): s is string => !!s && !!s.trim());
+  return parts.join(' ').trim() || fallback || '';
+}
+
+function pruneUndefined<T extends Record<string, unknown>>(obj: T): Partial<T> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (v !== undefined && v !== '') out[k] = v;
+  }
+  return out as Partial<T>;
+}
+
+async function loadUsers(): Promise<UserRow[]> {
+  const snap = await db.collection(COLLECTIONS.USERS).get();
+  return snap.docs.map((d) => ({ id: d.id, data: d.data() }));
+}
+
+async function loadPersonnel(): Promise<UserRow[]> {
+  const snap = await db.collection(COLLECTIONS.AUTHORIZED_PERSONNEL).get();
+  return snap.docs.map((d) => ({ id: d.id, data: d.data() }));
+}
+
+async function upsertEntry(hash: string, payload: Record<string, unknown>): Promise<void> {
+  const ref = db.collection(COLLECTIONS.PHONE_BOOK).doc(hash);
+  if (dryRun) {
+    console.log(`[dry-run] upsert ${hash}:`, payload);
+    return;
+  }
+  const existing = await ref.get();
+  if (!existing.exists) {
+    await ref.set({
+      ...payload,
+      createdAt: admin.firestore.FieldValue.serverTimestamp(),
+      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+    });
+  } else {
+    await ref.set(
+      {
+        ...payload,
+        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+      },
+      { merge: true }
+    );
+  }
+}
+
+async function main(): Promise<void> {
+  const [personnel, users] = await Promise.all([loadPersonnel(), loadUsers()]);
+  console.log(`Loaded ${personnel.length} personnel rows and ${users.length} user rows.`);
+
+  let personnelWrites = 0;
+  let userWrites = 0;
+  let skipped = 0;
+
+  // 1) Seed from authorized_personnel.
+  for (const p of personnel) {
+    const hash = (p.data.militaryPersonalNumberHash as string) || p.id;
+    if (!hash) {
+      skipped++;
+      continue;
+    }
+    const data = pruneUndefined({
+      id: hash,
+      source: 'authorized_personnel' as const,
+      militaryPersonalNumberHash: hash,
+      firstName: p.data.firstName,
+      lastName: p.data.lastName,
+      displayName: buildDisplayName(p.data.firstName, p.data.lastName, hash),
+      phoneNumber: p.data.phoneNumber,
+      userType: p.data.userType,
+      isRegistered: !!p.data.registered,
+    });
+    await upsertEntry(hash, data);
+    personnelWrites++;
+  }
+
+  // 2) Overlay users (overrides source + isRegistered + adds email/team/photo).
+  for (const u of users) {
+    const hash = u.data.militaryPersonalNumberHash as string | undefined;
+    if (!hash) {
+      skipped++;
+      continue;
+    }
+    const data = pruneUndefined({
+      id: hash,
+      source: 'users' as const,
+      userId: u.id,
+      militaryPersonalNumberHash: hash,
+      firstName: u.data.firstName,
+      lastName: u.data.lastName,
+      displayName: buildDisplayName(u.data.firstName, u.data.lastName, u.data.email || u.id),
+      phoneNumber: u.data.phoneNumber,
+      email: u.data.email,
+      teamId: u.data.teamId,
+      userType: u.data.userType,
+      photoURL: u.data.profileImage || u.data.photoURL,
+      isRegistered: true,
+    });
+    await upsertEntry(hash, data);
+    userWrites++;
+  }
+
+  console.log(
+    `Done. personnel=${personnelWrites} writes, users=${userWrites} writes, skipped=${skipped}.${
+      dryRun ? ' (dry-run)' : ''
+    }`
+  );
+}
+
+main().catch((e) => {
+  console.error('backfill failed:', e);
+  process.exit(1);
+});

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -5,6 +5,7 @@ import { COLLECTIONS } from '@/lib/db/collections';
 import { FieldValue } from 'firebase-admin/firestore';
 import { UserType } from '@/types/user';
 import { UserRole } from '@/types/equipment';
+import { serverUpsertPhoneBookFromUser } from '@/lib/db/server/phoneBookService';
 
 export async function POST(request: NextRequest) {
   try {
@@ -87,6 +88,16 @@ export async function POST(request: NextRequest) {
     await personnelRef.update({
       registered: true,
       updatedAt: FieldValue.serverTimestamp(),
+    });
+
+    await serverUpsertPhoneBookFromUser({
+      uid,
+      militaryPersonalNumberHash: militaryIdHash,
+      firstName: profile.firstName,
+      lastName: profile.lastName,
+      phoneNumber: profile.phoneNumber,
+      email: profile.email,
+      userType: profile.userType as UserType,
     });
 
     return NextResponse.json({ success: true, uid, message: 'User profile created successfully' });

--- a/src/app/api/authorized-personnel/bulk/route.ts
+++ b/src/app/api/authorized-personnel/bulk/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { serverBulkAddPersonnel } from '@/lib/db/server/authorizedPersonnelService';
+import { serverUpsertPhoneBookFromPersonnel } from '@/lib/db/server/phoneBookService';
 import { getActorOrError } from '@/lib/db/server/auth';
 import { UserType } from '@/types/user';
 
@@ -16,6 +17,25 @@ export async function POST(request: Request) {
       return NextResponse.json({ success: false, error: 'entries array is required' }, { status: 400 });
     }
     const result = await serverBulkAddPersonnel(entries);
+
+    // Write-through to phone book for each successfully added entry.
+    const failed = new Set(result.failedIndices);
+    await Promise.all(
+      entries.map((entry, idx) => {
+        if (failed.has(idx)) return Promise.resolve();
+        const data = entry?.data;
+        if (!data) return Promise.resolve();
+        return serverUpsertPhoneBookFromPersonnel({
+          militaryPersonalNumberHash: entry.docId,
+          firstName: data.firstName,
+          lastName: data.lastName,
+          phoneNumber: data.phoneNumber,
+          userType: data.userType as UserType | undefined,
+          registered: data.registered ?? false,
+        });
+      })
+    );
+
     return NextResponse.json({ success: true, ...result });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/src/app/api/authorized-personnel/route.ts
+++ b/src/app/api/authorized-personnel/route.ts
@@ -5,6 +5,10 @@ import {
   serverSyncPersonnelToUser,
   serverDeletePersonnel,
 } from '@/lib/db/server/authorizedPersonnelService';
+import {
+  serverDeletePhoneBookEntryByHash,
+  serverUpsertPhoneBookFromPersonnel,
+} from '@/lib/db/server/phoneBookService';
 import { getActorOrError } from '@/lib/db/server/auth';
 import { UserType } from '@/types/user';
 
@@ -25,6 +29,14 @@ export async function POST(request: Request) {
       return NextResponse.json({ success: false, error: 'docId and data are required' }, { status: 400 });
     }
     const id = await serverAddPersonnel(docId, data);
+    await serverUpsertPhoneBookFromPersonnel({
+      militaryPersonalNumberHash: docId,
+      firstName: data?.firstName,
+      lastName: data?.lastName,
+      phoneNumber: data?.phoneNumber,
+      userType: data?.userType,
+      registered: data?.registered ?? false,
+    });
     return NextResponse.json({ success: true, id });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -52,6 +64,15 @@ export async function PUT(request: Request) {
       await serverSyncPersonnelToUser(militaryIdHash, updates);
     }
 
+    await serverUpsertPhoneBookFromPersonnel({
+      militaryPersonalNumberHash: personnelId,
+      firstName: updates?.firstName,
+      lastName: updates?.lastName,
+      phoneNumber: updates?.phoneNumber,
+      userType: updates?.userType,
+      registered: updates?.registered,
+    });
+
     return NextResponse.json({ success: true });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -73,6 +94,7 @@ export async function DELETE(request: Request) {
       return NextResponse.json({ success: false, error: 'Personnel id is required' }, { status: 400 });
     }
     await serverDeletePersonnel(id);
+    await serverDeletePhoneBookEntryByHash(id);
     return NextResponse.json({ success: true });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/src/app/api/users/profile/route.ts
+++ b/src/app/api/users/profile/route.ts
@@ -1,7 +1,10 @@
 import { NextResponse } from 'next/server';
 import { serverUpdateUserProfile } from '@/lib/db/server/userService';
 import { getActorOrError } from '@/lib/db/server/auth';
+import { getAdminDb } from '@/lib/db/admin';
+import { COLLECTIONS } from '@/lib/db/collections';
 import { UserType } from '@/types/user';
+import { serverUpsertPhoneBookFromUser } from '@/lib/db/server/phoneBookService';
 
 /**
  * PATCH /api/users/profile
@@ -31,6 +34,30 @@ export async function PATCH(request: Request) {
       );
     }
     await serverUpdateUserProfile(body.uid, body.updates);
+
+    // Write-through to phone book when phone-relevant fields change.
+    const touchesPhoneBook =
+      body.updates.phoneNumber !== undefined ||
+      body.updates.teamId !== undefined ||
+      body.updates.profileImage !== undefined;
+    if (touchesPhoneBook) {
+      const snap = await getAdminDb().collection(COLLECTIONS.USERS).doc(body.uid).get();
+      if (snap.exists) {
+        const u = snap.data() ?? {};
+        await serverUpsertPhoneBookFromUser({
+          uid: body.uid,
+          militaryPersonalNumberHash: u.militaryPersonalNumberHash as string,
+          firstName: u.firstName as string | undefined,
+          lastName: u.lastName as string | undefined,
+          phoneNumber: u.phoneNumber as string | undefined,
+          email: u.email as string | undefined,
+          teamId: u.teamId as string | undefined,
+          userType: u.userType as UserType | undefined,
+          photoURL: (u.profileImage as string | undefined) || (u.photoURL as string | undefined),
+        });
+      }
+    }
+
     return NextResponse.json({ success: true });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/src/app/phone-book/page.tsx
+++ b/src/app/phone-book/page.tsx
@@ -1,0 +1,233 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import { Search, User as UserIcon } from 'lucide-react';
+import AuthGuard from '@/components/auth/AuthGuard';
+import AppShell from '@/app/components/AppShell';
+import { Select } from '@/components/ui';
+import { TEXT_CONSTANTS } from '@/constants/text';
+import { useSystemConfig } from '@/hooks/useSystemConfig';
+import { usePhoneBook } from '@/hooks/usePhoneBook';
+import { UserType } from '@/types/user';
+import type { PhoneBookEntry } from '@/types/phoneBook';
+
+const T = TEXT_CONSTANTS.FEATURES.PHONE_BOOK;
+const ROLE_LABEL: Record<UserType, string> = {
+  [UserType.ADMIN]: TEXT_CONSTANTS.PROFILE.ADMIN,
+  [UserType.SYSTEM_MANAGER]: TEXT_CONSTANTS.PROFILE.SYSTEM_MANAGER,
+  [UserType.MANAGER]: TEXT_CONSTANTS.PROFILE.MANAGER,
+  [UserType.TEAM_LEADER]: TEXT_CONSTANTS.PROFILE.TEAM_LEADER,
+  [UserType.USER]: TEXT_CONSTANTS.PROFILE.USER,
+};
+
+function initials(entry: PhoneBookEntry): string {
+  const first = entry.firstName?.charAt(0) ?? '';
+  const last = entry.lastName?.charAt(0) ?? '';
+  const result = `${first}${last}`.trim();
+  if (result) return result;
+  return entry.displayName.charAt(0) || '?';
+}
+
+export default function PhoneBookPage() {
+  return (
+    <AuthGuard>
+      <AppShell title={`📞 ${T.TITLE}`} subtitle={T.DESCRIPTION}>
+        <PhoneBookContent />
+      </AppShell>
+    </AuthGuard>
+  );
+}
+
+function PhoneBookContent() {
+  const { entries, isLoading, error } = usePhoneBook();
+  const { config: systemConfig } = useSystemConfig();
+  const [search, setSearch] = useState('');
+  const [team, setTeam] = useState<string | null>(null);
+  const [role, setRole] = useState<UserType | null>(null);
+
+  const teamOptions = useMemo(() => {
+    const seen = new Set<string>();
+    const out: { value: string; label: string }[] = [];
+    for (const t of systemConfig?.teams ?? []) {
+      if (!seen.has(t)) {
+        seen.add(t);
+        out.push({ value: t, label: t });
+      }
+    }
+    for (const e of entries) {
+      if (e.teamId && !seen.has(e.teamId)) {
+        seen.add(e.teamId);
+        out.push({ value: e.teamId, label: e.teamId });
+      }
+    }
+    return out;
+  }, [systemConfig?.teams, entries]);
+
+  const roleOptions = useMemo(
+    () =>
+      [
+        UserType.ADMIN,
+        UserType.SYSTEM_MANAGER,
+        UserType.MANAGER,
+        UserType.TEAM_LEADER,
+        UserType.USER,
+      ].map((r) => ({ value: r, label: ROLE_LABEL[r] })),
+    []
+  );
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return entries.filter((e) => {
+      if (team && e.teamId !== team) return false;
+      if (role && e.userType !== role) return false;
+      if (q) {
+        const hay = [
+          e.displayName,
+          e.firstName ?? '',
+          e.lastName ?? '',
+          e.phoneNumber ?? '',
+          e.email ?? '',
+        ]
+          .join(' ')
+          .toLowerCase();
+        if (!hay.includes(q)) return false;
+      }
+      return true;
+    });
+  }, [entries, search, team, role]);
+
+  return (
+    <div className="max-w-6xl mx-auto w-full pb-12 space-y-4">
+      {error && (
+        <div className="p-3 rounded-lg bg-danger-50 border border-danger-200 text-danger-800 text-sm">
+          {error}
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+        <div className="sm:col-span-1 relative">
+          <Search className="absolute start-3 top-1/2 -translate-y-1/2 w-4 h-4 text-neutral-400" />
+          <input
+            type="search"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder={T.SEARCH_PLACEHOLDER}
+            className="w-full ps-9 pe-3 py-2 text-sm border border-neutral-200 rounded-lg bg-white focus:ring-2 focus:ring-primary-500"
+          />
+        </div>
+        <Select
+          value={team}
+          onChange={(v) => setTeam(v)}
+          options={teamOptions}
+          placeholder={T.FILTER_TEAM_ALL}
+          clearable
+          ariaLabel={T.FILTER_TEAM}
+        />
+        <Select<UserType>
+          value={role}
+          onChange={(v) => setRole(v)}
+          options={roleOptions}
+          placeholder={T.FILTER_ROLE_ALL}
+          clearable
+          ariaLabel={T.FILTER_ROLE}
+        />
+      </div>
+
+      <div className="text-xs text-neutral-500">
+        {T.TOTAL.replace('{count}', String(filtered.length))}
+      </div>
+
+      {isLoading ? (
+        <div className="text-sm text-neutral-500 text-center py-12">{T.LOADING}</div>
+      ) : entries.length === 0 ? (
+        <div className="text-sm text-neutral-500 text-center py-10 border border-dashed border-neutral-200 rounded-lg">
+          {T.EMPTY}
+        </div>
+      ) : filtered.length === 0 ? (
+        <div className="text-sm text-neutral-500 text-center py-10 border border-dashed border-neutral-200 rounded-lg">
+          {T.EMPTY_FILTERED}
+        </div>
+      ) : (
+        <div className="overflow-x-auto border border-neutral-200 rounded-lg bg-white">
+          <table className="min-w-full text-right text-sm">
+            <thead className="bg-neutral-50">
+              <tr>
+                <th className="px-3 py-2 text-xs font-medium text-neutral-600">{T.COL_NAME}</th>
+                <th className="px-3 py-2 text-xs font-medium text-neutral-600">{T.COL_PHONE}</th>
+                <th className="px-3 py-2 text-xs font-medium text-neutral-600">{T.COL_TEAM}</th>
+                <th className="px-3 py-2 text-xs font-medium text-neutral-600">{T.COL_ROLE}</th>
+                <th className="px-3 py-2 text-xs font-medium text-neutral-600">{T.COL_EMAIL}</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-neutral-100">
+              {filtered.map((e) => (
+                <tr key={e.id} className={e.isRegistered ? 'hover:bg-neutral-50' : 'hover:bg-neutral-50 opacity-80'}>
+                  <td className="px-3 py-2">
+                    <div className="flex items-center gap-2">
+                      <Avatar entry={e} />
+                      <div>
+                        <div className="text-neutral-900">{e.displayName}</div>
+                        {!e.isRegistered && (
+                          <span className="inline-block mt-0.5 text-[10px] px-1.5 py-0.5 rounded bg-neutral-100 text-neutral-600">
+                            {T.UNREGISTERED_BADGE}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  </td>
+                  <td className="px-3 py-2 text-neutral-700 whitespace-nowrap">
+                    {e.phoneNumber ? (
+                      <a className="text-primary-600 hover:underline" href={`tel:${e.phoneNumber}`}>
+                        {e.phoneNumber}
+                      </a>
+                    ) : (
+                      <span className="text-neutral-400">—</span>
+                    )}
+                  </td>
+                  <td className="px-3 py-2 text-neutral-700">{e.teamId || '—'}</td>
+                  <td className="px-3 py-2">
+                    {e.userType ? (
+                      <span className="inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-medium bg-primary-50 text-primary-700">
+                        {ROLE_LABEL[e.userType]}
+                      </span>
+                    ) : (
+                      <span className="text-neutral-400">—</span>
+                    )}
+                  </td>
+                  <td className="px-3 py-2 text-neutral-700">
+                    {e.email ? (
+                      <a className="text-primary-600 hover:underline" href={`mailto:${e.email}`}>
+                        {e.email}
+                      </a>
+                    ) : (
+                      <span className="text-neutral-400">—</span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Avatar({ entry }: { entry: PhoneBookEntry }) {
+  if (entry.photoURL) {
+    return (
+      <span
+        role="img"
+        aria-label={entry.displayName}
+        style={{ backgroundImage: `url(${entry.photoURL})` }}
+        className="w-8 h-8 rounded-full bg-cover bg-center border border-neutral-200 inline-block"
+      />
+    );
+  }
+  const init = initials(entry);
+  return (
+    <div className="w-8 h-8 rounded-full bg-primary-100 text-primary-700 flex items-center justify-center text-xs font-medium border border-primary-200">
+      {init || <UserIcon className="w-4 h-4" />}
+    </div>
+  );
+}

--- a/src/constants/text.ts
+++ b/src/constants/text.ts
@@ -858,6 +858,25 @@ export const TEXT_CONSTANTS = {
         ERR_SUBMIT_FAILED: 'שליחת התכנון נכשלה'
       }
     },
+    PHONE_BOOK: {
+      TITLE: 'ספר טלפונים',
+      DESCRIPTION: 'אנשי קשר של היחידה',
+      SEARCH_PLACEHOLDER: 'חפש לפי שם',
+      FILTER_TEAM: 'צוות',
+      FILTER_TEAM_ALL: 'כל הצוותים',
+      FILTER_ROLE: 'תפקיד',
+      FILTER_ROLE_ALL: 'כל התפקידים',
+      EMPTY: 'אין רשומות בספר הטלפונים',
+      EMPTY_FILTERED: 'לא נמצאו תוצאות לחיפוש',
+      LOADING: 'טוען...',
+      COL_NAME: 'שם',
+      COL_PHONE: 'טלפון',
+      COL_TEAM: 'צוות',
+      COL_ROLE: 'תפקיד',
+      COL_EMAIL: 'אימייל',
+      UNREGISTERED_BADGE: 'לא רשום',
+      TOTAL: 'סה״כ {count}'
+    },
     CONVOYS: {
       TITLE: 'שיירות',
       DESCRIPTION: 'תכנון וניהול שיירות'

--- a/src/hooks/usePhoneBook.ts
+++ b/src/hooks/usePhoneBook.ts
@@ -1,0 +1,37 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { listPhoneBookEntries } from '@/lib/phoneBook/phoneBookService';
+import type { PhoneBookEntry } from '@/types/phoneBook';
+
+export interface UsePhoneBookReturn {
+  entries: PhoneBookEntry[];
+  isLoading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+}
+
+export function usePhoneBook(): UsePhoneBookReturn {
+  const [entries, setEntries] = useState<PhoneBookEntry[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const list = await listPhoneBookEntries();
+      setEntries(list);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'שגיאה בטעינת ספר טלפונים');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  return { entries, isLoading, error, refresh };
+}

--- a/src/lib/db/collections.ts
+++ b/src/lib/db/collections.ts
@@ -28,6 +28,7 @@ export const COLLECTIONS = {
   PERMISSION_GRANTS: 'permissionGrants',
   SOLDIER_STATUS: 'soldierStatus',
   TRAINING_PLANS: 'trainingPlans',
+  PHONE_BOOK: 'phoneBook',
 } as const;
 
 export type CollectionName = typeof COLLECTIONS[keyof typeof COLLECTIONS];

--- a/src/lib/db/server/phoneBookService.ts
+++ b/src/lib/db/server/phoneBookService.ts
@@ -1,0 +1,165 @@
+/**
+ * Server-side Phone Book Service (firebase-admin).
+ *
+ * The `phoneBook` collection is a downstream, denormalized directory.
+ * Every write that adds or changes a phone number on a registered user
+ * (or an authorized_personnel row) must call into this service so the
+ * directory stays in sync.
+ *
+ * Doc id strategy:
+ *   - For users / authorized_personnel: the `militaryPersonalNumberHash`
+ *     so that the same person's entry merges across the registration
+ *     transition (personnel-only → personnel + user).
+ *   - For external entries (Phase 2): an arbitrary id.
+ */
+import { getAdminDb } from '../admin';
+import { COLLECTIONS } from '../collections';
+import { FieldValue } from 'firebase-admin/firestore';
+import type { UserType } from '@/types/user';
+
+interface UpsertFromUserInput {
+  uid: string;
+  militaryPersonalNumberHash: string;
+  firstName?: string;
+  lastName?: string;
+  phoneNumber?: string;
+  email?: string;
+  teamId?: string;
+  userType?: UserType;
+  photoURL?: string;
+}
+
+interface UpsertFromPersonnelInput {
+  militaryPersonalNumberHash: string;
+  firstName?: string;
+  lastName?: string;
+  phoneNumber?: string;
+  userType?: UserType;
+  registered?: boolean;
+}
+
+function buildDisplayName(firstName?: string, lastName?: string): string {
+  const parts = [firstName, lastName].filter((s): s is string => !!s && !!s.trim());
+  return parts.join(' ').trim();
+}
+
+function pruneUndefined<T extends Record<string, unknown>>(obj: T): Partial<T> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (v !== undefined && v !== '') out[k] = v;
+  }
+  return out as Partial<T>;
+}
+
+/**
+ * Upsert a phone-book entry from a registered user. Doc id =
+ * militaryPersonalNumberHash. Marks the entry as registered.
+ *
+ * Side-effects only — never throws upstream. Logs and swallows so the
+ * caller's primary write (e.g. registration) is not blocked by a directory
+ * sync hiccup.
+ */
+export async function serverUpsertPhoneBookFromUser(input: UpsertFromUserInput): Promise<void> {
+  try {
+    if (!input.militaryPersonalNumberHash) return;
+    const db = getAdminDb();
+    const ref = db.collection(COLLECTIONS.PHONE_BOOK).doc(input.militaryPersonalNumberHash);
+
+    const displayName = buildDisplayName(input.firstName, input.lastName) || input.email || input.uid;
+
+    const data = pruneUndefined({
+      id: input.militaryPersonalNumberHash,
+      source: 'users' as const,
+      userId: input.uid,
+      militaryPersonalNumberHash: input.militaryPersonalNumberHash,
+      firstName: input.firstName,
+      lastName: input.lastName,
+      displayName,
+      phoneNumber: input.phoneNumber,
+      email: input.email,
+      teamId: input.teamId,
+      userType: input.userType,
+      photoURL: input.photoURL,
+      isRegistered: true,
+      updatedAt: FieldValue.serverTimestamp(),
+    });
+
+    const existing = await ref.get();
+    if (!existing.exists) {
+      await ref.set({ ...data, createdAt: FieldValue.serverTimestamp() });
+    } else {
+      await ref.set(data, { merge: true });
+    }
+  } catch (e) {
+    console.error('[phoneBook] upsert from user failed:', e);
+  }
+}
+
+/**
+ * Upsert a phone-book entry from an authorized_personnel record. Doc id =
+ * militaryPersonalNumberHash. `isRegistered` mirrors the personnel flag.
+ *
+ * Side-effects only — same swallow-and-log policy as the user variant.
+ */
+export async function serverUpsertPhoneBookFromPersonnel(
+  input: UpsertFromPersonnelInput
+): Promise<void> {
+  try {
+    if (!input.militaryPersonalNumberHash) return;
+    const db = getAdminDb();
+    const ref = db.collection(COLLECTIONS.PHONE_BOOK).doc(input.militaryPersonalNumberHash);
+
+    const displayName = buildDisplayName(input.firstName, input.lastName) || input.militaryPersonalNumberHash;
+
+    const data = pruneUndefined({
+      id: input.militaryPersonalNumberHash,
+      source: 'authorized_personnel' as const,
+      militaryPersonalNumberHash: input.militaryPersonalNumberHash,
+      firstName: input.firstName,
+      lastName: input.lastName,
+      displayName,
+      phoneNumber: input.phoneNumber,
+      userType: input.userType,
+      isRegistered: input.registered ?? false,
+      updatedAt: FieldValue.serverTimestamp(),
+    });
+
+    const existing = await ref.get();
+    if (!existing.exists) {
+      await ref.set({ ...data, createdAt: FieldValue.serverTimestamp() });
+    } else {
+      // Don't downgrade an already-registered entry: keep `source='users'`
+      // and `isRegistered=true` if a personnel-only refresh comes through.
+      const prev = existing.data() ?? {};
+      const safe: Record<string, unknown> = { ...data };
+      if (prev.source === 'users') {
+        delete safe.source;
+        delete safe.isRegistered;
+      }
+      await ref.set(safe, { merge: true });
+    }
+  } catch (e) {
+    console.error('[phoneBook] upsert from personnel failed:', e);
+  }
+}
+
+/**
+ * Best-effort delete for a personnel-removal flow. Only deletes the entry
+ * if it has no `userId` (i.e. the person never registered) — registered
+ * users should keep their phoneBook entry until the underlying user doc
+ * is removed.
+ */
+export async function serverDeletePhoneBookEntryByHash(hash: string): Promise<void> {
+  try {
+    if (!hash) return;
+    const db = getAdminDb();
+    const ref = db.collection(COLLECTIONS.PHONE_BOOK).doc(hash);
+    const snap = await ref.get();
+    if (!snap.exists) return;
+    const data = snap.data() ?? {};
+    if (data.userId) return;
+    await ref.delete();
+  } catch (e) {
+    console.error('[phoneBook] delete by hash failed:', e);
+  }
+}

--- a/src/lib/phoneBook/phoneBookService.ts
+++ b/src/lib/phoneBook/phoneBookService.ts
@@ -1,0 +1,14 @@
+/**
+ * Client-side reads for the phoneBook collection.
+ * Mutations go through the server-side write-through pipeline.
+ */
+import { db } from '@/lib/firebase';
+import { collection, getDocs, orderBy, query } from 'firebase/firestore';
+import { COLLECTIONS } from '@/lib/db/collections';
+import type { PhoneBookEntry } from '@/types/phoneBook';
+
+export async function listPhoneBookEntries(): Promise<PhoneBookEntry[]> {
+  const q = query(collection(db, COLLECTIONS.PHONE_BOOK), orderBy('displayName'));
+  const snap = await getDocs(q);
+  return snap.docs.map((d) => ({ id: d.id, ...d.data() }) as PhoneBookEntry);
+}

--- a/src/types/phoneBook.ts
+++ b/src/types/phoneBook.ts
@@ -1,0 +1,33 @@
+import type { Timestamp } from 'firebase/firestore';
+import type { UserType } from './user';
+
+/**
+ * Source feed for a phoneBook document. The collection is downstream:
+ * registered users + authorized_personnel are the two write-through sources.
+ * `external` is reserved for Phase 2 (suppliers, range officers, etc.).
+ */
+export type PhoneBookSource = 'users' | 'authorized_personnel' | 'external';
+
+export interface PhoneBookEntry {
+  id: string;
+  source: PhoneBookSource;
+  /** Firebase Auth UID — set once the person registers. */
+  userId?: string;
+  /**
+   * For people on the army roster, this is `militaryPersonalNumberHash` — same
+   * value used as the doc id when the entry came from `users` /
+   * `authorized_personnel`. For external entries this is omitted.
+   */
+  militaryPersonalNumberHash?: string;
+  firstName?: string;
+  lastName?: string;
+  displayName: string;
+  phoneNumber?: string;
+  email?: string;
+  teamId?: string;
+  userType?: UserType;
+  photoURL?: string;
+  isRegistered: boolean;
+  createdAt: Timestamp;
+  updatedAt: Timestamp;
+}


### PR DESCRIPTION
New `/phone-book` page providing a searchable, filterable list of unit contacts. Phase 1 sources data from the existing `users` and `authorized_personnel` collections via a write-through sync — every register, profile phone-update, and authorized-personnel mutation also upserts the matching `phoneBook` doc. Future phases (external contacts, direct-edit UI) layer onto the same collection.

- New collection `phoneBook` with doc id = `militaryPersonalNumberHash`. Type at `src/types/phoneBook.ts`.
- Server service `src/lib/db/server/phoneBookService.ts` with `serverUpsertPhoneBookFromUser`, `serverUpsertPhoneBookFromPersonnel`, and `serverDeletePhoneBookEntryByHash`. All side-effects best-effort (try/catch + log) so a sync hiccup never blocks the primary write.
- Wired write-through into `/api/auth/register` (POST), `/api/users/profile` (PATCH — only when phone/team/profileImage change), `/api/authorized-personnel` (POST/PUT/DELETE), and `/api/authorized-personnel/bulk` (POST).
- Backfill script `scripts/backfill-phone-book.ts` (idempotent, --dry-run) reconciles the directory against the source collections.
- Client read service `src/lib/phoneBook/phoneBookService.ts` and hook `src/hooks/usePhoneBook.ts` (`{ entries, isLoading, error, refresh }`).
- `/phone-book` page: name search, team filter (Select sourced from systemConfig.teams + observed values), role filter, table with avatar (photoURL or initials), name, tel-link phone, team, role badge, mailto-link email. Authenticated users only via AuthGuard + the firestore.rules gate.

Spec: `docs/spec/phone-book.md`. Codebase mirrors for the hook and server service.