### PR TITLE
feat(profile): section-edit pattern + combine team into Military Info

### DIFF
--- a/docs/codebase/src/app/profile/page.md
+++ b/docs/codebase/src/app/profile/page.md
@@ -1,12 +1,11 @@
 # page.tsx (Profile)
 
 **File:** `src/app/profile/page.tsx`
-**Lines:** 363
 **Status:** Active
 
 ## Purpose
 
-User profile page (`/profile`). Displays the authenticated user's personal and military information from `AuthContext.enhancedUser` (Firestore profile). Allows updating the profile image, phone number, and team assignment via dedicated sub-components and a section-level Save button. Protected by `AuthGuard`.
+User profile page (`/profile`). Displays the authenticated user's personal and military information from `AuthContext.enhancedUser` (Firestore profile). Editable sections (Military Info, Contact Info) use a section-level pencil toggle pattern owned by sibling components; Personal Info and System Info are read-only and rendered inline. Protected by `AuthGuard`.
 
 ## Exports / Public API
 
@@ -17,18 +16,26 @@ User profile page (`/profile`). Displays the authenticated user's personal and m
 | State | Type | Purpose |
 |-------|------|---------|
 | `profileImageUrl` | `string \| undefined` | Local mirror of `enhancedUser.profileImage`, synced via `useEffect` whenever the source changes |
-| `phoneNumber` | `string` | Local mirror of `enhancedUser.phoneNumber`, synced via `useEffect` |
-| `teamId` | `string` | Local mirror of `enhancedUser.teamId`, synced via `useEffect` |
-| `assignmentSaving` | `boolean` | Disables the Save button on the Team & Unit Assignment card while a PATCH is in flight |
-| `assignmentMessage` | `string \| null` | Inline status text after the Save button is clicked |
+| `phoneNumber` | `string` | Local mirror of `enhancedUser.phoneNumber`, synced via `useEffect`; passed into `ContactInfoSection` |
+
+All other editable state (teamId, enlistmentCycle, address) lives inside the dedicated section components (`MilitaryInfoSection`, `ContactInfoSection`).
+
+## Card layout
+
+The body grid renders four cards in this fixed order:
+
+1. **Personal Information** (read-only) — first/last name, gender, birthday.
+2. **Military Information** (editable: team, enlistment cycle) — `<MilitaryInfoSection>`. Rank, role, join date, status stay read-only. The "Team & Unit Assignment" standalone card that previously sat between Military Info and Contact Info has been removed; the `teamId` field is now inline inside Military Info and edited via the same section-edit pattern.
+3. **Contact Information** (editable: address) — `<ContactInfoSection>`. Email is read-only. Phone uses the existing `<PhoneNumberUpdate>` sub-component nested inside.
+4. **System Information** (read-only) — uid, user type, test-account badge.
 
 ## Persistence path
 
-All writes go through `updateUserProfile` (client wrapper in `src/lib/userProfileService.ts`) which posts to `PATCH /api/users/profile`. The route filters fields against an allowlist (`teamId`, `profileImage`, `phoneNumber`) and writes via `firebase-admin`. After every successful write the component calls `refreshEnhancedUser()` from `AuthContext` so the rest of the app sees the new value.
+All writes go through `updateUserProfile` (client wrapper in `src/lib/userProfileService.ts`) which posts to `PATCH /api/users/profile`. The server route filters against `PROFILE_WRITABLE_FIELDS` (currently `teamId`, `profileImage`, `phoneNumber`, `enlistmentCycle`, `address`) and writes via `firebase-admin`. After every successful section save the component calls `refreshEnhancedUser()` from `AuthContext` so the rest of the app sees the new value.
 
 ## Hydration model
 
-Local state initializes to empty/undefined, then `useEffect` hooks watch each `enhancedUser` field and rehydrate when the async profile fetch in `AuthContext` resolves. This is why hard refresh now correctly shows the saved profile image, phone, and team — earlier code seeded `useState` from `enhancedUser` at first render, before the Firestore data had arrived.
+The page seeds local state to empty/undefined, then `useEffect` hooks watch each `enhancedUser` field and rehydrate when the async profile fetch in `AuthContext` resolves. The section components own their own edit-mode buffers and re-sync against `user.*` whenever the source-of-truth changes (post-save refresh or first-render hydration).
 
 ## Layout notes
 
@@ -36,11 +43,14 @@ Local state initializes to empty/undefined, then `useEffect` hooks watch each `e
 - Personal Info and Military Info use a `<dl>` with `sm:grid sm:grid-cols-3` so labels and values inline on tablet/desktop and stack on mobile.
 - All section headers wrap (`flex-wrap`) and the icon has `shrink-0` so it never gets clipped at narrow widths.
 - Mobile padding is reduced (`p-4 sm:p-6`) across all cards for consistency.
+- The pencil "Edit" button sits at the top-leading corner of each editable section, opposite the title, and is hidden while in edit mode (replaced by Save/Cancel at the section footer).
 
 ## Date formatting
 
-Uses `date-fns` with `he` locale. Handles both `Date` objects and Firestore `Timestamp` (duck-typed via `toDate()`).
+Uses `date-fns` with `he` locale. Handles both `Date` objects and Firestore `Timestamp` (duck-typed via `toDate()`). The enlistment-cycle field is stored as ISO `YYYY-MM` and displayed via `format(parse(value, 'yyyy-MM'), 'MMMM yyyy', { locale: he })` (e.g. `2010-03` → `מרץ 2010`).
 
 ## Related queued work
 
-- "My Team" merge into Military Info, enlistment-cycle field, section-level inline edit, and address field — all queued to `project_future_features` memory (2026-05-12 punch list).
+- Image editor v2 (pan + wider zoom + group-photo focus) — still queued.
+- Profile image localStorage cache — still queued.
+- Soldier qualifications + personal logistics — blocked on 6 open product Qs (see `project_soldier_qualifications`).

--- a/docs/codebase/src/components/profile/ContactInfoSection.md
+++ b/docs/codebase/src/components/profile/ContactInfoSection.md
@@ -1,0 +1,32 @@
+# ContactInfoSection.tsx
+
+**File:** `src/components/profile/ContactInfoSection.tsx`
+**Status:** Active
+
+## Purpose
+
+Renders the "Contact Information" card on `/profile`. Email is read-only. Phone is delegated to the existing `<PhoneNumberUpdate>` sub-component (its own internal flow — out of scope for the section-edit pencil). Address is editable behind the section-level pencil toggle.
+
+## Props
+
+| Prop | Type | Purpose |
+|------|------|---------|
+| `user` | `EnhancedAuthUser` | Source of truth |
+| `authEmail` | `string \| undefined` | Fallback when `user.email` is missing (early hydration) |
+| `phoneNumber` | `string` | Passed through to `<PhoneNumberUpdate>` |
+| `onPhoneUpdate` | `(newPhone: string) => Promise<void> \| void` | Forwarded to `<PhoneNumberUpdate>` |
+| `onSaved` | `() => Promise<void> \| void` | Called after a successful address save |
+
+## Edit pattern
+
+Identical to `MilitaryInfoSection`: pencil toggle → input swap → footer Save/Cancel → `updateUserProfile({ address })` → `onSaved()`. The address buffer rehydrates from `user.address` via `useEffect` when not editing.
+
+The phone update flow is NOT gated by the pencil — `<PhoneNumberUpdate>` has its own confirmation UI and remains independently usable whether or not the section is in edit mode.
+
+## Field shape
+
+- `address`: free-form string (trimmed on save). No validation; intentionally permissive for international / mixed-format addresses. Used downstream by Phone Book Phase 2 categorization (`project_phone_book`) when that lands.
+
+## Localization
+
+See `MilitaryInfoSection` docs.

--- a/docs/codebase/src/components/profile/MilitaryInfoSection.md
+++ b/docs/codebase/src/components/profile/MilitaryInfoSection.md
@@ -1,0 +1,30 @@
+# MilitaryInfoSection.tsx
+
+**File:** `src/components/profile/MilitaryInfoSection.tsx`
+**Status:** Active
+
+## Purpose
+
+Renders the "Military Information" card on `/profile`. Read-only display of `rank`, `role`, `joinDate`, `status`. Editable (behind a section-level pencil toggle): `teamId`, `enlistmentCycle`.
+
+## Props
+
+| Prop | Type | Purpose |
+|------|------|---------|
+| `user` | `EnhancedAuthUser` | Source of truth for all displayed fields |
+| `onSaved` | `() => Promise<void> \| void` | Called after a successful save (page-level `refreshEnhancedUser`) |
+
+## Edit pattern
+
+Top-trailing pencil button switches the card into edit mode. Editable fields swap their display node for an input; read-only fields stay unchanged. Save / Cancel render at the section footer. Save calls `updateUserProfile({ teamId, enlistmentCycle })` then `onSaved()`; cancel resets the edit buffers to the source values and exits edit mode. While saving, all inputs are disabled and Save reads "שומר...".
+
+Local edit buffers re-sync against `user.teamId` / `user.enlistmentCycle` via a `useEffect` whenever the source changes AND the card is not in edit mode — this prevents the buffer from being clobbered mid-edit if `AuthContext` re-runs.
+
+## Field shapes
+
+- `teamId`: free-form string (trimmed on save).
+- `enlistmentCycle`: ISO `YYYY-MM` (e.g. `2010-03`). The input uses `type="month"` so the platform renders a native month/year picker. Display formats via `format(parse(value, 'yyyy-MM'), 'MMMM yyyy', { locale: he })` → `מרץ 2010`. Falsy values render as `NOT_AVAILABLE`. Malformed values fall through to the raw string rather than throwing.
+
+## Localization
+
+Hebrew strings live in `TEXT_CONSTANTS.PROFILE.*`. English mirrors for the new keys are in `src/constants/text.en.ts` per `feedback_bilingual_text`; the runtime still reads Hebrew only — the language toggle will wire reads through a locale-aware accessor once the i18n PR lands.

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -4,29 +4,19 @@ import { useEffect, useState } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import AuthGuard from '@/components/auth/AuthGuard';
 import AppShell from '@/app/components/AppShell';
-import { UserRole } from '@/types/equipment';
 import { format } from 'date-fns';
 import { he } from 'date-fns/locale';
 import ProfileImageUpload from '@/components/profile/ProfileImageUpload';
-import PhoneNumberUpdate from '@/components/profile/PhoneNumberUpdate';
+import MilitaryInfoSection from '@/components/profile/MilitaryInfoSection';
+import ContactInfoSection from '@/components/profile/ContactInfoSection';
 import { TEXT_CONSTANTS } from '@/constants/text';
 import { updateUserProfile } from '@/lib/userProfileService';
 
-/**
- * User Profile Page
- * Displays user information fetched from Firestore
- */
 export default function ProfilePage() {
   const { enhancedUser, user, refreshEnhancedUser } = useAuth();
   const [profileImageUrl, setProfileImageUrl] = useState<string | undefined>(undefined);
   const [phoneNumber, setPhoneNumber] = useState<string>('');
-  const [teamId, setTeamId] = useState<string>('');
-  const [assignmentSaving, setAssignmentSaving] = useState(false);
-  const [assignmentMessage, setAssignmentMessage] = useState<string | null>(null);
 
-  // enhancedUser arrives async after AuthContext loads the Firestore profile.
-  // Sync local fields whenever it changes so the page reflects the latest
-  // persisted state across hard refreshes (not just the first render).
   useEffect(() => {
     const img = enhancedUser?.profileImage;
     setProfileImageUrl(img && /^https?:\/\//i.test(img) ? img : undefined);
@@ -36,16 +26,9 @@ export default function ProfilePage() {
     setPhoneNumber(enhancedUser?.phoneNumber || '');
   }, [enhancedUser?.phoneNumber]);
 
-  useEffect(() => {
-    setTeamId(enhancedUser?.teamId || '');
-  }, [enhancedUser?.teamId]);
-
-  // Format date helper
   const formatDate = (date: Date | { toDate: () => Date } | string | null | undefined) => {
     if (!date) return TEXT_CONSTANTS.PROFILE.NOT_AVAILABLE;
-    
     try {
-      // Handle Firestore Timestamp
       let jsDate: Date;
       if (typeof date === 'object' && date !== null && 'toDate' in date) {
         jsDate = date.toDate();
@@ -59,12 +42,10 @@ export default function ProfilePage() {
     }
   };
 
-  // Get display values with fallbacks
   const getDisplayValue = (value: string | undefined, fallback: string = TEXT_CONSTANTS.PROFILE.NOT_AVAILABLE) => {
     return value || fallback;
   };
 
-  // Handle profile image update — persists to Firestore via admin API.
   const handleImageUpdate = async (newImageUrl: string) => {
     setProfileImageUrl(newImageUrl);
     if (!enhancedUser) return;
@@ -76,7 +57,6 @@ export default function ProfilePage() {
     }
   };
 
-  // Handle phone number update
   const handlePhoneUpdate = async (newPhoneNumber: string) => {
     setPhoneNumber(newPhoneNumber);
     if (!enhancedUser) return;
@@ -85,23 +65,6 @@ export default function ProfilePage() {
       await refreshEnhancedUser();
     } catch (err) {
       console.error('[profile] failed to save phone', err);
-    }
-  };
-
-  const handleSaveAssignment = async () => {
-    if (!enhancedUser) return;
-    setAssignmentSaving(true);
-    setAssignmentMessage(null);
-    try {
-      await updateUserProfile(enhancedUser.uid, {
-        teamId: teamId.trim(),
-      });
-      await refreshEnhancedUser();
-      setAssignmentMessage(TEXT_CONSTANTS.ONBOARDING.SAVED);
-    } catch {
-      setAssignmentMessage(TEXT_CONSTANTS.ONBOARDING.SAVE_ERROR);
-    } finally {
-      setAssignmentSaving(false);
     }
   };
 
@@ -115,7 +78,6 @@ export default function ProfilePage() {
           {/* Profile Header */}
           <div className="bg-white rounded-2xl shadow-lg p-4 sm:p-8 mb-6 sm:mb-8">
             <div className="flex flex-wrap items-center gap-4 sm:gap-6">
-              {/* Profile Avatar with Upload */}
               {enhancedUser?.uid && (
                 <div className="shrink-0">
                   <ProfileImageUpload
@@ -128,7 +90,6 @@ export default function ProfilePage() {
                 </div>
               )}
 
-              {/* Basic Info */}
               <div className="flex-1 min-w-0">
                 <h1 className="text-2xl sm:text-3xl font-bold text-neutral-900 mb-1 sm:mb-2 truncate">
                   {getDisplayValue(
@@ -146,7 +107,6 @@ export default function ProfilePage() {
                 </p>
               </div>
 
-              {/* Status Badge */}
               {enhancedUser?.status && (
                 <div className={`shrink-0 ms-auto px-3 sm:px-4 py-1.5 sm:py-2 rounded-full text-xs sm:text-sm font-medium ${
                   enhancedUser.status === 'active'
@@ -159,9 +119,8 @@ export default function ProfilePage() {
             </div>
           </div>
 
-          {/* Profile Details */}
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
-            {/* Personal Information */}
+            {/* Personal Information (read-only) */}
             <div className="bg-white rounded-2xl shadow-lg p-4 sm:p-6">
               <h2 className="text-lg sm:text-xl font-bold text-neutral-900 mb-4 flex items-center gap-2">
                 <svg className="w-5 h-5 text-primary-600 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -175,12 +134,10 @@ export default function ProfilePage() {
                   <dt className="text-sm font-medium text-neutral-600">{TEXT_CONSTANTS.PROFILE.FIRST_NAME}</dt>
                   <dd className="text-neutral-900 sm:col-span-2">{getDisplayValue(enhancedUser?.firstName)}</dd>
                 </div>
-
                 <div className="py-2 sm:grid sm:grid-cols-3 sm:gap-3">
                   <dt className="text-sm font-medium text-neutral-600">{TEXT_CONSTANTS.PROFILE.LAST_NAME}</dt>
                   <dd className="text-neutral-900 sm:col-span-2">{getDisplayValue(enhancedUser?.lastName)}</dd>
                 </div>
-
                 <div className="py-2 sm:grid sm:grid-cols-3 sm:gap-3">
                   <dt className="text-sm font-medium text-neutral-600">{TEXT_CONSTANTS.PROFILE.GENDER}</dt>
                   <dd className="text-neutral-900 sm:col-span-2">
@@ -189,7 +146,6 @@ export default function ProfilePage() {
                      getDisplayValue(enhancedUser?.gender)}
                   </dd>
                 </div>
-
                 <div className="py-2 sm:grid sm:grid-cols-3 sm:gap-3">
                   <dt className="text-sm font-medium text-neutral-600">{TEXT_CONSTANTS.PROFILE.BIRTH_DATE}</dt>
                   <dd className="text-neutral-900 sm:col-span-2">{formatDate(enhancedUser?.birthday)}</dd>
@@ -197,112 +153,23 @@ export default function ProfilePage() {
               </dl>
             </div>
 
-            {/* Military Information */}
-            <div className="bg-white rounded-2xl shadow-lg p-4 sm:p-6">
-              <h2 className="text-lg sm:text-xl font-bold text-neutral-900 mb-4 flex items-center gap-2">
-                <svg className="w-5 h-5 text-primary-600 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.031 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
-                </svg>
-                {TEXT_CONSTANTS.PROFILE.MILITARY_INFO}
-              </h2>
+            {/* Military Information (editable: team, enlistment cycle) */}
+            {enhancedUser && (
+              <MilitaryInfoSection user={enhancedUser} onSaved={refreshEnhancedUser} />
+            )}
 
-              <dl className="divide-y divide-neutral-100 -my-2">
-                <div className="py-2 sm:grid sm:grid-cols-3 sm:gap-3">
-                  <dt className="text-sm font-medium text-neutral-600">{TEXT_CONSTANTS.PROFILE.RANK}</dt>
-                  <dd className="text-neutral-900 sm:col-span-2">{getDisplayValue(enhancedUser?.rank)}</dd>
-                </div>
+            {/* Contact Information (editable: address; phone has its own component) */}
+            {enhancedUser && (
+              <ContactInfoSection
+                user={enhancedUser}
+                authEmail={user?.email}
+                phoneNumber={phoneNumber}
+                onPhoneUpdate={handlePhoneUpdate}
+                onSaved={refreshEnhancedUser}
+              />
+            )}
 
-                <div className="py-2 sm:grid sm:grid-cols-3 sm:gap-3">
-                  <dt className="text-sm font-medium text-neutral-600">{TEXT_CONSTANTS.PROFILE.ROLE}</dt>
-                  <dd className="text-neutral-900 sm:col-span-2">
-                    {enhancedUser?.role === UserRole.SOLDIER ? TEXT_CONSTANTS.PROFILE.SOLDIER :
-                     enhancedUser?.role === UserRole.COMMANDER ? TEXT_CONSTANTS.PROFILE.COMMANDER :
-                     enhancedUser?.role === UserRole.OFFICER ? TEXT_CONSTANTS.PROFILE.OFFICER :
-                     enhancedUser?.role === UserRole.EQUIPMENT_MANAGER ? TEXT_CONSTANTS.PROFILE.EQUIPMENT_MANAGER :
-                     getDisplayValue(enhancedUser?.role ? String(enhancedUser.role) : undefined)}
-                  </dd>
-                </div>
-
-                <div className="py-2 sm:grid sm:grid-cols-3 sm:gap-3">
-                  <dt className="text-sm font-medium text-neutral-600">{TEXT_CONSTANTS.PROFILE.JOIN_DATE}</dt>
-                  <dd className="text-neutral-900 sm:col-span-2">{formatDate(enhancedUser?.joinDate)}</dd>
-                </div>
-
-                <div className="py-2 sm:grid sm:grid-cols-3 sm:gap-3">
-                  <dt className="text-sm font-medium text-neutral-600">{TEXT_CONSTANTS.PROFILE.STATUS}</dt>
-                  <dd className="text-neutral-900 sm:col-span-2">
-                    {enhancedUser?.status === 'active' ? TEXT_CONSTANTS.PROFILE.ACTIVE :
-                     enhancedUser?.status === 'inactive' ? TEXT_CONSTANTS.PROFILE.INACTIVE :
-                     enhancedUser?.status === 'transferred' ? TEXT_CONSTANTS.PROFILE.TRANSFERRED :
-                     enhancedUser?.status === 'discharged' ? TEXT_CONSTANTS.PROFILE.DISCHARGED :
-                     getDisplayValue(enhancedUser?.status)}
-                  </dd>
-                </div>
-              </dl>
-            </div>
-
-            {/* Team & Unit Assignment */}
-            <div className="bg-white rounded-2xl shadow-lg p-4 sm:p-6">
-              <h2 className="text-lg sm:text-xl font-bold text-neutral-900 mb-4 flex flex-wrap items-center gap-2">
-                <svg className="w-5 h-5 text-primary-600 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a4 4 0 00-3-3.87M9 20H4v-2a4 4 0 013-3.87m6 5.87a4 4 0 108 0 4 4 0 00-8 0z" />
-                </svg>
-                {TEXT_CONSTANTS.ONBOARDING.ASSIGNMENT_TITLE}
-              </h2>
-              <div className="space-y-4">
-                <div>
-                  <label htmlFor="profile-team" className="block text-sm font-medium text-neutral-700 mb-1">
-                    {TEXT_CONSTANTS.ONBOARDING.TEAM_LABEL}
-                  </label>
-                  <input
-                    id="profile-team"
-                    type="text"
-                    value={teamId}
-                    onChange={(e) => setTeamId(e.target.value)}
-                    placeholder={TEXT_CONSTANTS.ONBOARDING.TEAM_PLACEHOLDER}
-                    className="input-base"
-                  />
-                </div>
-                <div className="flex items-center gap-3">
-                  <button
-                    type="button"
-                    onClick={handleSaveAssignment}
-                    disabled={assignmentSaving}
-                    className="btn-primary"
-                  >
-                    {assignmentSaving ? TEXT_CONSTANTS.ONBOARDING.SAVING : TEXT_CONSTANTS.ONBOARDING.SAVE}
-                  </button>
-                  {assignmentMessage && (
-                    <span className="text-sm text-neutral-600">{assignmentMessage}</span>
-                  )}
-                </div>
-              </div>
-            </div>
-
-            {/* Contact Information */}
-            <div className="bg-white rounded-2xl shadow-lg p-4 sm:p-6">
-              <h2 className="text-lg sm:text-xl font-bold text-neutral-900 mb-4 flex flex-wrap items-center gap-2">
-                <svg className="w-5 h-5 text-primary-600 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
-                </svg>
-                {TEXT_CONSTANTS.PROFILE.CONTACT_INFO}
-              </h2>
-              
-              <div className="space-y-6">
-                <div>
-                  <label className="block text-sm font-medium text-neutral-700 mb-1">{TEXT_CONSTANTS.PROFILE.EMAIL}</label>
-                  <div className="text-neutral-900">{getDisplayValue(enhancedUser?.email || user?.email)}</div>
-                </div>
-                
-                {/* Phone Number Update Component */}
-                <PhoneNumberUpdate
-                  currentPhoneNumber={phoneNumber}
-                  onPhoneUpdate={handlePhoneUpdate}
-                />
-              </div>
-            </div>
-
-            {/* System Information */}
+            {/* System Information (read-only) */}
             <div className="bg-white rounded-2xl shadow-lg p-4 sm:p-6">
               <h2 className="text-lg sm:text-xl font-bold text-neutral-900 mb-4 flex flex-wrap items-center gap-2">
                 <svg className="w-5 h-5 text-primary-600 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -310,13 +177,12 @@ export default function ProfilePage() {
                 </svg>
                 {TEXT_CONSTANTS.PROFILE.SYSTEM_INFO}
               </h2>
-              
+
               <div className="space-y-4">
                 <div>
                   <label className="block text-sm font-medium text-neutral-700 mb-1">{TEXT_CONSTANTS.PROFILE.UNIQUE_ID}</label>
                   <div className="text-neutral-900 font-mono text-sm">{getDisplayValue(enhancedUser?.uid || user?.uid)}</div>
                 </div>
-                
                 <div>
                   <label className="block text-sm font-medium text-neutral-700 mb-1">{TEXT_CONSTANTS.PROFILE.USER_TYPE}</label>
                   <div className="text-neutral-900">
@@ -324,11 +190,10 @@ export default function ProfilePage() {
                      user?.userType === 'system_manager' ? TEXT_CONSTANTS.PROFILE.SYSTEM_MANAGER :
                      user?.userType === 'manager' ? TEXT_CONSTANTS.PROFILE.MANAGER :
                      user?.userType === 'team_leader' ? TEXT_CONSTANTS.PROFILE.TEAM_LEADER :
-                     user?.userType === 'user' ? TEXT_CONSTANTS.PROFILE.USER : 
+                     user?.userType === 'user' ? TEXT_CONSTANTS.PROFILE.USER :
                      getDisplayValue(user?.userType ? String(user.userType) : undefined)}
                   </div>
                 </div>
-                
                 {enhancedUser?.testUser && (
                   <div>
                     <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-warning-100 text-warning-800">
@@ -349,7 +214,7 @@ export default function ProfilePage() {
               <div>
                 <h3 className="text-sm font-medium text-info-900 mb-1">{TEXT_CONSTANTS.PROFILE.DATA_SOURCE_TITLE}</h3>
                 <p className="text-sm text-info-700">
-                  {enhancedUser?.firstName ? 
+                  {enhancedUser?.firstName ?
                     TEXT_CONSTANTS.PROFILE.DATA_SOURCE_SYSTEM :
                     TEXT_CONSTANTS.PROFILE.DATA_SOURCE_AUTH
                   }

--- a/src/components/profile/ContactInfoSection.tsx
+++ b/src/components/profile/ContactInfoSection.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import type { EnhancedAuthUser } from '@/types/user';
+import { TEXT_CONSTANTS } from '@/constants/text';
+import { updateUserProfile } from '@/lib/userProfileService';
+import PhoneNumberUpdate from '@/components/profile/PhoneNumberUpdate';
+
+interface Props {
+  user: EnhancedAuthUser;
+  authEmail: string | undefined;
+  phoneNumber: string;
+  onPhoneUpdate: (newPhone: string) => Promise<void> | void;
+  onSaved: () => Promise<void> | void;
+}
+
+/**
+ * Contact Info card. Email is read-only. Phone keeps its existing
+ * dedicated update component. Address is editable behind the same
+ * section-level pencil pattern used by `MilitaryInfoSection`.
+ */
+export default function ContactInfoSection({ user, authEmail, phoneNumber, onPhoneUpdate, onSaved }: Props) {
+  const [editing, setEditing] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [address, setAddress] = useState(user.address || '');
+
+  useEffect(() => {
+    if (!editing) setAddress(user.address || '');
+  }, [user.address, editing]);
+
+  const onSave = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      await updateUserProfile(user.uid, { address: address.trim() });
+      await onSaved();
+      setEditing(false);
+    } catch {
+      setError(TEXT_CONSTANTS.PROFILE.SAVE_ERROR);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const onCancel = () => {
+    setAddress(user.address || '');
+    setError(null);
+    setEditing(false);
+  };
+
+  return (
+    <div className="bg-white rounded-2xl shadow-lg p-4 sm:p-6">
+      <div className="flex items-center justify-between mb-4 gap-2">
+        <h2 className="text-lg sm:text-xl font-bold text-neutral-900 flex items-center gap-2 min-w-0">
+          <svg className="w-5 h-5 text-primary-600 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+          </svg>
+          <span className="truncate">{TEXT_CONSTANTS.PROFILE.CONTACT_INFO}</span>
+        </h2>
+        {!editing && (
+          <button
+            type="button"
+            onClick={() => setEditing(true)}
+            aria-label={TEXT_CONSTANTS.PROFILE.EDIT_SECTION_ARIA}
+            className="btn-ghost text-sm flex items-center gap-1 shrink-0"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+            </svg>
+            <span>{TEXT_CONSTANTS.PROFILE.EDIT_SECTION}</span>
+          </button>
+        )}
+      </div>
+
+      <div className="space-y-6">
+        <div>
+          <label className="block text-sm font-medium text-neutral-700 mb-1">{TEXT_CONSTANTS.PROFILE.EMAIL}</label>
+          <div className="text-neutral-900">{user.email || authEmail || TEXT_CONSTANTS.PROFILE.NOT_AVAILABLE}</div>
+        </div>
+
+        <PhoneNumberUpdate
+          currentPhoneNumber={phoneNumber}
+          onPhoneUpdate={onPhoneUpdate}
+        />
+
+        <div>
+          <label className="block text-sm font-medium text-neutral-700 mb-1">{TEXT_CONSTANTS.PROFILE.ADDRESS}</label>
+          {editing ? (
+            <input
+              type="text"
+              value={address}
+              onChange={(e) => setAddress(e.target.value)}
+              placeholder={TEXT_CONSTANTS.PROFILE.ADDRESS_PLACEHOLDER}
+              className="input-base"
+              disabled={saving}
+            />
+          ) : (
+            <div className="text-neutral-900">{user.address || TEXT_CONSTANTS.PROFILE.NOT_AVAILABLE}</div>
+          )}
+        </div>
+      </div>
+
+      {editing && (
+        <div className="mt-4 flex flex-wrap items-center gap-3">
+          <button
+            type="button"
+            onClick={onSave}
+            disabled={saving}
+            className="btn-primary"
+          >
+            {saving ? TEXT_CONSTANTS.PROFILE.SAVING : TEXT_CONSTANTS.PROFILE.SAVE}
+          </button>
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={saving}
+            className="btn-ghost"
+          >
+            {TEXT_CONSTANTS.PROFILE.CANCEL}
+          </button>
+          {error && <span className="text-sm text-danger-600">{error}</span>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/profile/MilitaryInfoSection.tsx
+++ b/src/components/profile/MilitaryInfoSection.tsx
@@ -1,0 +1,199 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { format, parse, isValid } from 'date-fns';
+import { he } from 'date-fns/locale';
+import type { EnhancedAuthUser } from '@/types/user';
+import { UserRole } from '@/types/equipment';
+import { TEXT_CONSTANTS } from '@/constants/text';
+import { updateUserProfile } from '@/lib/userProfileService';
+
+interface Props {
+  user: EnhancedAuthUser;
+  onSaved: () => Promise<void> | void;
+}
+
+/**
+ * Military Info card. Read-only display of rank/role/joinDate/status; team
+ * and enlistment cycle are editable behind a section-level pencil toggle.
+ * Save persists via `updateUserProfile` then asks the parent to refresh.
+ */
+export default function MilitaryInfoSection({ user, onSaved }: Props) {
+  const [editing, setEditing] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [teamId, setTeamId] = useState(user.teamId || '');
+  const [enlistmentCycle, setEnlistmentCycle] = useState(user.enlistmentCycle || '');
+
+  // Re-sync local edit state whenever the source-of-truth user object
+  // changes (post-save refresh, or async hydration on first render).
+  useEffect(() => {
+    if (!editing) {
+      setTeamId(user.teamId || '');
+      setEnlistmentCycle(user.enlistmentCycle || '');
+    }
+  }, [user.teamId, user.enlistmentCycle, editing]);
+
+  const formatJoinDate = (date: EnhancedAuthUser['joinDate']) => {
+    if (!date) return TEXT_CONSTANTS.PROFILE.NOT_AVAILABLE;
+    try {
+      const js = typeof date === 'object' && 'toDate' in date ? date.toDate() : new Date(date as unknown as string);
+      return format(js, 'dd/MM/yyyy', { locale: he });
+    } catch {
+      return TEXT_CONSTANTS.PROFILE.INVALID_DATE;
+    }
+  };
+
+  const formatEnlistmentCycle = (value: string | undefined) => {
+    if (!value) return TEXT_CONSTANTS.PROFILE.NOT_AVAILABLE;
+    const parsed = parse(value, 'yyyy-MM', new Date());
+    if (!isValid(parsed)) return value;
+    return format(parsed, 'MMMM yyyy', { locale: he });
+  };
+
+  const roleLabel = (role: UserRole | undefined) => {
+    if (role === UserRole.SOLDIER) return TEXT_CONSTANTS.PROFILE.SOLDIER;
+    if (role === UserRole.COMMANDER) return TEXT_CONSTANTS.PROFILE.COMMANDER;
+    if (role === UserRole.OFFICER) return TEXT_CONSTANTS.PROFILE.OFFICER;
+    if (role === UserRole.EQUIPMENT_MANAGER) return TEXT_CONSTANTS.PROFILE.EQUIPMENT_MANAGER;
+    return role ? String(role) : TEXT_CONSTANTS.PROFILE.NOT_AVAILABLE;
+  };
+
+  const statusLabel = (status: EnhancedAuthUser['status']) => {
+    if (status === 'active') return TEXT_CONSTANTS.PROFILE.ACTIVE;
+    if (status === 'inactive') return TEXT_CONSTANTS.PROFILE.INACTIVE;
+    if (status === 'transferred') return TEXT_CONSTANTS.PROFILE.TRANSFERRED;
+    if (status === 'discharged') return TEXT_CONSTANTS.PROFILE.DISCHARGED;
+    return status || TEXT_CONSTANTS.PROFILE.NOT_AVAILABLE;
+  };
+
+  const onSave = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      await updateUserProfile(user.uid, {
+        teamId: teamId.trim(),
+        enlistmentCycle: enlistmentCycle.trim(),
+      });
+      await onSaved();
+      setEditing(false);
+    } catch {
+      setError(TEXT_CONSTANTS.PROFILE.SAVE_ERROR);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const onCancel = () => {
+    setTeamId(user.teamId || '');
+    setEnlistmentCycle(user.enlistmentCycle || '');
+    setError(null);
+    setEditing(false);
+  };
+
+  return (
+    <div className="bg-white rounded-2xl shadow-lg p-4 sm:p-6">
+      <div className="flex items-center justify-between mb-4 gap-2">
+        <h2 className="text-lg sm:text-xl font-bold text-neutral-900 flex items-center gap-2 min-w-0">
+          <svg className="w-5 h-5 text-primary-600 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.031 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+          </svg>
+          <span className="truncate">{TEXT_CONSTANTS.PROFILE.MILITARY_INFO}</span>
+        </h2>
+        {!editing && (
+          <button
+            type="button"
+            onClick={() => setEditing(true)}
+            aria-label={TEXT_CONSTANTS.PROFILE.EDIT_SECTION_ARIA}
+            className="btn-ghost text-sm flex items-center gap-1 shrink-0"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+            </svg>
+            <span>{TEXT_CONSTANTS.PROFILE.EDIT_SECTION}</span>
+          </button>
+        )}
+      </div>
+
+      <dl className="divide-y divide-neutral-100 -my-2">
+        <div className="py-2 sm:grid sm:grid-cols-3 sm:gap-3">
+          <dt className="text-sm font-medium text-neutral-600">{TEXT_CONSTANTS.PROFILE.RANK}</dt>
+          <dd className="text-neutral-900 sm:col-span-2">{user.rank || TEXT_CONSTANTS.PROFILE.NOT_AVAILABLE}</dd>
+        </div>
+
+        <div className="py-2 sm:grid sm:grid-cols-3 sm:gap-3">
+          <dt className="text-sm font-medium text-neutral-600">{TEXT_CONSTANTS.PROFILE.ROLE}</dt>
+          <dd className="text-neutral-900 sm:col-span-2">{roleLabel(user.role)}</dd>
+        </div>
+
+        <div className="py-2 sm:grid sm:grid-cols-3 sm:gap-3">
+          <dt className="text-sm font-medium text-neutral-600">{TEXT_CONSTANTS.PROFILE.JOIN_DATE}</dt>
+          <dd className="text-neutral-900 sm:col-span-2">{formatJoinDate(user.joinDate)}</dd>
+        </div>
+
+        <div className="py-2 sm:grid sm:grid-cols-3 sm:gap-3">
+          <dt className="text-sm font-medium text-neutral-600">{TEXT_CONSTANTS.PROFILE.STATUS}</dt>
+          <dd className="text-neutral-900 sm:col-span-2">{statusLabel(user.status)}</dd>
+        </div>
+
+        <div className="py-2 sm:grid sm:grid-cols-3 sm:gap-3 sm:items-center">
+          <dt className="text-sm font-medium text-neutral-600">{TEXT_CONSTANTS.PROFILE.TEAM}</dt>
+          <dd className="sm:col-span-2">
+            {editing ? (
+              <input
+                type="text"
+                value={teamId}
+                onChange={(e) => setTeamId(e.target.value)}
+                placeholder={TEXT_CONSTANTS.ONBOARDING.TEAM_PLACEHOLDER}
+                className="input-base"
+                disabled={saving}
+              />
+            ) : (
+              <span className="text-neutral-900">{user.teamId || TEXT_CONSTANTS.PROFILE.NOT_AVAILABLE}</span>
+            )}
+          </dd>
+        </div>
+
+        <div className="py-2 sm:grid sm:grid-cols-3 sm:gap-3 sm:items-center">
+          <dt className="text-sm font-medium text-neutral-600">{TEXT_CONSTANTS.PROFILE.ENLISTMENT_CYCLE}</dt>
+          <dd className="sm:col-span-2">
+            {editing ? (
+              <input
+                type="month"
+                value={enlistmentCycle}
+                onChange={(e) => setEnlistmentCycle(e.target.value)}
+                placeholder={TEXT_CONSTANTS.PROFILE.ENLISTMENT_CYCLE_PLACEHOLDER}
+                className="input-base"
+                disabled={saving}
+              />
+            ) : (
+              <span className="text-neutral-900">{formatEnlistmentCycle(user.enlistmentCycle)}</span>
+            )}
+          </dd>
+        </div>
+      </dl>
+
+      {editing && (
+        <div className="mt-4 flex flex-wrap items-center gap-3">
+          <button
+            type="button"
+            onClick={onSave}
+            disabled={saving}
+            className="btn-primary"
+          >
+            {saving ? TEXT_CONSTANTS.PROFILE.SAVING : TEXT_CONSTANTS.PROFILE.SAVE}
+          </button>
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={saving}
+            className="btn-ghost"
+          >
+            {TEXT_CONSTANTS.PROFILE.CANCEL}
+          </button>
+          {error && <span className="text-sm text-danger-600">{error}</span>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/constants/text.en.ts
+++ b/src/constants/text.en.ts
@@ -1,0 +1,25 @@
+/**
+ * Partial English mirror of TEXT_CONSTANTS — populated only for keys added
+ * after `feedback_bilingual_text` (2026-05-13) took effect. The full
+ * English population of legacy keys is the responsibility of the i18n PR.
+ *
+ * Lookup contract: `TEXT_EN.<SECTION>.<KEY>` mirrors
+ * `TEXT_CONSTANTS.<SECTION>.<KEY>`. Missing keys here fall back to the
+ * Hebrew string at the call site (the runtime is not yet locale-aware).
+ */
+export const TEXT_EN = {
+  PROFILE: {
+    TEAM: 'Team',
+    ENLISTMENT_CYCLE: 'Enlistment cycle',
+    ENLISTMENT_CYCLE_PLACEHOLDER: 'YYYY-MM',
+    ADDRESS: 'Address',
+    ADDRESS_PLACEHOLDER: 'City, street, house no.',
+    EDIT_SECTION: 'Edit',
+    EDIT_SECTION_ARIA: 'Edit section',
+    SAVE: 'Save',
+    CANCEL: 'Cancel',
+    SAVING: 'Saving...',
+    SAVED: 'Saved',
+    SAVE_ERROR: 'Save failed. Try again.',
+  },
+} as const;

--- a/src/constants/text.ts
+++ b/src/constants/text.ts
@@ -204,6 +204,20 @@ export const TEXT_CONSTANTS = {
     UNIQUE_ID: 'מזהה ייחודי',
     USER_TYPE: 'סוג משתמש',
     TEST_ACCOUNT: 'חשבון בדיקה',
+    TEAM: 'צוות',
+    ENLISTMENT_CYCLE: 'מחזור גיוס',
+    ENLISTMENT_CYCLE_PLACEHOLDER: 'YYYY-MM',
+    ADDRESS: 'כתובת',
+    ADDRESS_PLACEHOLDER: 'עיר, רחוב ומספר בית',
+
+    // Section-edit controls
+    EDIT_SECTION: 'ערוך',
+    EDIT_SECTION_ARIA: 'ערוך מקטע',
+    SAVE: 'שמור',
+    CANCEL: 'ביטול',
+    SAVING: 'שומר...',
+    SAVED: 'נשמר בהצלחה',
+    SAVE_ERROR: 'שמירה נכשלה. נסה שוב.',
     
     // Data Source Info
     DATA_SOURCE_TITLE: 'מקור הנתונים',

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -125,6 +125,8 @@ export function AuthProvider({ children }: AuthProviderProps) {
               profileImage: firestoreData.profileImage,
               testUser: firestoreData.testUser,
               teamId: firestoreData.teamId,
+              enlistmentCycle: firestoreData.enlistmentCycle,
+              address: firestoreData.address,
               communicationPreferences: firestoreData.communicationPreferences,
               initials: UserDataService.generateInitials(firestoreData)
             };
@@ -286,6 +288,8 @@ export function AuthProvider({ children }: AuthProviderProps) {
       profileImage: firestoreData.profileImage,
       testUser: firestoreData.testUser,
       teamId: firestoreData.teamId,
+      enlistmentCycle: firestoreData.enlistmentCycle,
+      address: firestoreData.address,
       communicationPreferences: firestoreData.communicationPreferences,
       initials: UserDataService.generateInitials(firestoreData),
     };

--- a/src/lib/db/server/userService.ts
+++ b/src/lib/db/server/userService.ts
@@ -14,6 +14,8 @@ const PROFILE_WRITABLE_FIELDS = [
   'teamId',
   'profileImage',
   'phoneNumber',
+  'enlistmentCycle',
+  'address',
 ] as const;
 type ProfileWritableField = (typeof PROFILE_WRITABLE_FIELDS)[number];
 

--- a/src/lib/userProfileService.ts
+++ b/src/lib/userProfileService.ts
@@ -9,6 +9,8 @@ export interface ProfileUpdates {
   teamId?: string;
   profileImage?: string;
   phoneNumber?: string;
+  enlistmentCycle?: string;
+  address?: string;
 }
 
 export async function updateUserProfile(uid: string, updates: ProfileUpdates): Promise<void> {

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -60,6 +60,15 @@ export interface EnhancedAuthUser {
   // Team assignment (used by equipment scope queries)
   teamId?: string;
 
+  // Enlistment cycle: ISO YYYY-MM (e.g. "2010-03" for March 2010).
+  // Stored as a plain string so it survives Firestore JSON round-trips and
+  // doesn't introduce timezone ambiguity (no day/hour component).
+  enlistmentCycle?: string;
+
+  // Mailing / home address. Free-form text. Used by the phone book Phase 2
+  // categorization (Address/City) when that lands.
+  address?: string;
+
   // Active permission grants (temporary role bumps). Server-loaded only;
   // client-side EnhancedAuthUser instances leave this undefined.
   grants?: ActiveGrant[];
@@ -94,6 +103,8 @@ export interface FirestoreUserProfile {
   profileImage?: string;
   testUser?: boolean;
   teamId?: string;
+  enlistmentCycle?: string;
+  address?: string;
   communicationPreferences?: CommunicationPreferences;
 }
 


### PR DESCRIPTION
Combines the standalone 'Team & Unit Assignment' card INTO the Military Info card and introduces a section-level pencil-toggle edit pattern. Adds two new editable profile fields: enlistmentCycle (מחזור גיוס, ISO YYYY-MM) and address (כתובת).

Card layout on /profile is now:
1. Personal Info (read-only)
2. Military Info (editable: team, enlistment cycle; read-only: rank, role, join date, status) — new MilitaryInfoSection component
3. Contact Info (editable: address; phone keeps its own update component; email read-only) — new ContactInfoSection component
4. System Info (read-only)

Section edit: top-trailing pencil swaps the section into edit mode; editable fields become inputs, read-only fields stay text; footer Save + Cancel; Save persists via updateUserProfile and asks the page to refreshEnhancedUser; Cancel resets the buffers and exits. Local edit buffers re-sync against the source user object via useEffect whenever not editing, so post-save refresh + first-render hydration both work.

Enlistment cycle uses input type='month' for the native picker; displayed via date-fns format(parse(value, 'yyyy-MM'), 'MMMM yyyy', { he }) (e.g. 2010-03 → מרץ 2010). Malformed values fall through to the raw string.

Schema:
- EnhancedAuthUser + FirestoreUserProfile: add enlistmentCycle?, address?
- ProfileUpdates: add enlistmentCycle, address
- PROFILE_WRITABLE_FIELDS server allowlist: extended to include both
- AuthContext maps both fields in initial hydrate + refreshEnhancedUser

New text keys in TEXT_CONSTANTS.PROFILE: TEAM, ENLISTMENT_CYCLE (+ placeholder), ADDRESS (+ placeholder), EDIT_SECTION (+ aria), SAVE, CANCEL, SAVING, SAVED, SAVE_ERROR. Per feedback_bilingual_text, mirrored in a new src/constants/text.en.ts containing only the new keys; full English population deferred to the i18n PR.

Docs: profile/page.md rewritten to reflect the new card layout + section-edit pattern. New docs for both section components under docs/codebase/src/components/profile/.