### PR TITLE
fix(rtl): batch 3 — shared modals + login + registration

### DIFF
--- a/docs/rtl-audit.md
+++ b/docs/rtl-audit.md
@@ -57,39 +57,59 @@ Recurring offender: action-row headers that want the primary CTA on the right.
 - `src/app/components/SoldiersTableMobile.tsx` — 2 hits. Name span padding
   `pr-0.5` → `pe-0.5`; platoon span margin `ml-3` → `me-3`.
 
+### ✅ Fixed (2026-05-12, batch 3 — `fix/rtl-batch-3-shared-modals`)
+
+- `src/components/ui/ConfirmationModal.tsx` — 2 hits + 1 forbidden per-component
+  `dir`. Removed `dir={useHomePageStyle ? "rtl" : "ltr"}` (CLAUDE.md forbids
+  per-component `dir`; modal inherits from `<html dir="rtl">`). `ml-3` → `ms-3`,
+  spinner `mr-2` → `me-2`.
+- `src/components/auth/LoginModal.tsx` — 4 real hits (the audit had only listed
+  1; found more on inspection). Close button `right-4` → `end-4`; email + password
+  inputs `text-right` → `text-end`, `pr-12` → `pe-12`; absolute-positioned
+  email icon `left-3` → `end-3`; password eye-toggle `left-3` → `end-3`.
+- `src/app/components/SearchBar.tsx` — 2 hits. Input padding `pl-10` → `ps-10`;
+  absolute icon `left-0 pl-3` → `start-0 ps-3`.
+- `src/components/registration/AccountDetailsStep.tsx` — 12 hits (audit had
+  listed 3; tooltip + spinner pile-on). All `text-right` → `text-end`. Email
+  field `pr-12` + `right-3` → `ps-12` + `start-3`. Password field
+  `pl-12 pr-12` → `pe-12 ps-12`; eye-toggle button `left-3` → `end-3`; lock
+  icon `right-3` → `start-3`. Tooltip absolute `right-0` → `start-0`, arrow
+  `right-3` → `start-3`, `border-l-4 border-r-4 border-l-transparent
+  border-r-transparent` → `border-s-4 border-e-4 border-s-transparent
+  border-e-transparent`. Spinner `-ml-1 mr-2` → `-ms-1 me-2`. Stale "Now on
+  Left/Right" comments removed.
+- `src/components/ui/FormField.tsx` — 1 hit. Required-asterisk `mr-1` → `ms-1`.
+- `src/app/components/TextInputWithError.tsx` — 1 hit. Label `pr-1.5` → `pe-1.5`.
+
 ### 🟡 Quick-win candidates (next batch)
 
-Re-counted with the stricter grep `(\s|"|')(pl-|pr-|ml-|mr-)\d` — these are
-the remaining real hits, not substring false-positives.
+Remaining real hits after batch 3: **19 hits across 11 files**. Almost all in
+admin tabs (low daily traffic) or dev-only test components.
 
 | File | Hits | Notes |
 |------|------|-------|
 | `src/components/EquipmentTest.tsx` | 5 | Dev/test component — skip unless QA flags |
-| `src/components/registration/AccountDetailsStep.tsx` | 3 | Registration flow |
+| `src/components/SimpleUserTest.tsx` | 2 | Dev/test component — skip |
 | `src/components/management/tabs/DataManagementTab.tsx` | 2 | Admin tab |
 | `src/components/management/tabs/EmailTab.tsx` | 2 | Admin tab |
 | `src/components/management/tabs/PermissionsTab.tsx` | 2 | Admin tab |
-| `src/components/ui/ConfirmationModal.tsx` | 2 | Shared modal — fix once, propagates everywhere |
-| `src/app/components/SearchBar.tsx` | 2 | Top-bar search |
-| `src/components/SimpleUserTest.tsx` | 2 | Dev/test component — skip |
 | `src/components/management/sidebar/SidebarNavigation.tsx` | 1 | Sidebar |
 | `src/components/management/tabs/AuditLogsTab.tsx` | 1 | Admin tab |
 | `src/components/management/tabs/CustomUserSelectionModal.tsx` | 1 | Admin modal |
 | `src/components/management/tabs/EnforceTransferTab.tsx` | 1 | Admin tab |
-| `src/components/auth/LoginModal.tsx` | 1 | Login modal |
 | `src/components/equipment/template-form/FormFieldRequiresDailyCheck.tsx` | 1 | Form field |
 | `src/components/registration/RegistrationDetailsStep.tsx` | 1 | Registration flow |
-| `src/components/ui/FormField.tsx` | 1 | Shared form field |
-| `src/app/components/TextInputWithError.tsx` | 1 | Input wrapper |
 
-Convert each file in isolation; don't bundle. After each conversion, QA the
-affected page on mobile (where misalignment is most visible) and add it to the
-"Fixed" list above with a short note.
+**Priority for next batch:** `RegistrationDetailsStep.tsx` (registration flow,
+user-facing); then the admin tabs together (one branch, since they share
+patterns). Test components can stay broken — they are not user-facing.
 
-**Priority order for next batch:** `ConfirmationModal.tsx` first (shared, fix
-once + propagate), then `LoginModal.tsx` + `SearchBar.tsx` + `AccountDetailsStep.tsx`
-(high-visibility user-facing flows). Admin tabs are low-priority — small hit
-counts, few daily users.
+Pattern for password / email input pairs (codify):
+- Hebrew text-input: `text-end` (not `text-right`)
+- Reserve space for trailing icon: `pe-12` (not `pr-12`) when icon at `end-3`
+- Reserve space for leading icon: `ps-12` (not `pl-12`) when icon at `start-3`
+- Absolute icon positioning: `start-3` / `end-3` (not `left-3` / `right-3`)
+- Borders: `border-s-*` / `border-e-*` (not `border-l-*` / `border-r-*`)
 
 ### 🔴 Intentional `dir="ltr"` (DO NOT REMOVE)
 

--- a/src/app/components/SearchBar.tsx
+++ b/src/app/components/SearchBar.tsx
@@ -19,9 +19,9 @@ export default function SearchBar({
           value={value}
           onChange={(e) => onChange(e.target.value)}
           placeholder={placeholder}
-          className="w-full border-2 border-neutral-400 rounded-md px-3 py-2 text-neutral-800 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500 placeholder-neutral-600 pl-10"
+          className="w-full border-2 border-neutral-400 rounded-md px-3 py-2 text-neutral-800 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500 placeholder-neutral-600 ps-10"
         />
-        <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
+        <div className="absolute inset-y-0 start-0 flex items-center ps-3 pointer-events-none">
           <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-neutral-400" viewBox="0 0 20 20" fill="currentColor">
             <path fillRule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clipRule="evenodd" />
           </svg>

--- a/src/app/components/TextInputWithError.tsx
+++ b/src/app/components/TextInputWithError.tsx
@@ -21,7 +21,7 @@ export default function TextInputWithError({
 }: TextInputWithErrorProps) {
   return (
     <div>
-      <label className="block text-sm font-medium text-neutral-700 mb-1 pr-1.5">
+      <label className="block text-sm font-medium text-neutral-700 mb-1 pe-1.5">
         {label} {required && <span className="text-danger-500">*</span>}
       </label>
       <input 

--- a/src/components/auth/LoginModal.tsx
+++ b/src/components/auth/LoginModal.tsx
@@ -74,7 +74,7 @@ export default function LoginModal({ isOpen, onClose, onSwitch }: LoginModalProp
           {/* Close Button - Top Right */}
           <button
             onClick={handleClose}
-            className="absolute top-4 right-4 z-10 p-2 hover:bg-neutral-100 rounded-full btn-press focus-ring
+            className="absolute top-4 end-4 z-10 p-2 hover:bg-neutral-100 rounded-full btn-press focus-ring
                        text-neutral-400 hover:text-neutral-600 transition-all duration-200"
             disabled={isLoading}
             aria-label={TEXT_CONSTANTS.ARIA_LABELS.CLOSE_MODAL}
@@ -118,14 +118,14 @@ export default function LoginModal({ isOpen, onClose, onSwitch }: LoginModalProp
                     onChange={handleInputChange}
                     className="w-full px-4 py-3.5 border-2 border-neutral-200 rounded-xl focus:ring-2
                              focus:ring-primary-500 focus:border-primary-500 outline-none transition-all
-                             text-right text-neutral-800 bg-neutral-50 focus:bg-white placeholder-neutral-500"
+                             text-end text-neutral-800 bg-neutral-50 focus:bg-white placeholder-neutral-500"
                     placeholder={TEXT_CONSTANTS.AUTH.EMAIL_PLACEHOLDER}
                     disabled={isLoading}
                     required
                   />
-                  <div className="absolute left-3 top-1/2 transform -translate-y-1/2">
+                  <div className="absolute end-3 top-1/2 transform -translate-y-1/2">
                     <svg className="w-5 h-5 text-neutral-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} 
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
                             d="M16 12a4 4 0 10-8 0 4 4 0 008 0zm0 0v1.5a2.5 2.5 0 005 0V12a9 9 0 10-9 9m4.5-1.206a8.959 8.959 0 01-4.5 1.207" />
                     </svg>
                   </div>
@@ -149,7 +149,7 @@ export default function LoginModal({ isOpen, onClose, onSwitch }: LoginModalProp
                     onChange={handleInputChange}
                     className="w-full px-4 py-3.5 border-2 border-neutral-200 rounded-xl focus:ring-2
                              focus:ring-primary-500 focus:border-primary-500 outline-none transition-all
-                             text-right text-neutral-800 bg-neutral-50 focus:bg-white pr-12 placeholder-neutral-500"
+                             text-end text-neutral-800 bg-neutral-50 focus:bg-white pe-12 placeholder-neutral-500"
                     placeholder={TEXT_CONSTANTS.AUTH.PASSWORD_PLACEHOLDER}
                     disabled={isLoading}
                     required
@@ -157,7 +157,7 @@ export default function LoginModal({ isOpen, onClose, onSwitch }: LoginModalProp
                   <button
                     type="button"
                     onClick={() => setShowPassword(!showPassword)}
-                    className="absolute left-3 top-1/2 transform -translate-y-1/2 
+                    className="absolute end-3 top-1/2 transform -translate-y-1/2
                              text-neutral-400 hover:text-neutral-600 transition-colors p-1 rounded-md
                              focus:outline-none focus:ring-2 focus:ring-primary-300"
                     disabled={isLoading}

--- a/src/components/registration/AccountDetailsStep.tsx
+++ b/src/components/registration/AccountDetailsStep.tsx
@@ -98,7 +98,7 @@ export default function AccountDetailsStep({
                 value={formData.email}
                 onChange={(e) => handleInputChange('email', e.target.value)}
                 className={`w-full px-4 py-2.5 border-2 rounded-xl focus:ring-2 outline-none transition-all
-                         text-right text-neutral-800 bg-neutral-50 focus:bg-white placeholder-neutral-500 pr-12 ${
+                         text-end text-neutral-800 bg-neutral-50 focus:bg-white placeholder-neutral-500 ps-12 ${
                   validationErrors.email && formData.email
                     ? 'border-danger-500 focus:border-danger-500 focus:ring-danger-500'
                     : 'border-neutral-200 focus:border-info-500 focus:ring-info-500'
@@ -106,9 +106,9 @@ export default function AccountDetailsStep({
                 placeholder={TEXT_CONSTANTS.AUTH.EMAIL_PLACEHOLDER_REGISTRATION}
                 data-testid="email-input"
               />
-              <div className="absolute right-3 top-1/2 transform -translate-y-1/2">
+              <div className="absolute start-3 top-1/2 transform -translate-y-1/2">
                 <svg className="w-5 h-5 text-neutral-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} 
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
                         d="M16 12a4 4 0 10-8 0 4 4 0 008 0zm0 0v1.5a2.5 2.5 0 005 0V12a9 9 0 10-9 9m4.5-1.206a8.959 8.959 0 01-4.5 1.207" />
                 </svg>
               </div>
@@ -116,7 +116,7 @@ export default function AccountDetailsStep({
             
             {/* Email Error Message */}
             {validationErrors.email && formData.email && (
-              <p className="text-xs text-danger-600 text-right px-1" data-testid="email-error">
+              <p className="text-xs text-danger-600 text-end px-1" data-testid="email-error">
                 {validationErrors.email}
               </p>
             )}
@@ -133,7 +133,7 @@ export default function AccountDetailsStep({
                 value={formData.password}
                 onChange={(e) => handleInputChange('password', e.target.value)}
                 className={`w-full px-4 py-2.5 border-2 rounded-xl focus:ring-2 outline-none transition-all
-                         text-right text-neutral-800 bg-neutral-50 focus:bg-white placeholder-neutral-500 pl-12 pr-12 ${
+                         text-end text-neutral-800 bg-neutral-50 focus:bg-white placeholder-neutral-500 pe-12 ps-12 ${
                   validationErrors.password && formData.password
                     ? 'border-danger-500 focus:border-danger-500 focus:ring-danger-500'
                     : 'border-neutral-200 focus:border-info-500 focus:ring-info-500'
@@ -142,11 +142,11 @@ export default function AccountDetailsStep({
                 data-testid="password-input"
               />
               
-              {/* Password Toggle Button - Now on Left */}
+              {/* Password Toggle Button */}
               <button
                 type="button"
                 onClick={togglePasswordVisibility}
-                className="absolute left-3 top-1/2 transform -translate-y-1/2 text-neutral-400 hover:text-neutral-600 transition-colors duration-200"
+                className="absolute end-3 top-1/2 transform -translate-y-1/2 text-neutral-400 hover:text-neutral-600 transition-colors duration-200"
                 data-testid="password-toggle"
                 aria-label={showPassword ? TEXT_CONSTANTS.AUTH.HIDE_PASSWORD : TEXT_CONSTANTS.AUTH.SHOW_PASSWORD}
               >
@@ -165,9 +165,9 @@ export default function AccountDetailsStep({
                 )}
               </button>
 
-              {/* Lock Icon with Tooltip - Now on Right */}
-              <div className="absolute right-3 top-1/2 transform -translate-y-1/2">
-                <div 
+              {/* Lock Icon with Tooltip */}
+              <div className="absolute start-3 top-1/2 transform -translate-y-1/2">
+                <div
                   className="relative"
                   onMouseEnter={() => setShowPasswordTooltip(true)}
                   onMouseLeave={() => setShowPasswordTooltip(false)}
@@ -179,9 +179,9 @@ export default function AccountDetailsStep({
                   
                   {/* Password Requirements Tooltip */}
                   {showPasswordTooltip && (
-                    <div className="absolute bottom-full right-0 mb-2 w-64 bg-neutral-800 text-white text-xs rounded-lg p-3 z-10 shadow-lg">
+                    <div className="absolute bottom-full start-0 mb-2 w-64 bg-neutral-800 text-white text-xs rounded-lg p-3 z-10 shadow-lg">
                       <div className="text-center font-semibold mb-2">דרישות סיסמה:</div>
-                      <ul className="text-right space-y-1">
+                      <ul className="text-end space-y-1">
                         <li>• לפחות 8 תווים</li>
                         <li>• אות גדולה (A-Z)</li>
                         <li>• אות קטנה (a-z)</li>
@@ -189,7 +189,7 @@ export default function AccountDetailsStep({
                         <li>• תו מיוחד (!@#$%^&*)</li>
                       </ul>
                       {/* Tooltip Arrow */}
-                      <div className="absolute top-full right-3 w-0 h-0 border-l-4 border-r-4 border-t-4 border-l-transparent border-r-transparent border-t-neutral-800"></div>
+                      <div className="absolute top-full start-3 w-0 h-0 border-s-4 border-e-4 border-t-4 border-s-transparent border-e-transparent border-t-neutral-800"></div>
                     </div>
                   )}
                 </div>
@@ -198,7 +198,7 @@ export default function AccountDetailsStep({
             
             {/* Password Error Message */}
             {validationErrors.password && formData.password && (
-              <p className="text-xs text-danger-600 text-right px-1" data-testid="password-error">
+              <p className="text-xs text-danger-600 text-end px-1" data-testid="password-error">
                 {validationErrors.password}
               </p>
             )}
@@ -220,7 +220,7 @@ export default function AccountDetailsStep({
                 
                 data-testid="consent-checkbox"
               />
-              <label htmlFor="consent" className="text-sm text-neutral-700 text-right leading-5">
+              <label htmlFor="consent" className="text-sm text-neutral-700 text-end leading-5">
                 * אני מסכים/ה ל
                 <button
                   type="button"
@@ -236,7 +236,7 @@ export default function AccountDetailsStep({
           {/* Submission error from parent (linkEmailPassword / register API) */}
           {submitError && !isSubmitting && (
             <p
-              className="text-xs text-danger-600 text-right px-1"
+              className="text-xs text-danger-600 text-end px-1"
               data-testid="account-submit-error"
               role="alert"
             >
@@ -260,7 +260,7 @@ export default function AccountDetailsStep({
           >
             {isSubmitting ? (
               <>
-                <svg className="animate-spin -ml-1 mr-2 h-5 w-5 text-white" fill="none" viewBox="0 0 24 24">
+                <svg className="animate-spin -ms-1 me-2 h-5 w-5 text-white" fill="none" viewBox="0 0 24 24">
                   <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
                   <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                 </svg>

--- a/src/components/ui/ConfirmationModal.tsx
+++ b/src/components/ui/ConfirmationModal.tsx
@@ -87,11 +87,10 @@ export default function ConfirmationModal({
   };
 
   return (
-    <div 
+    <div
       className="fixed inset-0 z-50 overflow-y-auto"
       onKeyDown={handleKeyDown}
       tabIndex={-1}
-      dir={useHomePageStyle ? "rtl" : "ltr"}
     >
       {/* Backdrop */}
       <div 
@@ -108,7 +107,7 @@ export default function ConfirmationModal({
               <div className={`flex-shrink-0 w-10 h-10 rounded-full ${styles.iconBg} flex items-center justify-center`}>
                 <span className={`${styles.iconColor} text-xl`}>{styles.icon}</span>
               </div>
-              <div className="ml-3">
+              <div className="ms-3">
                 <h3 className="text-lg font-medium text-neutral-900 dark:text-white">
                   {title}
                 </h3>
@@ -167,7 +166,7 @@ export default function ConfirmationModal({
             >
               {isLoading ? (
                 <div className="flex items-center">
-                  <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2"></div>
+                  <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white me-2"></div>
                   טוען...
                 </div>
               ) : (

--- a/src/components/ui/FormField.tsx
+++ b/src/components/ui/FormField.tsx
@@ -30,7 +30,7 @@ export default function FormField({
         className="block text-sm font-medium text-neutral-700"
       >
         {label}
-        {required && <span className="text-danger-500 mr-1">*</span>}
+        {required && <span className="text-danger-500 ms-1">*</span>}
       </label>
       
       <div className="relative">


### PR DESCRIPTION
Convert physical Tailwind classes to logical equivalents (start/end/ms/me/ ps/pe/border-s/border-e) across shared modal + high-visibility entry-point flows. Eliminates LTR-leak when <html dir="rtl">.

- ConfirmationModal.tsx — removed forbidden per-component dir={useHomePageStyle ? "rtl" : "ltr"} (CLAUDE.md forbids per-component dir; modal now inherits from <html dir="rtl">). ml-3 -> ms-3, spinner mr-2 -> me-2.
- LoginModal.tsx — close button right-4 -> end-4; email + password inputs text-right -> text-end and pr-12 -> pe-12; absolute email icon left-3 -> end-3; password eye-toggle left-3 -> end-3.
- SearchBar.tsx — input pl-10 -> ps-10; absolute icon left-0 pl-3 -> start-0 ps-3.
- AccountDetailsStep.tsx — 12 real hits (audit had listed 3; tooltip + spinner + lock icon + eye toggle all leaked). text-right -> text-end throughout; pr-12 / pl-12 -> ps-12 / pe-12; absolute right-3 / left-3 on icons -> start-3 / end-3; tooltip arrow border-l-/border-r- -> border-s-/border-e-; spinner -ml-1 mr-2 -> -ms-1 me-2. Stale "Now on Left/Right" comments removed.
- FormField.tsx (shared) — required-asterisk mr-1 -> ms-1.
- TextInputWithError.tsx — label pr-1.5 -> pe-1.5.

docs/rtl-audit.md updated: batch-3 results, remaining 19 hits in 11 files (mostly admin tabs / dev components), codified pattern for password/email input pairs as future reference.