### PR TITLE
feat(convoy): ask include-personnel on template save (Bug 3)

### DIFF
--- a/docs/codebase/src/app/tools/convoy/page.md
+++ b/docs/codebase/src/app/tools/convoy/page.md
@@ -51,9 +51,14 @@ The file is fully self-contained — all HTML/CSS/JS is inline, no external `<li
 
 Symptoms: templates won't save, deletes appear to revert on reload. The page logs a `console.warn` when `location.protocol === 'file:'`; `saveTemplatesData` and `deleteConvoyTemplate` show an offline-aware modal explaining the situation. Future improvement (separate PR): add Export/Import JSON buttons to bypass localStorage entirely.
 
+### Template shape (v1 → v2)
+
+`saveConvoyTemplate` writes `{ vehicles: Vehicle[], includesPersonnel: boolean }` under `localStorage["convoyMasterTemplates"][name]`. The pre-existing flat-array shape (`Vehicle[]`) is still accepted on load and treated as `{ vehicles: data, includesPersonnel: true }` via the `unwrapTemplate` helper — older templates remain usable, no migration needed.
+
+When the current convoy has at least one passenger anywhere, `saveConvoyTemplate` opens a 3-button `showActionModal`: `שמור תפקידים בלבד` (strips `v.passengers = []` per vehicle), `שמור כולל חברים` (keeps them verbatim), `חזרה` (abort). When there are no passengers anywhere, the modal is skipped and the save runs directly with `includesPersonnel: false`. If a template already exists under the chosen name, the overwrite-confirm runs first and the personnel choice fires only after the user confirms overwrite. The save toast and the load toast both annotate which mode was used.
+
 ### Open follow-ups
 
-- **Bug 3 (PR-B):** at template save time, ask the user via in-page modal whether to bundle personnel (`חברים`) with the saved vehicles. Two affirmative buttons + return: "שמור תפקידים בלבד", "שמור כולל חברים", "חזרה". Persists `{ vehicles, includesPersonnel }` shape; older templates default to `includesPersonnel: true`.
 - **Bug 4 (separate PR):** offline-mode banner + Export/Import templates as JSON.
 - **Sister tool `logistics.html`** still uses native `alert`/`confirm`/`prompt` — same migration to the in-app modal helpers should be applied. Tracked as a separate sweep.
 

--- a/public/tools/hmmwvConvoy.html
+++ b/public/tools/hmmwvConvoy.html
@@ -525,6 +525,18 @@
         if (templates[currentVal]) select.value = currentVal;
     }
 
+    // Template shape evolution:
+    //   v1: Vehicle[]                           — legacy, treated as includesPersonnel: true
+    //   v2: { vehicles: Vehicle[], includesPersonnel: boolean }
+    // Helper normalizes either shape to { vehicles, includesPersonnel }.
+    function unwrapTemplate(data) {
+        if (Array.isArray(data)) return { vehicles: data, includesPersonnel: true };
+        if (data && Array.isArray(data.vehicles)) {
+            return { vehicles: data.vehicles, includesPersonnel: data.includesPersonnel !== false };
+        }
+        return null;
+    }
+
     // שמירה או דריסה של תבנית
     function saveConvoyTemplate() {
         const templateName = document.getElementById('newTemplateName').value.trim();
@@ -533,13 +545,37 @@
 
         let templates = getTemplatesData();
 
-        const doSave = () => {
-            templates[templateName] = JSON.parse(JSON.stringify(currentConvoy));
+        const hasAnyPassengers = currentConvoy.some(v => Array.isArray(v.passengers) && v.passengers.length > 0);
+
+        const doSave = (includesPersonnel) => {
+            const vehicles = JSON.parse(JSON.stringify(currentConvoy));
+            if (!includesPersonnel) {
+                vehicles.forEach(v => { v.passengers = []; });
+            }
+            templates[templateName] = { vehicles, includesPersonnel };
             if (saveTemplatesData(templates)) {
                 updateTemplatesDropdown();
                 document.getElementById('savedTemplates').value = templateName;
-                showToast(`✅ השיירה נשמרה כתבנית: '${templateName}'`);
+                const suffix = includesPersonnel ? ' (כולל חברים)' : ' (תפקידים בלבד)';
+                showToast(`✅ השיירה נשמרה כתבנית: '${templateName}'${suffix}`);
             }
+        };
+
+        const askPersonnel = () => {
+            // No passengers anywhere — both choices store identical data. Skip
+            // the modal and save directly with includesPersonnel: false (no
+            // passengers to include anyway).
+            if (!hasAnyPassengers) { doSave(false); return; }
+
+            showActionModal(
+                'מה לשמור בתבנית? בחר אחת:',
+                'שמירת תבנית',
+                [
+                    { label: 'שמור תפקידים בלבד', kind: 'primary', onClick: () => doSave(false) },
+                    { label: 'שמור כולל חברים', kind: 'primary', onClick: () => doSave(true) },
+                    { label: 'חזרה', kind: 'neutral' }
+                ]
+            );
         };
 
         if (templates[templateName]) {
@@ -547,10 +583,10 @@
                 `תבנית בשם '${templateName}' כבר קיימת.\nלדרוס אותה עם השיירה המעודכנת?`,
                 'דריסת תבנית',
                 'דרוס',
-                doSave
+                askPersonnel
             );
         } else {
-            doSave();
+            askPersonnel();
         }
     }
 
@@ -560,16 +596,17 @@
         if (!templateName) { showInfoModal("אנא בחר תבנית מהרשימה."); return; }
 
         let templates = getTemplatesData();
-        const data = templates[templateName];
+        const unwrapped = unwrapTemplate(templates[templateName]);
 
-        if (!data || !Array.isArray(data)) { showInfoModal("שגיאה: התבנית פגומה או לא נמצאה.", "טעינה נכשלה"); return; }
+        if (!unwrapped) { showInfoModal("שגיאה: התבנית פגומה או לא נמצאה.", "טעינה נכשלה"); return; }
 
         const doLoad = () => {
-            currentConvoy = JSON.parse(JSON.stringify(data));
+            currentConvoy = JSON.parse(JSON.stringify(unwrapped.vehicles));
             document.getElementById('newTemplateName').value = templateName;
             renderConvoyList();
             generateConvoyText();
-            showToast(`✅ התבנית '${templateName}' נטענה בהצלחה`, 'info');
+            const suffix = unwrapped.includesPersonnel ? '' : ' (תפקידים בלבד — חברים לא נכללו)';
+            showToast(`✅ התבנית '${templateName}' נטענה בהצלחה${suffix}`, 'info');
         };
 
         if (currentConvoy.length > 0) {


### PR DESCRIPTION
saveConvoyTemplate now opens a 3-button showActionModal asking whether to bundle passengers (חברים) with the saved vehicles:
- 'שמור תפקידים בלבד' strips v.passengers = [] per vehicle
- 'שמור כולל חברים' keeps them verbatim
- 'חזרה' aborts

The modal is skipped when no vehicle has any passenger — both choices would store identical data. The save toast annotates the mode used.

Template shape evolves from flat Vehicle[] (v1) to { vehicles: Vehicle[], includesPersonnel: boolean } (v2). Legacy v1 templates are still accepted on load via the unwrapTemplate helper and treated as includesPersonnel: true — no migration needed.

When the chosen name already exists, the overwrite-confirm runs first; the personnel choice fires only after the user confirms overwrite. The load toast annotates when a 'roles only' template is loaded.

Docs: convoy page.md gains a 'Template shape (v1 → v2)' section documenting the modal flow and the backward-compat unwrap. Bug 3 entry dropped from open follow-ups.