### PR TITLE
fix(security): lock phone in profile API + move FAB to RTL visual right

### DIFF
--- a/docs/codebase/src/app/api/users/profile/route.md
+++ b/docs/codebase/src/app/api/users/profile/route.md
@@ -1,0 +1,44 @@
+# PATCH /api/users/profile
+
+**File:** `src/app/api/users/profile/route.ts`
+**Status:** Active
+
+## Purpose
+
+Server-side write endpoint for a user's editable profile fields. Backed by `firebase-admin` via `serverUpdateUserProfile`. Triggers phone-book write-through when phone-book-relevant fields change.
+
+## Request
+
+```
+PATCH /api/users/profile
+Authorization: Bearer <idToken>
+Body: { uid: string, updates: { teamId?: string, profileImage?: string } }
+```
+
+## Authorization
+
+- Bearer token via `getActorOrError`.
+- Caller may update their OWN profile (uid matches actor).
+- ADMIN / SYSTEM_MANAGER may update any user's profile.
+
+## Field allowlist
+
+`PROFILE_WRITABLE_FIELDS` in `src/lib/db/server/userService.ts` is the single source of truth. Currently: `teamId`, `profileImage`. Unknown keys are silently dropped at the service layer.
+
+## phoneNumber is rejected explicitly (400)
+
+If the request body contains `updates.phoneNumber`, the route returns 400 immediately — BEFORE the actor check, intentionally — with a message pointing at the dedicated phone-change flow (Settings PR-C, not yet shipped). Rationale: phone is an identity anchor and a profile-update PATCH must not be able to rewrite it without OTP re-verification + fresh password re-auth. The explicit 400 is loud-not-silent: a client that mistakenly includes `phoneNumber` learns immediately rather than seeing a 200 with no persisted change.
+
+## Phone-book write-through
+
+After a successful profile write, the route re-reads `users/{uid}` and calls `serverUpsertPhoneBookFromUser` whenever `teamId` or `profileImage` changed. The phone-book row is keyed by `militaryPersonalNumberHash` so it survives a future user→personnel relink.
+
+## Failure modes
+
+- 400 — missing `uid`, missing `updates` object, or `phoneNumber` present.
+- 403 — caller is not the user and not elevated.
+- 500 — Firestore failure during write or phone-book upsert.
+
+## Related
+
+- Council threat model + full PR-A → PR-C plan: `project_settings_page.md` in user memory.

--- a/docs/codebase/src/app/components/QuickActionFab.md
+++ b/docs/codebase/src/app/components/QuickActionFab.md
@@ -17,7 +17,8 @@ When real flows are implemented, wire each action to its own modal or route.
 
 ## Behavior
 
-- Fixed `bottom-5 end-5 z-50`, hidden on `lg:` and up.
+- Fixed `bottom-5 start-5 z-50`, hidden on `lg:` and up. In RTL (the app default) `start` resolves to the visual right edge — placing the FAB under the user's right thumb (the conventional position for right-handed users regardless of text direction).
+- Speed-dial children align with `items-end` so the action chips trail to the visual left away from the FAB.
 - Click outside or `Escape` closes the speed-dial.
 - Plus icon rotates 45° (→ X) when open.
 

--- a/src/app/api/users/profile/route.ts
+++ b/src/app/api/users/profile/route.ts
@@ -8,10 +8,15 @@ import { serverUpsertPhoneBookFromUser } from '@/lib/db/server/phoneBookService'
 
 /**
  * PATCH /api/users/profile
- * Body: { uid: string, updates: { teamId?, profileImage?, phoneNumber? } }
+ * Body: { uid: string, updates: { teamId?, profileImage? } }
  *
  * Caller must be authenticated (bearer token). Only the user themselves, or
  * an ADMIN / SYSTEM_MANAGER, may update a profile.
+ *
+ * `phoneNumber` is explicitly rejected with 400 — phone changes MUST go
+ * through the dedicated phone-change route (queued as Settings PR-C) that
+ * requires fresh password re-auth + a Firebase Auth credential proof. See
+ * `project_settings_page.md` Council synthesis for the threat model.
  */
 export async function PATCH(request: Request) {
   try {
@@ -25,6 +30,15 @@ export async function PATCH(request: Request) {
     if (!body?.updates || typeof body.updates !== 'object') {
       return NextResponse.json({ success: false, error: 'updates object is required' }, { status: 400 });
     }
+    if ('phoneNumber' in body.updates) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: 'phoneNumber cannot be updated via this endpoint — use the dedicated phone-change flow (Settings PR-C, not yet shipped). This guard prevents identity-anchor changes without OTP re-verification.',
+        },
+        { status: 400 }
+      );
+    }
     const isElevated =
       actor.userType === UserType.ADMIN || actor.userType === UserType.SYSTEM_MANAGER;
     if (body.uid !== actor.uid && !isElevated) {
@@ -35,9 +49,10 @@ export async function PATCH(request: Request) {
     }
     await serverUpdateUserProfile(body.uid, body.updates);
 
-    // Write-through to phone book when phone-relevant fields change.
+    // Write-through to phone book when phone-book-relevant fields change.
+    // phoneNumber is excluded above; the phone-change route will trigger its
+    // own write-through once landed.
     const touchesPhoneBook =
-      body.updates.phoneNumber !== undefined ||
       body.updates.teamId !== undefined ||
       body.updates.profileImage !== undefined;
     if (touchesPhoneBook) {

--- a/src/app/components/QuickActionFab.tsx
+++ b/src/app/components/QuickActionFab.tsx
@@ -72,7 +72,7 @@ export default function QuickActionFab() {
 
       <div
         ref={containerRef}
-        className="lg:hidden fixed bottom-5 end-5 z-50 flex flex-col items-start gap-3"
+        className="lg:hidden fixed bottom-5 start-5 z-50 flex flex-col items-end gap-3"
       >
         <AnimatePresence>
           {open && (

--- a/src/lib/db/server/userService.ts
+++ b/src/lib/db/server/userService.ts
@@ -9,11 +9,16 @@ import { FieldValue } from 'firebase-admin/firestore';
 /**
  * Updates a user's editable profile fields. Only whitelisted keys are accepted
  * to keep the route tight — roles and permissions are not user-editable here.
+ *
+ * `phoneNumber` is INTENTIONALLY excluded. Phone is an identity anchor and
+ * MUST flow through a dedicated change route that requires (a) fresh password
+ * re-auth and (b) a Firebase Auth `updatePhoneNumber` credential proof. See
+ * `project_settings_page.md` PR-C. The route layer also 400s explicitly on
+ * any `phoneNumber` field so the rejection is loud, not silent.
  */
 const PROFILE_WRITABLE_FIELDS = [
   'teamId',
   'profileImage',
-  'phoneNumber',
 ] as const;
 type ProfileWritableField = (typeof PROFILE_WRITABLE_FIELDS)[number];
 


### PR DESCRIPTION
Two changes bundled per user request.

1. Settings PR-A hotfix — lock `phoneNumber` in `PATCH /api/users/profile`:

Phone is an identity anchor. The pre-fix server accepted `phoneNumber` via the profile allowlist, which means any caller with a valid bearer token (or any elevated admin/system-manager) could silently rewrite the phone on `users/{uid}` AND trigger phone-book write-through with no OTP, no re-auth, and no `updatePhoneNumber` on Firebase Auth. The mock UI in `PhoneNumberUpdate.tsx` was frontend theater — the real write path was wide open.

- Drop `phoneNumber` from `PROFILE_WRITABLE_FIELDS` in `src/lib/db/server/userService.ts`.
- Add explicit 400 in `src/app/api/users/profile/route.ts` when `phoneNumber` appears in `updates`, BEFORE the actor check, with a message pointing at the dedicated phone-change flow (Settings PR-C). Loud-not-silent: a client learns immediately rather than getting a 200 with no persisted change.
- Trim the phone-book write-through trigger to drop the phoneNumber branch.

Mock `PhoneNumberUpdate.tsx` keeps working as UI state only; its `updateUserProfile({ phoneNumber })` call now throws and gets caught + logged, which matches the mock's pre-existing dishonesty about persistence. Real phone-change flow lands in Settings PR-C.

2. FAB position — `QuickActionFab.tsx`:

`bottom-5 end-5` resolves to the visual LEFT in RTL (Hebrew is the app default). Convention for the right-handed thumb-reachable position is the visual RIGHT regardless of text direction. Swap `end-5` → `start-5` so RTL renders the FAB on the visual right. Inner speed-dial alignment flipped `items-start` → `items-end` so the action chips trail away from the FAB to the visual left.

Docs:
- New `docs/codebase/src/app/api/users/profile/route.md` documents the explicit phone rejection + allowlist contract + write-through.
- `docs/codebase/src/app/components/QuickActionFab.md` updated to reflect the new position + cross-axis alignment + the RTL rationale.