### PR TITLE
fix(rtl): batch 4 — registration details + admin tabs

### DIFF
--- a/docs/rtl-audit.md
+++ b/docs/rtl-audit.md
@@ -81,28 +81,63 @@ Recurring offender: action-row headers that want the primary CTA on the right.
 - `src/components/ui/FormField.tsx` — 1 hit. Required-asterisk `mr-1` → `ms-1`.
 - `src/app/components/TextInputWithError.tsx` — 1 hit. Label `pr-1.5` → `pe-1.5`.
 
+### ✅ Fixed (2026-05-13, batch 4 — `fix/rtl-batch-4-registration-and-admin-tabs`)
+
+`RegistrationDetailsStep.tsx` + 8 admin/form components. Audit's strict grep
+(margin-only) listed 11 hits; widened to also catch `text-right`, `border-r-*`,
+`absolute left-*/right-*`, etc. that the strict grep missed. Real fixed count:
+~25 hits across these files.
+
+- `src/components/registration/RegistrationDetailsStep.tsx` — 12 hits. Read-only
+  first/last-name inputs `text-right` → `text-end`; email + password inputs
+  `text-right` → `text-end`; password `pr-12` → `pe-12`; absolute email icon +
+  password eye-toggle `left-3` → `end-3`; six error-message `text-right` →
+  `text-end`; birthdate input `text-right` → `text-end`.
+- `src/components/management/tabs/DataManagementTab.tsx` — 7 hits. Five
+  table-header `text-right` → `text-start`; two action-button `ml-2` → `me-2`.
+- `src/components/management/tabs/EmailTab.tsx` — 3 hits. Two checkbox
+  `ml-2` → `me-2`; one template-card `text-right` → `text-end`.
+- `src/components/management/tabs/PermissionsTab.tsx` — 2 hits. Both checkbox
+  `ml-2` → `me-2`.
+- `src/components/management/sidebar/SidebarNavigation.tsx` — 3 hits. Active-tab
+  indicator `border-r-2` → `border-e-2`; icon-text gap `ml-3` → `me-3`; label
+  `text-right` → `text-start`.
+- `src/components/management/tabs/AuditLogsTab.tsx` — 7 hits. Six table-header
+  `text-right` → `text-start`; stats-card text block `mr-4` → `ms-4`.
+- `src/components/management/tabs/CustomUserSelectionModal.tsx` — 3 hits.
+  Horizontal scroller `pl-4 pr-4` → `ps-4 pe-4`; two absolute fade-edges
+  `left-0` / `right-0` → `end-0` / `start-0` (gradient direction unchanged —
+  site is pure RTL, so visual placement is preserved).
+- `src/components/management/tabs/EnforceTransferTab.tsx` — 7 hits. Six
+  table-header `text-right` → `text-start`; approve-button `ml-2` → `me-2`.
+- `src/components/equipment/template-form/FormFieldRequiresDailyCheck.tsx` — 1
+  hit. Label `mr-2` → `ms-2`.
+
 ### 🟡 Quick-win candidates (next batch)
 
-Remaining real hits after batch 3: **19 hits across 11 files**. Almost all in
-admin tabs (low daily traffic) or dev-only test components.
+Remaining hits surfaced during batch 4 that are out of its scope. Audit's
+margin-only strict grep undercounted these; logical conversion is still
+incomplete in many admin/registration components.
 
-| File | Hits | Notes |
-|------|------|-------|
-| `src/components/EquipmentTest.tsx` | 5 | Dev/test component — skip unless QA flags |
-| `src/components/SimpleUserTest.tsx` | 2 | Dev/test component — skip |
-| `src/components/management/tabs/DataManagementTab.tsx` | 2 | Admin tab |
-| `src/components/management/tabs/EmailTab.tsx` | 2 | Admin tab |
-| `src/components/management/tabs/PermissionsTab.tsx` | 2 | Admin tab |
-| `src/components/management/sidebar/SidebarNavigation.tsx` | 1 | Sidebar |
-| `src/components/management/tabs/AuditLogsTab.tsx` | 1 | Admin tab |
-| `src/components/management/tabs/CustomUserSelectionModal.tsx` | 1 | Admin modal |
-| `src/components/management/tabs/EnforceTransferTab.tsx` | 1 | Admin tab |
-| `src/components/equipment/template-form/FormFieldRequiresDailyCheck.tsx` | 1 | Form field |
-| `src/components/registration/RegistrationDetailsStep.tsx` | 1 | Registration flow |
+| File | Notes |
+|------|-------|
+| `src/components/management/tabs/UsersTab.tsx` | 6 table-header `text-right` (batch 2 fixed margins only). Convert to `text-start`. |
+| `src/components/management/tabs/TemplatesTab.tsx` | `text-right` on disclosure button. |
+| `src/components/management/tabs/PermissionGrantsTab.tsx` | `left-1/2` on toast. |
+| `src/components/management/BulkTemplateImportModal.tsx` | `text-right` table. |
+| `src/components/registration/PersonalDetailsStep.tsx` | 6 `text-right` + 1 `text-left` (date input — exempt; verify). |
+| `src/components/registration/OTPVerificationStep.tsx` | `left-3` icon. |
+| `src/components/registration/RegistrationForm.tsx` | `text-right` + `left-3` icon. |
+| `src/components/registration/RegistrationStepDots.tsx` | `left-1/2` tooltip + `border-l-2 border-r-2 …` triangle. |
+| `src/components/ammunition/AmmunitionInventoryView.tsx` + 4 other `Ammunition*` views | `text-right` tables. |
+| `src/components/equipment/TransferModal.tsx` | 2 `text-right` (search results — batch 2 fixed icons). |
+| `src/components/notifications/NotificationItem.tsx` | `border-r-2` + `left-2` dot. |
+| `src/components/notifications/NotificationBell.tsx` | 2 `-right-1` absolute badges. |
+| `src/components/equipment/EquipmentErrorBoundary.tsx` | `text-left` (English stack trace — likely exempt). |
+| `src/components/EquipmentTest.tsx` + `SimpleUserTest.tsx` | Dev-only — skip. |
 
-**Priority for next batch:** `RegistrationDetailsStep.tsx` (registration flow,
-user-facing); then the admin tabs together (one branch, since they share
-patterns). Test components can stay broken — they are not user-facing.
+`justify-end` on button rows is intentional everywhere it appears (CTAs end-aligned
+in modal footers). Do not flag those.
 
 Pattern for password / email input pairs (codify):
 - Hebrew text-input: `text-end` (not `text-right`)

--- a/src/components/equipment/template-form/FormFieldRequiresDailyCheck.tsx
+++ b/src/components/equipment/template-form/FormFieldRequiresDailyCheck.tsx
@@ -26,7 +26,7 @@ export default function FormFieldRequiresDailyCheck({
         disabled={disabled}
         className="h-4 w-4 text-primary-600 focus:ring-primary-500 border-neutral-300 rounded"
       />
-      <label htmlFor="requiresDailyStatusCheck" className="mr-2 text-sm text-neutral-700">
+      <label htmlFor="requiresDailyStatusCheck" className="ms-2 text-sm text-neutral-700">
         {TEXT_CONSTANTS.FEATURES.EQUIPMENT.TEMPLATE_FORM.REQUIRES_DAILY_CHECK}
       </label>
     </div>

--- a/src/components/management/sidebar/SidebarNavigation.tsx
+++ b/src/components/management/sidebar/SidebarNavigation.tsx
@@ -57,12 +57,12 @@ export default function SidebarNavigation({
                       'hover:bg-primary-50 hover:text-primary-700',
                       'focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2',
                       isActive
-                        ? 'bg-primary-100 text-primary-700 border-r-2 border-primary-600'
+                        ? 'bg-primary-100 text-primary-700 border-e-2 border-primary-600'
                         : 'text-neutral-700 hover:text-primary-700'
                     )}
                   >
-                    <Icon className="w-5 h-5 ml-3 flex-shrink-0" />
-                    <span className="flex-1 text-right">{tab.label}</span>
+                    <Icon className="w-5 h-5 me-3 flex-shrink-0" />
+                    <span className="flex-1 text-start">{tab.label}</span>
                   </button>
                 );
               })}

--- a/src/components/management/tabs/AuditLogsTab.tsx
+++ b/src/components/management/tabs/AuditLogsTab.tsx
@@ -154,12 +154,12 @@ export default function AuditLogsTab() {
             <table className="min-w-full divide-y divide-neutral-200">
               <thead className="bg-neutral-50">
                 <tr>
-                  <th className="px-6 py-3 text-right text-xs font-medium text-neutral-500 uppercase tracking-wider">זמן</th>
-                  <th className="px-6 py-3 text-right text-xs font-medium text-neutral-500 uppercase tracking-wider">מבצע</th>
-                  <th className="px-6 py-3 text-right text-xs font-medium text-neutral-500 uppercase tracking-wider">פעולה</th>
-                  <th className="px-6 py-3 text-right text-xs font-medium text-neutral-500 uppercase tracking-wider">ציוד</th>
-                  <th className="px-6 py-3 text-right text-xs font-medium text-neutral-500 uppercase tracking-wider">יעד</th>
-                  <th className="px-6 py-3 text-right text-xs font-medium text-neutral-500 uppercase tracking-wider">הערות</th>
+                  <th className="px-6 py-3 text-start text-xs font-medium text-neutral-500 uppercase tracking-wider">זמן</th>
+                  <th className="px-6 py-3 text-start text-xs font-medium text-neutral-500 uppercase tracking-wider">מבצע</th>
+                  <th className="px-6 py-3 text-start text-xs font-medium text-neutral-500 uppercase tracking-wider">פעולה</th>
+                  <th className="px-6 py-3 text-start text-xs font-medium text-neutral-500 uppercase tracking-wider">ציוד</th>
+                  <th className="px-6 py-3 text-start text-xs font-medium text-neutral-500 uppercase tracking-wider">יעד</th>
+                  <th className="px-6 py-3 text-start text-xs font-medium text-neutral-500 uppercase tracking-wider">הערות</th>
                 </tr>
               </thead>
               <tbody className="bg-white divide-y divide-neutral-200">
@@ -189,7 +189,7 @@ export default function AuditLogsTab() {
           <div className="w-8 h-8 bg-info-100 rounded-full flex items-center justify-center">
             <span className="text-info-600 font-bold">📊</span>
           </div>
-          <div className="mr-4">
+          <div className="ms-4">
             <div className="text-2xl font-bold text-neutral-900">{logs.length}</div>
             <div className="text-sm text-neutral-600">רשומות מוצגות</div>
           </div>

--- a/src/components/management/tabs/CustomUserSelectionModal.tsx
+++ b/src/components/management/tabs/CustomUserSelectionModal.tsx
@@ -264,7 +264,7 @@ export default function CustomUserSelectionModal({
                 ) : (
                   <div className="relative">
                     {/* Horizontal scrollable container */}
-                    <div className="flex gap-3 overflow-x-auto pb-4 pl-4 pr-4 scrollbar-thin scrollbar-thumb-neutral-300 scrollbar-track-neutral-100">
+                    <div className="flex gap-3 overflow-x-auto pb-4 ps-4 pe-4 scrollbar-thin scrollbar-thumb-neutral-300 scrollbar-track-neutral-100">
                       {filteredUsers.map((user) => (
                         <UserChip
                           key={user.uid}
@@ -276,8 +276,8 @@ export default function CustomUserSelectionModal({
                     </div>
                     
                     {/* Fade edges for visual scroll indication */}
-                    <div className="absolute left-0 top-0 bottom-4 w-4 bg-gradient-to-r from-white to-transparent pointer-events-none" />
-                    <div className="absolute right-0 top-0 bottom-4 w-4 bg-gradient-to-l from-white to-transparent pointer-events-none" />
+                    <div className="absolute end-0 top-0 bottom-4 w-4 bg-gradient-to-r from-white to-transparent pointer-events-none" />
+                    <div className="absolute start-0 top-0 bottom-4 w-4 bg-gradient-to-l from-white to-transparent pointer-events-none" />
                   </div>
                 )}
 

--- a/src/components/management/tabs/DataManagementTab.tsx
+++ b/src/components/management/tabs/DataManagementTab.tsx
@@ -26,11 +26,11 @@ export default function DataManagementTab() {
           <table className="min-w-full divide-y divide-neutral-200">
             <thead className="bg-neutral-50">
               <tr>
-                <th className="px-6 py-3 text-right text-xs font-medium text-neutral-500 uppercase tracking-wider">טבלה</th>
-                <th className="px-6 py-3 text-right text-xs font-medium text-neutral-500 uppercase tracking-wider">רשומות</th>
-                <th className="px-6 py-3 text-right text-xs font-medium text-neutral-500 uppercase tracking-wider">גודל</th>
-                <th className="px-6 py-3 text-right text-xs font-medium text-neutral-500 uppercase tracking-wider">עדכון אחרון</th>
-                <th className="px-6 py-3 text-right text-xs font-medium text-neutral-500 uppercase tracking-wider">פעולות</th>
+                <th className="px-6 py-3 text-start text-xs font-medium text-neutral-500 uppercase tracking-wider">טבלה</th>
+                <th className="px-6 py-3 text-start text-xs font-medium text-neutral-500 uppercase tracking-wider">רשומות</th>
+                <th className="px-6 py-3 text-start text-xs font-medium text-neutral-500 uppercase tracking-wider">גודל</th>
+                <th className="px-6 py-3 text-start text-xs font-medium text-neutral-500 uppercase tracking-wider">עדכון אחרון</th>
+                <th className="px-6 py-3 text-start text-xs font-medium text-neutral-500 uppercase tracking-wider">פעולות</th>
               </tr>
             </thead>
             <tbody className="bg-white divide-y divide-neutral-200">
@@ -41,8 +41,8 @@ export default function DataManagementTab() {
                   <td className="px-6 py-4 whitespace-nowrap text-sm text-neutral-900">{table.size}</td>
                   <td className="px-6 py-4 whitespace-nowrap text-sm text-neutral-500">{table.lastUpdate}</td>
                   <td className="px-6 py-4 whitespace-nowrap text-sm space-x-2">
-                    <button className="text-info-600 hover:text-info-900 ml-2">ייצא</button>
-                    <button className="text-success-600 hover:text-success-900 ml-2">גבה</button>
+                    <button className="text-info-600 hover:text-info-900 me-2">ייצא</button>
+                    <button className="text-success-600 hover:text-success-900 me-2">גבה</button>
                     <button className="text-orange-600 hover:text-orange-900">נקה</button>
                   </td>
                 </tr>

--- a/src/components/management/tabs/EmailTab.tsx
+++ b/src/components/management/tabs/EmailTab.tsx
@@ -149,7 +149,7 @@ export default function EmailTab() {
                             setSelectedRoles(selectedRoles.filter(r => r !== userType.value));
                           }
                         }}
-                        className="text-primary-600 focus:ring-primary-500 ml-2"
+                        className="text-primary-600 focus:ring-primary-500 me-2"
                       />
                       <span className="text-sm text-neutral-700">{userType.label}</span>
                     </div>
@@ -174,7 +174,7 @@ export default function EmailTab() {
                             setSelectedTeams(selectedTeams.filter(t => t !== team.value));
                           }
                         }}
-                        className="text-primary-600 focus:ring-primary-500 ml-2"
+                        className="text-primary-600 focus:ring-primary-500 me-2"
                       />
                       <span className="text-sm text-neutral-700">{team.label}</span>
                     </div>
@@ -281,7 +281,7 @@ export default function EmailTab() {
             <button
               key={index}
               onClick={() => handleTemplateSelect(template)}
-              className="p-3 text-right border border-neutral-200 rounded-lg hover:border-primary-300 hover:bg-primary-50 transition-colors"
+              className="p-3 text-end border border-neutral-200 rounded-lg hover:border-primary-300 hover:bg-primary-50 transition-colors"
             >
               <div className="font-medium text-neutral-900 text-sm">{template.title}</div>
               <div className="text-neutral-600 text-xs mt-1">{template.content}</div>

--- a/src/components/management/tabs/EnforceTransferTab.tsx
+++ b/src/components/management/tabs/EnforceTransferTab.tsx
@@ -190,12 +190,12 @@ export default function EnforceTransferTab() {
             <table className="min-w-full divide-y divide-neutral-200">
               <thead className="bg-neutral-50">
                 <tr>
-                  <th className="px-6 py-3 text-right text-xs font-medium text-neutral-500 uppercase tracking-wider">ציוד</th>
-                  <th className="px-6 py-3 text-right text-xs font-medium text-neutral-500 uppercase tracking-wider">מאת</th>
-                  <th className="px-6 py-3 text-right text-xs font-medium text-neutral-500 uppercase tracking-wider">אל</th>
-                  <th className="px-6 py-3 text-right text-xs font-medium text-neutral-500 uppercase tracking-wider">תאריך</th>
-                  <th className="px-6 py-3 text-right text-xs font-medium text-neutral-500 uppercase tracking-wider">סיבה</th>
-                  <th className="px-6 py-3 text-right text-xs font-medium text-neutral-500 uppercase tracking-wider">פעולות</th>
+                  <th className="px-6 py-3 text-start text-xs font-medium text-neutral-500 uppercase tracking-wider">ציוד</th>
+                  <th className="px-6 py-3 text-start text-xs font-medium text-neutral-500 uppercase tracking-wider">מאת</th>
+                  <th className="px-6 py-3 text-start text-xs font-medium text-neutral-500 uppercase tracking-wider">אל</th>
+                  <th className="px-6 py-3 text-start text-xs font-medium text-neutral-500 uppercase tracking-wider">תאריך</th>
+                  <th className="px-6 py-3 text-start text-xs font-medium text-neutral-500 uppercase tracking-wider">סיבה</th>
+                  <th className="px-6 py-3 text-start text-xs font-medium text-neutral-500 uppercase tracking-wider">פעולות</th>
                 </tr>
               </thead>
               <tbody className="bg-white divide-y divide-neutral-200">
@@ -210,7 +210,7 @@ export default function EnforceTransferTab() {
                       <button
                         onClick={() => handleApprove(transfer.id)}
                         disabled={actionInProgress === transfer.id}
-                        className="text-success-600 hover:text-success-900 ml-2 disabled:opacity-50"
+                        className="text-success-600 hover:text-success-900 me-2 disabled:opacity-50"
                       >
                         {actionInProgress === transfer.id ? '...' : 'אשר'}
                       </button>

--- a/src/components/management/tabs/PermissionsTab.tsx
+++ b/src/components/management/tabs/PermissionsTab.tsx
@@ -40,7 +40,7 @@ export default function PermissionsTab() {
                     <input
                       type="checkbox"
                       checked={role.permissions.includes(permission.id)}
-                      className="text-primary-600 focus:ring-primary-500 ml-2"
+                      className="text-primary-600 focus:ring-primary-500 me-2"
                       readOnly
                     />
                     <span className="text-sm text-neutral-700">{permission.name}</span>
@@ -79,7 +79,7 @@ export default function PermissionsTab() {
                   <div key={permission.id} className="flex items-center">
                     <input
                       type="checkbox"
-                      className="text-primary-600 focus:ring-primary-500 ml-2"
+                      className="text-primary-600 focus:ring-primary-500 me-2"
                     />
                     <span className="text-sm text-neutral-700">{permission.name}</span>
                   </div>

--- a/src/components/registration/RegistrationDetailsStep.tsx
+++ b/src/components/registration/RegistrationDetailsStep.tsx
@@ -134,8 +134,8 @@ export default function RegistrationDetailsStep({
                 type="text"
                 value={firstName}
                 readOnly
-                className="w-full px-4 py-3 border-2 border-neutral-200 rounded-xl bg-neutral-100 
-                         text-right text-neutral-600 cursor-not-allowed"
+                className="w-full px-4 py-3 border-2 border-neutral-200 rounded-xl bg-neutral-100
+                         text-end text-neutral-600 cursor-not-allowed"
                 data-testid="first-name-readonly"
               />
             </div>
@@ -149,8 +149,8 @@ export default function RegistrationDetailsStep({
                 type="text"
                 value={lastName}
                 readOnly
-                className="w-full px-4 py-3 border-2 border-neutral-200 rounded-xl bg-neutral-100 
-                         text-right text-neutral-600 cursor-not-allowed"
+                className="w-full px-4 py-3 border-2 border-neutral-200 rounded-xl bg-neutral-100
+                         text-end text-neutral-600 cursor-not-allowed"
                 data-testid="last-name-readonly"
               />
             </div>
@@ -169,7 +169,7 @@ export default function RegistrationDetailsStep({
                 value={formData.email}
                 onChange={(e) => handleInputChange('email', e.target.value)}
                 className={`w-full px-4 py-3.5 border-2 rounded-xl focus:ring-2 outline-none transition-all
-                         text-right text-neutral-800 bg-neutral-50 focus:bg-white placeholder-neutral-500 ${
+                         text-end text-neutral-800 bg-neutral-50 focus:bg-white placeholder-neutral-500 ${
                   validationErrors.email && formData.email
                     ? 'border-danger-500 focus:border-danger-500 focus:ring-danger-500'
                     : 'border-neutral-200 focus:border-info-500 focus:ring-info-500'
@@ -177,15 +177,15 @@ export default function RegistrationDetailsStep({
                 placeholder={TEXT_CONSTANTS.AUTH.EMAIL_PLACEHOLDER_REGISTRATION}
                 data-testid="email-input"
               />
-              <div className="absolute left-3 top-1/2 transform -translate-y-1/2">
+              <div className="absolute end-3 top-1/2 transform -translate-y-1/2">
                 <svg className="w-5 h-5 text-neutral-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} 
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
                         d="M16 12a4 4 0 10-8 0 4 4 0 008 0zm0 0v1.5a2.5 2.5 0 005 0V12a9 9 0 10-9 9m4.5-1.206a8.959 8.959 0 01-4.5 1.207" />
                 </svg>
               </div>
             </div>
             {validationErrors.email && formData.email && (
-              <p className="text-sm text-danger-600 text-right px-1" data-testid="email-error">
+              <p className="text-sm text-danger-600 text-end px-1" data-testid="email-error">
                 {validationErrors.email}
               </p>
             )}
@@ -202,7 +202,7 @@ export default function RegistrationDetailsStep({
                 value={formData.password}
                 onChange={(e) => handleInputChange('password', e.target.value)}
                 className={`w-full px-4 py-3.5 border-2 rounded-xl focus:ring-2 outline-none transition-all
-                         text-right text-neutral-800 bg-neutral-50 focus:bg-white pr-12 placeholder-neutral-500 ${
+                         text-end text-neutral-800 bg-neutral-50 focus:bg-white pe-12 placeholder-neutral-500 ${
                   validationErrors.password && formData.password
                     ? 'border-danger-500 focus:border-danger-500 focus:ring-danger-500'
                     : 'border-neutral-200 focus:border-info-500 focus:ring-info-500'
@@ -213,7 +213,7 @@ export default function RegistrationDetailsStep({
               <button
                 type="button"
                 onClick={() => setShowPassword(!showPassword)}
-                className="absolute left-3 top-1/2 transform -translate-y-1/2 
+                className="absolute end-3 top-1/2 transform -translate-y-1/2
                          text-neutral-400 hover:text-neutral-600 transition-colors p-1 rounded-md
                          focus:outline-none focus:ring-2 focus:ring-info-300"
               >
@@ -233,7 +233,7 @@ export default function RegistrationDetailsStep({
               </button>
             </div>
             {validationErrors.password && formData.password && (
-              <p className="text-sm text-danger-600 text-right px-1" data-testid="password-error">
+              <p className="text-sm text-danger-600 text-end px-1" data-testid="password-error">
                 {validationErrors.password}
               </p>
             )}
@@ -257,7 +257,7 @@ export default function RegistrationDetailsStep({
               ariaLabel={TEXT_CONSTANTS.AUTH.GENDER}
             />
             {validationErrors.gender && (
-              <p className="text-sm text-danger-600 text-right px-1" data-testid="gender-error">
+              <p className="text-sm text-danger-600 text-end px-1" data-testid="gender-error">
                 {validationErrors.gender}
               </p>
             )}
@@ -273,7 +273,7 @@ export default function RegistrationDetailsStep({
               value={formData.birthdate}
               onChange={(e) => handleInputChange('birthdate', e.target.value)}
               className={`w-full px-4 py-3.5 border-2 rounded-xl focus:ring-2 outline-none transition-all
-                       text-right text-neutral-800 bg-neutral-50 focus:bg-white ${
+                       text-end text-neutral-800 bg-neutral-50 focus:bg-white ${
                 validationErrors.birthdate && formData.birthdate
                   ? 'border-danger-500 focus:border-danger-500 focus:ring-danger-500'
                   : 'border-neutral-200 focus:border-info-500 focus:ring-info-500'
@@ -281,7 +281,7 @@ export default function RegistrationDetailsStep({
               data-testid="birthdate-input"
             />
             {validationErrors.birthdate && formData.birthdate && (
-              <p className="text-sm text-danger-600 text-right px-1" data-testid="birthdate-error">
+              <p className="text-sm text-danger-600 text-end px-1" data-testid="birthdate-error">
                 {validationErrors.birthdate}
               </p>
             )}
@@ -310,7 +310,7 @@ export default function RegistrationDetailsStep({
               </span>
             </label>
             {validationErrors.consent && (
-              <p className="text-sm text-danger-600 text-right px-1" data-testid="consent-error">
+              <p className="text-sm text-danger-600 text-end px-1" data-testid="consent-error">
                 {validationErrors.consent}
               </p>
             )}


### PR DESCRIPTION
Convert physical Tailwind direction utilities to logical equivalents in the registration details flow and the admin/management tabs. Site is RTL-global; logical utilities keep the visual layout correct without relying on hardcoded physical sides and avoid LTR-leaks where a class combo silently flips.

- RegistrationDetailsStep: text-right→text-end across read-only inputs, email/password/birthdate inputs, and all error rows; password pr-12→pe-12; email icon + password eye-toggle left-3→end-3.
- DataManagementTab / AuditLogsTab / EnforceTransferTab: table-header text-right→text-start; action-button ml-2→me-2; AuditLogsTab stats card mr-4→ms-4.
- EmailTab / PermissionsTab: checkbox ml-2→me-2; EmailTab template-card text-right→text-end.
- SidebarNavigation: active-tab border-r-2→border-e-2; icon ml-3→me-3; tab label text-right→text-start.
- CustomUserSelectionModal: scroller pl-4 pr-4→ps-4 pe-4; absolute fade overlays left-0/right-0→end-0/start-0 (gradient direction unchanged).
- FormFieldRequiresDailyCheck: label mr-2→ms-2.

Audit's strict-margin grep undercounted these (text-right / border-r / absolute left|right don't match the digit-suffix pattern). Updated docs/rtl-audit.md with the real fixed count (~25 hits across 10 files) and a new "next batch" table listing carryover hits in UsersTab, TemplatesTab, PersonalDetailsStep, ammunition views, etc.