### PR TITLE
fix(phone-book): wire phone book into sidebar nav

### DIFF
--- a/src/utils/navigationUtils.ts
+++ b/src/utils/navigationUtils.ts
@@ -71,6 +71,16 @@ export function getFeatureRoutes(): FeatureRoute[] {
       isComingSoon: false
     },
     {
+      title: TEXT_CONSTANTS.FEATURES.PHONE_BOOK.TITLE,
+      description: TEXT_CONSTANTS.FEATURES.PHONE_BOOK.DESCRIPTION,
+      icon: "📞",
+      href: "/phone-book",
+      available: true,
+      color: "bg-primary-600",
+      requiresAuth: true,
+      isComingSoon: false
+    },
+    {
       title: TEXT_CONSTANTS.FEATURES.CONVOYS.TITLE,
       description: TEXT_CONSTANTS.FEATURES.CONVOYS.DESCRIPTION,
       icon: "🚗",


### PR DESCRIPTION
The /phone-book page shipped in PR #48 but was missing from the feature routes list, so the sidebar (and any other consumer of getFeatureRoutes / getMenuItems) didn't show a link.

Add an entry between Ammunition and Convoys with the 📞 icon. Visible only to authenticated users (`requiresAuth: true`), matching the page's own AuthGuard.