### PR TITLE
fix(rtl+ui): batch 2 logical-Tailwind sweep + browser-dialog replacement

### DIFF
--- a/docs/rtl-audit.md
+++ b/docs/rtl-audit.md
@@ -1,8 +1,12 @@
 # RTL Audit — findings & triage
 
-**Status:** In progress. First batch landed 2026-05-12 on `fix/admin-role-and-status-polish`.
-Full sweep is multi-session (505 physical-class hits across 116 .tsx files); this doc
-tracks the punch list.
+**Status:** In progress. Batches landing one at a time on dedicated branches.
+Full sweep is multi-session; this doc tracks the punch list.
+
+**Hit-count note:** the initial 505-hit count came from a loose grep
+(`pl-|pr-|...` without word boundary, which matched substrings like `pr-imary-`).
+The stricter grep `(\s|"|')(pl-|pr-|ml-|mr-)\d` returns **49 real hits across 21
+files** — much more tractable. Use the stricter form when re-running.
 
 `<html dir="rtl">` is set globally in `src/app/layout.tsx`. CLAUDE.md forbids
 per-component `dir="rtl"`. Despite that, components leak LTR through hardcoded
@@ -36,27 +40,56 @@ Recurring offender: action-row headers that want the primary CTA on the right.
 - `src/app/ammunition/training/page.tsx:56` — `justify-end` → `justify-start`
   on the "תכנן אימון" action row (was pushing the Plus button to the left).
 
+### ✅ Fixed (2026-05-12, batch 2 — `fix/rtl-batch-2-and-no-browser-dialogs`)
+
+- `src/components/equipment/TransferModal.tsx` — 6 hits. Search-input icon
+  positioning converted from `left-0 pl-3` / `right-0 pr-3` to `start-0 ps-3` /
+  `end-0 pe-3`. Textarea icon at `top-3 left-3` → `top-3 start-3`. Input padding
+  flipped to logical (`ps-10 pe-3`). Required-asterisk margins to `ms-1`.
+  Stray `text-red-*` / `border-red-*` swapped for `text-danger-*` /
+  `border-danger-*` tokens while at it.
+- `src/components/management/tabs/UsersTab.tsx` — 9 hits. All `ml-*` on
+  icons → `me-*` (gap toward following text). All `mr-4` on stats-card text
+  blocks → `ms-4` (gap toward preceding icon).
+- `src/app/status/page.tsx` — 3 hits. Search-input padding `pl-10` → `ps-10`;
+  absolute-positioned search icon `left-0 pl-3` → `start-0 ps-3`; counter
+  span margin `mr-2` → `ms-2`.
+- `src/app/components/SoldiersTableMobile.tsx` — 2 hits. Name span padding
+  `pr-0.5` → `pe-0.5`; platoon span margin `ml-3` → `me-3`.
+
 ### 🟡 Quick-win candidates (next batch)
 
-Files with the highest physical-class density that touch user-visible flows.
-Counts are approximate (grep hit-count, not distinct-class-count).
+Re-counted with the stricter grep `(\s|"|')(pl-|pr-|ml-|mr-)\d` — these are
+the remaining real hits, not substring false-positives.
 
 | File | Hits | Notes |
 |------|------|-------|
-| `src/components/equipment/TransferModal.tsx` | 16 | Modal — likely safe to convert in isolation |
-| `src/components/management/tabs/DataManagementTab.tsx` | 17 | Admin tab |
-| `src/components/management/tabs/AuditLogsTab.tsx` | 13 | Admin tab |
-| `src/components/management/tabs/EnforceTransferTab.tsx` | 12 | Admin tab |
-| `src/components/management/tabs/PermissionGrantsTab.tsx` | 12 | Admin tab |
-| `src/components/profile/PhoneNumberUpdate.tsx` | 9 | User-facing |
-| `src/components/ammunition/AmmunitionTemplateForm.tsx` | 9 | Form |
-| `src/components/ammunition/ReportUsageForm.tsx` | 8 | Form |
-| `src/app/components/SoldiersTableMobile.tsx` | 9 | Status page mobile (touched in batch 1 for registered-dot) |
-| `src/app/components/SoldiersTableDesktop.tsx` | 8 | Status page desktop (touched in batch 1) |
+| `src/components/EquipmentTest.tsx` | 5 | Dev/test component — skip unless QA flags |
+| `src/components/registration/AccountDetailsStep.tsx` | 3 | Registration flow |
+| `src/components/management/tabs/DataManagementTab.tsx` | 2 | Admin tab |
+| `src/components/management/tabs/EmailTab.tsx` | 2 | Admin tab |
+| `src/components/management/tabs/PermissionsTab.tsx` | 2 | Admin tab |
+| `src/components/ui/ConfirmationModal.tsx` | 2 | Shared modal — fix once, propagates everywhere |
+| `src/app/components/SearchBar.tsx` | 2 | Top-bar search |
+| `src/components/SimpleUserTest.tsx` | 2 | Dev/test component — skip |
+| `src/components/management/sidebar/SidebarNavigation.tsx` | 1 | Sidebar |
+| `src/components/management/tabs/AuditLogsTab.tsx` | 1 | Admin tab |
+| `src/components/management/tabs/CustomUserSelectionModal.tsx` | 1 | Admin modal |
+| `src/components/management/tabs/EnforceTransferTab.tsx` | 1 | Admin tab |
+| `src/components/auth/LoginModal.tsx` | 1 | Login modal |
+| `src/components/equipment/template-form/FormFieldRequiresDailyCheck.tsx` | 1 | Form field |
+| `src/components/registration/RegistrationDetailsStep.tsx` | 1 | Registration flow |
+| `src/components/ui/FormField.tsx` | 1 | Shared form field |
+| `src/app/components/TextInputWithError.tsx` | 1 | Input wrapper |
 
 Convert each file in isolation; don't bundle. After each conversion, QA the
 affected page on mobile (where misalignment is most visible) and add it to the
 "Fixed" list above with a short note.
+
+**Priority order for next batch:** `ConfirmationModal.tsx` first (shared, fix
+once + propagate), then `LoginModal.tsx` + `SearchBar.tsx` + `AccountDetailsStep.tsx`
+(high-visibility user-facing flows). Admin tabs are low-priority — small hit
+counts, few daily users.
 
 ### 🔴 Intentional `dir="ltr"` (DO NOT REMOVE)
 
@@ -74,7 +107,10 @@ affected page on mobile (where misalignment is most visible) and add it to the
 
 ## Related follow-up (not RTL but found during audit)
 
-- `src/components/ammunition/PlannedTrainingsTable.tsx:175,178` — uses
-  `window.prompt` and `window.alert`. Violates `feedback_no_browser_dialogs`.
-  Replace with the existing in-app `ConfirmationModal` / a new
-  `TextInputModal` (or extend `ConfirmationModal` with an optional input).
+- ~~`src/components/ammunition/PlannedTrainingsTable.tsx:175,178` — uses
+  `window.prompt` and `window.alert`.~~ **DONE 2026-05-12 on
+  `fix/rtl-batch-2-and-no-browser-dialogs`.** Replaced with an inline
+  Headless UI `Dialog` containing a textarea for the rejection reason +
+  inline error rendering for the empty-reason case. New text constants:
+  `REJECT_TITLE`, `REJECT_SUBMIT`, `REJECT_CANCEL`, `REJECT_REASON_PLACEHOLDER`
+  under `FEATURES.AMMUNITION.TRAINING`.

--- a/src/app/components/SoldiersTableMobile.tsx
+++ b/src/app/components/SoldiersTableMobile.tsx
@@ -200,7 +200,7 @@ export default function SoldiersTableMobile({
                 onChange={() => onToggleSelection(index)}
                 className="w-4 h-4 text-primary-600 border-neutral-300 rounded focus:ring-primary-500"
               />
-              <span className="text-neutral-700 pr-0.5 font-medium flex-1 inline-flex items-center gap-2">
+              <span className="text-neutral-700 pe-0.5 font-medium flex-1 inline-flex items-center gap-2">
                 <span
                   aria-hidden="true"
                   title={
@@ -214,7 +214,7 @@ export default function SoldiersTableMobile({
                 />
                 {soldier.name}
               </span>
-              <span className="text-neutral-600 ml-3 text-sm">{soldier.platoon}</span>
+              <span className="text-neutral-600 me-3 text-sm">{soldier.platoon}</span>
             
               {/* Status Toggle Icons */}
               <div className="flex bg-neutral-100 rounded-lg p-1">

--- a/src/app/status/page.tsx
+++ b/src/app/status/page.tsx
@@ -274,9 +274,9 @@ export default function StatusPage() {
                     value={nameFilter}
                     onChange={(e) => setNameFilter(e.target.value)}
                     placeholder={TEXT_CONSTANTS.STATUS_PAGE.SEARCH_BY_NAME}
-                    className="w-full border-2 border-neutral-400 rounded-md px-3 py-2 text-neutral-800 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500 placeholder-neutral-600 pl-10"
+                    className="w-full border-2 border-neutral-400 rounded-md px-3 py-2 text-neutral-800 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500 placeholder-neutral-600 ps-10"
                   />
-                  <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
+                  <div className="absolute inset-y-0 start-0 flex items-center ps-3 pointer-events-none">
                     <svg
                       xmlns="http://www.w3.org/2000/svg"
                       className="h-5 w-5 text-neutral-400"
@@ -298,7 +298,7 @@ export default function StatusPage() {
                   <p className="text-lg font-medium text-neutral-800">
                     נבחרו: {filteredSelectedCount} מתוך {filteredTotalCount}
                     {(nameFilter || selectedTeams.length > 0 || selectedStatuses.length > 0) && (
-                      <span className="text-sm text-neutral-600 mr-2">
+                      <span className="text-sm text-neutral-600 ms-2">
                         (סה&quot;כ: {selectedCount} מתוך {totalCount})
                       </span>
                     )}

--- a/src/components/ammunition/PlannedTrainingsTable.tsx
+++ b/src/components/ammunition/PlannedTrainingsTable.tsx
@@ -1,7 +1,15 @@
 'use client';
 
 import React, { useMemo, useState } from 'react';
-import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/react';
+import {
+  Disclosure,
+  DisclosureButton,
+  DisclosurePanel,
+  Dialog,
+  DialogBackdrop,
+  DialogPanel,
+  DialogTitle,
+} from '@headlessui/react';
 import { ChevronDown } from 'lucide-react';
 import { Button } from '@/components/ui';
 import ConfirmationModal from '@/components/ui/ConfirmationModal';
@@ -161,6 +169,9 @@ function PlanTable({
 }: PlanTableProps) {
   const [busyId, setBusyId] = useState<string | null>(null);
   const [pendingCancelId, setPendingCancelId] = useState<string | null>(null);
+  const [rejectingPlanId, setRejectingPlanId] = useState<string | null>(null);
+  const [rejectReason, setRejectReason] = useState('');
+  const [rejectError, setRejectError] = useState<string | null>(null);
 
   const handleAction = async (planId: string, fn: () => Promise<boolean>) => {
     setBusyId(planId);
@@ -171,14 +182,31 @@ function PlanTable({
     }
   };
 
-  const handleReject = async (planId: string) => {
-    const reason = window.prompt(TT.REJECT_PROMPT, '');
-    if (reason === null) return;
-    if (!reason.trim()) {
-      window.alert(TT.REJECT_REASON_REQUIRED);
+  const handleReject = (planId: string) => {
+    setRejectingPlanId(planId);
+    setRejectReason('');
+    setRejectError(null);
+  };
+
+  const closeRejectDialog = () => {
+    if (busyId === rejectingPlanId) return;
+    setRejectingPlanId(null);
+    setRejectReason('');
+    setRejectError(null);
+  };
+
+  const submitReject = async () => {
+    if (!rejectingPlanId) return;
+    const trimmed = rejectReason.trim();
+    if (!trimmed) {
+      setRejectError(TT.REJECT_REASON_REQUIRED);
       return;
     }
-    await handleAction(planId, () => onReject(planId, reason.trim()));
+    const planId = rejectingPlanId;
+    setRejectingPlanId(null);
+    setRejectReason('');
+    setRejectError(null);
+    await handleAction(planId, () => onReject(planId, trimmed));
   };
 
   const handleCancel = (planId: string) => {
@@ -315,6 +343,62 @@ function PlanTable({
         variant="warning"
         useHomePageStyle
       />
+
+      <Dialog
+        open={!!rejectingPlanId}
+        onClose={closeRejectDialog}
+        className="relative z-50"
+      >
+        <DialogBackdrop className="fixed inset-0 bg-black/30 backdrop-blur-sm" />
+        <div className="fixed inset-0 flex items-center justify-center p-4">
+          <DialogPanel className="w-full max-w-md bg-white rounded-xl shadow-2xl border border-neutral-200">
+            <div className="px-6 py-4 border-b border-neutral-200">
+              <DialogTitle className="text-lg font-semibold text-neutral-900">
+                {TT.REJECT_TITLE}
+              </DialogTitle>
+            </div>
+            <div className="p-6 space-y-3">
+              <label htmlFor="reject-reason" className="block text-sm font-medium text-neutral-700">
+                {TT.REJECT_PROMPT}
+              </label>
+              <textarea
+                id="reject-reason"
+                value={rejectReason}
+                onChange={(e) => {
+                  setRejectReason(e.target.value);
+                  if (rejectError) setRejectError(null);
+                }}
+                rows={4}
+                disabled={busyId === rejectingPlanId}
+                placeholder={TT.REJECT_REASON_PLACEHOLDER}
+                className="w-full px-3 py-2 border border-neutral-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500"
+                autoFocus
+              />
+              {rejectError && (
+                <p className="text-sm text-danger-700" role="alert">
+                  {rejectError}
+                </p>
+              )}
+            </div>
+            <div className="flex justify-end gap-3 p-6 border-t border-neutral-200">
+              <Button
+                variant="secondary"
+                onClick={closeRejectDialog}
+                disabled={busyId === rejectingPlanId}
+              >
+                {TT.REJECT_CANCEL}
+              </Button>
+              <Button
+                variant="danger"
+                onClick={submitReject}
+                disabled={busyId === rejectingPlanId}
+              >
+                {TT.REJECT_SUBMIT}
+              </Button>
+            </div>
+          </DialogPanel>
+        </div>
+      </Dialog>
     </div>
   );
 }

--- a/src/components/equipment/TransferModal.tsx
+++ b/src/components/equipment/TransferModal.tsx
@@ -224,10 +224,10 @@ export default function TransferModal({
           <div className="relative" ref={dropdownRef}>
             <label className="block text-sm font-medium text-neutral-700 mb-2">
               {TEXT_CONSTANTS.FEATURES.EQUIPMENT.TRANSFER.TO_USER}
-              <span className="text-red-500 mr-1">*</span>
+              <span className="text-danger-500 ms-1">*</span>
             </label>
             <div className="relative">
-              <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+              <div className="absolute inset-y-0 start-0 ps-3 flex items-center pointer-events-none">
                 <Search className="h-5 w-5 text-neutral-400" />
               </div>
               <input
@@ -247,13 +247,13 @@ export default function TransferModal({
                    }
                  }}
                 placeholder={TEXT_CONSTANTS.FEATURES.EQUIPMENT.TRANSFER.TO_USER_PLACEHOLDER}
-                className={`w-full pl-10 pr-3 py-2 border rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 transition-colors ${
-                  errors.toUserId ? 'border-red-300' : 'border-neutral-300'
+                className={`w-full ps-10 pe-3 py-2 border rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 transition-colors ${
+                  errors.toUserId ? 'border-danger-300' : 'border-neutral-300'
                 }`}
                 disabled={isSubmitting}
               />
               {isSearching && (
-                <div className="absolute inset-y-0 right-0 pr-3 flex items-center">
+                <div className="absolute inset-y-0 end-0 pe-3 flex items-center">
                   <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-primary-600"></div>
                 </div>
               )}
@@ -306,7 +306,7 @@ export default function TransferModal({
           <div>
             <label className="block text-sm font-medium text-neutral-700 mb-2">
               {TEXT_CONSTANTS.FEATURES.EQUIPMENT.TRANSFER.REASON}
-              <span className="text-red-500 mr-1">*</span>
+              <span className="text-danger-500 ms-1">*</span>
             </label>
             <input
               type="text"
@@ -329,7 +329,7 @@ export default function TransferModal({
               {TEXT_CONSTANTS.FEATURES.EQUIPMENT.TRANSFER.NOTE}
             </label>
             <div className="relative">
-              <div className="absolute top-3 left-3 pointer-events-none">
+              <div className="absolute top-3 start-3 pointer-events-none">
                 <MessageSquare className="h-5 w-5 text-neutral-400" />
               </div>
               <textarea
@@ -337,7 +337,7 @@ export default function TransferModal({
                 onChange={(e) => handleInputChange('note', e.target.value)}
                 placeholder={TEXT_CONSTANTS.FEATURES.EQUIPMENT.TRANSFER.NOTE_PLACEHOLDER}
                 rows={3}
-                className="w-full pl-10 pr-3 py-2 border border-neutral-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 transition-colors resize-none"
+                className="w-full ps-10 pe-3 py-2 border border-neutral-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 transition-colors resize-none"
                 disabled={isSubmitting}
               />
             </div>

--- a/src/components/management/tabs/UsersTab.tsx
+++ b/src/components/management/tabs/UsersTab.tsx
@@ -100,7 +100,7 @@ export default function UsersTab() {
     return (
       <div className="space-y-6">
         <div className="flex items-center justify-center py-12">
-          <RefreshCw className="w-8 h-8 text-primary-600 animate-spin ml-3" />
+          <RefreshCw className="w-8 h-8 text-primary-600 animate-spin me-3" />
           <span className="text-lg text-neutral-600">{TEXT_CONSTANTS.MANAGEMENT.USERS.LOADING_USERS}</span>
         </div>
       </div>
@@ -113,7 +113,7 @@ export default function UsersTab() {
       <div className="space-y-6">
         <div className="bg-danger-50 border border-danger-200 rounded-lg p-6">
           <div className="flex items-center">
-            <AlertCircle className="w-6 h-6 text-danger-600 ml-3" />
+            <AlertCircle className="w-6 h-6 text-danger-600 me-3" />
             <div>
               <h3 className="text-lg font-medium text-danger-800">{TEXT_CONSTANTS.MANAGEMENT.USERS.ERROR_LOADING_TITLE}</h3>
               <p className="text-sm text-danger-600 mt-1">{error}</p>
@@ -139,7 +139,7 @@ export default function UsersTab() {
           className="px-4 py-2 bg-neutral-600 hover:bg-neutral-700 text-white font-medium rounded-lg transition-colors shadow-sm flex items-center"
           disabled={loading}
         >
-          <RefreshCw className={`w-4 h-4 ml-2 ${loading ? 'animate-spin' : ''}`} />
+          <RefreshCw className={`w-4 h-4 me-2 ${loading ? 'animate-spin' : ''}`} />
           {TEXT_CONSTANTS.MANAGEMENT.USERS.REFRESH_BUTTON}
         </button>
         <button className="px-4 py-2 bg-primary-600 hover:bg-primary-700 text-white font-medium rounded-lg transition-colors shadow-sm">
@@ -229,7 +229,7 @@ export default function UsersTab() {
                   <tr key={user.uid} className="hover:bg-neutral-50">
                     <td className="px-6 py-4 whitespace-nowrap">
                       <div className="flex items-center">
-                        <div className="w-8 h-8 bg-primary-100 rounded-full flex items-center justify-center ml-3">
+                        <div className="w-8 h-8 bg-primary-100 rounded-full flex items-center justify-center me-3">
                           <span className="text-sm font-bold text-primary-600">
                             {getUserInitials(user.fullName)}
                           </span>
@@ -262,7 +262,7 @@ export default function UsersTab() {
                       </span>
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm space-x-2">
-                      <button className="text-info-600 hover:text-info-900 ml-2">{TEXT_CONSTANTS.MANAGEMENT.USERS.EDIT_ACTION}</button>
+                      <button className="text-info-600 hover:text-info-900 me-2">{TEXT_CONSTANTS.MANAGEMENT.USERS.EDIT_ACTION}</button>
                       <button className="text-danger-600 hover:text-danger-900">{TEXT_CONSTANTS.MANAGEMENT.USERS.DELETE_ACTION}</button>
                     </td>
                   </tr>
@@ -278,7 +278,7 @@ export default function UsersTab() {
         <div className="bg-white rounded-lg border border-neutral-200 p-4">
           <div className="flex items-center">
             <Users className="w-8 h-8 text-info-600" />
-            <div className="mr-4">
+            <div className="ms-4">
               <div className="text-2xl font-bold text-neutral-900">{stats.total}</div>
               <div className="text-sm text-neutral-600">{TEXT_CONSTANTS.MANAGEMENT.USERS.TOTAL_USERS}</div>
             </div>
@@ -289,7 +289,7 @@ export default function UsersTab() {
             <div className="w-8 h-8 bg-success-100 rounded-full flex items-center justify-center">
               <span className="text-success-600 font-bold">✓</span>
             </div>
-            <div className="mr-4">
+            <div className="ms-4">
               <div className="text-2xl font-bold text-success-600">{stats.active}</div>
               <div className="text-sm text-neutral-600">{TEXT_CONSTANTS.MANAGEMENT.USERS.ACTIVE_USERS}</div>
             </div>
@@ -300,7 +300,7 @@ export default function UsersTab() {
             <div className="w-8 h-8 bg-danger-100 rounded-full flex items-center justify-center">
               <span className="text-danger-600 font-bold">×</span>
             </div>
-            <div className="mr-4">
+            <div className="ms-4">
               <div className="text-2xl font-bold text-danger-600">{stats.inactive}</div>
               <div className="text-sm text-neutral-600">{TEXT_CONSTANTS.MANAGEMENT.USERS.INACTIVE_USERS}</div>
             </div>
@@ -311,7 +311,7 @@ export default function UsersTab() {
             <div className="w-8 h-8 bg-warning-100 rounded-full flex items-center justify-center">
               <span className="text-warning-600 font-bold">⏳</span>
             </div>
-            <div className="mr-4">
+            <div className="ms-4">
               <div className="text-2xl font-bold text-warning-600">{stats.pending}</div>
               <div className="text-sm text-neutral-600">{TEXT_CONSTANTS.MANAGEMENT.USERS.TRANSFERRED_USERS}</div>
             </div>

--- a/src/constants/text.ts
+++ b/src/constants/text.ts
@@ -846,6 +846,10 @@ export const TEXT_CONSTANTS = {
         COMPLETE: 'סמן הושלם',
         REJECT_PROMPT: 'נמק את הסיבה לדחייה:',
         REJECT_REASON_REQUIRED: 'יש להזין סיבה לדחייה',
+        REJECT_TITLE: 'דחיית תכנון אימון',
+        REJECT_SUBMIT: 'שלח דחייה',
+        REJECT_CANCEL: 'ביטול',
+        REJECT_REASON_PLACEHOLDER: 'הזן סיבה...',
         CANCEL_CONFIRM: 'לבטל את התכנון?',
         STATUS: {
           PENDING_APPROVAL: 'ממתין לאישור',


### PR DESCRIPTION
RTL batch 2 — convert physical Tailwind classes to logical equivalents (start/end/ms/me/ps/pe) so the affected pages stop leaking LTR layout under <html dir="rtl">:

- TransferModal.tsx (6 hits): search-input icon positioning + textarea icon + input padding to logical. Stray text-red-*/border-red-* swapped for the danger-* tokens.
- UsersTab.tsx (9 hits): all ml-* on icons -> me-*; all mr-4 on stats-card text blocks -> ms-4.
- status/page.tsx (3 hits): search-input ps-10, absolute icon start-0, counter span ms-2.
- SoldiersTableMobile.tsx (2 hits): name pe-0.5, platoon me-3.

Browser-dialog fix — PlannedTrainingsTable.tsx used window.prompt + window.alert for the rejection-reason flow (violates feedback_no_browser_dialogs). Replaced with an inline Headless UI Dialog containing a textarea + inline error rendering. New text constants REJECT_TITLE / REJECT_SUBMIT / REJECT_CANCEL / REJECT_REASON_PLACEHOLDER under FEATURES.AMMUNITION.TRAINING.

docs/rtl-audit.md updated with batch-2 results, corrected hit-count methodology (initial 505 was a substring false-positive; real number is ~49 across 21 files), and a prioritized next-batch list.