### PR TITLE
chore(scripts): backfill-phone-book reads creds from .env.local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ yarn-error.log*
 # env files (can opt-in for committing if needed)
 .env*
 service-account-key.json
+sa.json
+*.serviceaccount.json
 # vercel
 .vercel
 

--- a/docs/spec/phone-book.md
+++ b/docs/spec/phone-book.md
@@ -54,11 +54,14 @@ it never downgrades an entry that is already `source='users'`.
 ## Backfill
 
 `scripts/backfill-phone-book.ts` reads both source collections via
-firebase-admin and upserts every doc. Idempotent. Invocation:
+firebase-admin and upserts every doc. Idempotent.
+
+Credentials are loaded from `.env.local` — same `GOOGLE_SERVICE_ACCOUNT_JSON`
+(base64) and `NEXT_PUBLIC_FIREBASE_PROJECT_ID` that the Next.js runtime
+uses. No separate `sa.json` file required.
 
 ```
-GOOGLE_APPLICATION_CREDENTIALS=./sa.json \
-  ts-node scripts/backfill-phone-book.ts --project sayeret-givati-1983 [--dry-run]
+npx ts-node scripts/backfill-phone-book.ts [--dry-run]
 ```
 
 Run once before pointing client traffic at `/phone-book`.

--- a/scripts/backfill-phone-book.ts
+++ b/scripts/backfill-phone-book.ts
@@ -9,27 +9,74 @@
  * Doc id strategy: `militaryPersonalNumberHash`. Registered users
  * overwrite the personnel-only entry (source = 'users', isRegistered = true).
  *
+ * Credentials: reads `GOOGLE_SERVICE_ACCOUNT_JSON` (base64) and
+ * `NEXT_PUBLIC_FIREBASE_PROJECT_ID` from `.env.local` — same vars the
+ * Next.js runtime uses. No separate `sa.json` file required.
+ *
  * Usage:
- *   GOOGLE_APPLICATION_CREDENTIALS=./sa.json \
- *     ts-node scripts/backfill-phone-book.ts --project sayeret-givati-1983
+ *   npx ts-node scripts/backfill-phone-book.ts [--project <id>] [--dry-run]
  *
  * Flags:
- *   --dry-run   Log the planned writes without persisting.
+ *   --project <id>   Override project id (defaults to NEXT_PUBLIC_FIREBASE_PROJECT_ID).
+ *   --dry-run        Log the planned writes without persisting.
  */
 import * as admin from 'firebase-admin';
+import { readFileSync } from 'fs';
+import * as path from 'path';
+
+function loadEnvLocal(): void {
+  try {
+    const file = readFileSync(path.resolve(process.cwd(), '.env.local'), 'utf8');
+    for (const line of file.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#')) continue;
+      const eq = trimmed.indexOf('=');
+      if (eq < 0) continue;
+      const key = trimmed.slice(0, eq).trim();
+      let value = trimmed.slice(eq + 1).trim();
+      if (
+        (value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))
+      ) {
+        value = value.slice(1, -1);
+      }
+      if (!(key in process.env)) process.env[key] = value;
+    }
+  } catch {
+    // .env.local missing — fall back to whatever is already in process.env
+  }
+}
+
+loadEnvLocal();
 
 const args = process.argv.slice(2);
 const projectIdx = args.indexOf('--project');
-const projectId = projectIdx >= 0 ? args[projectIdx + 1] : undefined;
+const cliProjectId = projectIdx >= 0 ? args[projectIdx + 1] : undefined;
+const projectId = cliProjectId || process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID;
 const dryRun = args.includes('--dry-run');
 
 if (!projectId) {
-  console.error('Missing --project <projectId>');
+  console.error('Missing project id (pass --project or set NEXT_PUBLIC_FIREBASE_PROJECT_ID in .env.local)');
+  process.exit(1);
+}
+
+const saB64 = process.env.GOOGLE_SERVICE_ACCOUNT_JSON;
+if (!saB64) {
+  console.error('Missing GOOGLE_SERVICE_ACCOUNT_JSON in .env.local (base64-encoded service-account JSON)');
+  process.exit(1);
+}
+
+let saJson: admin.ServiceAccount;
+try {
+  const decoded = Buffer.from(saB64, 'base64').toString('utf8');
+  saJson = JSON.parse(decoded);
+} catch (e) {
+  console.error('Failed to decode GOOGLE_SERVICE_ACCOUNT_JSON:', e);
   process.exit(1);
 }
 
 admin.initializeApp({
-  credential: admin.credential.applicationDefault(),
+  credential: admin.credential.cert(saJson),
   projectId,
 });
 


### PR DESCRIPTION
Drop the requirement for a separate `sa.json` file when running the phone-book backfill. The script now reads `GOOGLE_SERVICE_ACCOUNT_JSON` (base64) and `NEXT_PUBLIC_FIREBASE_PROJECT_ID` from `.env.local` — the same vars the Next.js runtime uses.

- New invocation: npx ts-node scripts/backfill-phone-book.ts [--dry-run]
- Adds a tiny inline `.env.local` parser (no `dotenv` dep) + base64-decode
  + admin.credential.cert() init. CLI `--project` still wins if passed.
- `sa.json` and `*.serviceaccount.json` added to `.gitignore` defensively.
- docs/spec/phone-book.md updated to match.

The two older migration scripts (migrate-soldier-status, migrate-equipment-team-fields) still use the GOOGLE_APPLICATION_CREDENTIALS file-path pattern. Unifying them onto the same loader is queued in project_future_features.