### PR TITLE
feat(settings): wire Change Password flow (Settings PR-B)

### DIFF
--- a/docs/codebase/src/app/settings/page.md
+++ b/docs/codebase/src/app/settings/page.md
@@ -18,10 +18,15 @@ Settings page (`/settings`). Provides a comprehensive settings UI covering profi
 |-------|------|---------|
 | `settings` | `{ emailNotifications, equipmentTransferAlerts, language, theme }` | Local toggle state — not persisted |
 | `profileImageUrl` | `string \| undefined` | Profile image optimistic local state |
+| `changePasswordOpen` | `boolean` | Controls visibility of `<ChangePasswordModal>` |
+
+## Wired actions (real backend)
+
+- **Change password** — opens `<ChangePasswordModal>` (`src/components/settings/ChangePasswordModal.tsx`). Re-authenticates via Firebase, then `updatePassword`. Success → toast via `useToast`. Errors mapped through `mapFirebaseAuthError`. See PR-B in `project_settings_page.md`.
 
 ## Known Issues / TODO
 
-- All settings toggles are UI-only. No Firestore write is connected to any toggle or button.
+- Most settings toggles are still UI-only (notifications, language, theme, permission requests, account deletion). Tracked in `project_settings_page.md` PR sequence.
 - `handleToggle` — logs to console, changes local state only.
 - `handleButtonClick` — logs to console, no action.
 - `handleImageUpdate` — does not persist image to Firestore.

--- a/docs/codebase/src/components/settings/ChangePasswordModal.md
+++ b/docs/codebase/src/components/settings/ChangePasswordModal.md
@@ -1,0 +1,43 @@
+# ChangePasswordModal.tsx
+
+**File:** `src/components/settings/ChangePasswordModal.tsx`
+**Status:** Active (Settings PR-B)
+
+## Purpose
+
+Modal dialog that lets a signed-in user change their account password. Mounted by `/settings` and opened when the user clicks the "שנה סיסמה" button.
+
+## Props
+
+| Prop | Type | Purpose |
+|------|------|---------|
+| `open` | `boolean` | Controls dialog visibility |
+| `onClose` | `() => void` | Closes the dialog. Disabled while a submit is in flight to avoid losing the spinner state |
+| `onSuccess` | `() => void` | Called after a successful password change; the page wires this to a toast |
+
+## Flow
+
+1. User types current + new + confirm-new password.
+2. Client validates: all three filled, new ≥ 6 chars (Firebase default minimum), new === confirm, new !== current.
+3. Submit calls `changePassword(currentPassword, newPassword)` from `src/lib/firebasePhoneAuth.ts`.
+4. Helper performs `reauthenticateWithCredential(EmailAuthProvider.credential(email, current))` then `updatePassword(user, new)`.
+5. On any error, `mapFirebaseAuthError` translates to a Hebrew message rendered inline (`role="alert"`).
+6. On success, the modal calls `onSuccess()` and closes.
+
+## Error surfaces
+
+- `auth/wrong-password` / `auth/invalid-credential` / `auth/invalid-login-credentials` → "הסיסמה הנוכחית שגויה." (`WRONG_PASSWORD`)
+- `auth/weak-password` → "הסיסמה חלשה מדי..." (`WEAK_PASSWORD`) — also pre-emptively blocked by the client-side length check
+- `auth/requires-recent-login` → mapped via `RequiresRecentLoginError` in the helper; surfaces "הפעולה דורשת התחברות מחדש..." (`REQUIRES_RECENT_LOGIN`). When this lands in production the modal should escalate to a logout + re-login prompt (TODO)
+- All other Firebase errors fall through to the default `OTP_INTERNAL_ERROR` mapping
+
+## UI
+
+- Built on Headless UI `Dialog` / `DialogBackdrop` / `DialogPanel` / `DialogTitle` per `feedback_ui_libs`.
+- Three reusable `PasswordField` instances inside the modal — each has its own show/hide eye toggle (`tabIndex={-1}` so it doesn't steal tab focus from the form).
+- Submit button uses `btn-primary`; secondary actions use `btn-ghost`. Both classes come from `globals.css` `@layer components`.
+- All state resets on `open` transition so a reopened modal never leaks the previous attempt's values.
+
+## Localization
+
+Hebrew strings live in `TEXT_CONSTANTS.SETTINGS.*`. English mirrors in `src/constants/text.en.ts` per `feedback_bilingual_text`. The runtime still reads Hebrew only until the i18n PR lands a locale-aware accessor.

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -6,16 +6,18 @@ import AuthGuard from '@/components/auth/AuthGuard';
 import AppShell from '@/app/components/AppShell';
 import { TEXT_CONSTANTS } from '@/constants/text';
 import ProfileImageUpload from '@/components/profile/ProfileImageUpload';
+import ChangePasswordModal from '@/components/settings/ChangePasswordModal';
 import { Select } from '@/components/ui';
-import { 
-  UserIcon, 
-  PhoneIcon, 
-  KeyIcon, 
-  ShieldCheckIcon, 
-  BellIcon, 
-  GlobeIcon, 
-  PaletteIcon, 
-  LockIcon, 
+import { useToast } from '@/components/ui/Toast';
+import {
+  UserIcon,
+  PhoneIcon,
+  KeyIcon,
+  ShieldCheckIcon,
+  BellIcon,
+  GlobeIcon,
+  PaletteIcon,
+  LockIcon,
   TrashIcon,
   MailIcon,
   PackageIcon,
@@ -29,7 +31,9 @@ import {
  */
 export default function SettingsPage() {
   const { enhancedUser } = useAuth();
-  
+  const { showToast } = useToast();
+  const [changePasswordOpen, setChangePasswordOpen] = useState(false);
+
   // TODO: Replace with actual state management when backend is implemented
   const [settings, setSettings] = useState({
     emailNotifications: true,
@@ -145,14 +149,14 @@ export default function SettingsPage() {
                       {TEXT_CONSTANTS.SETTINGS.CHANGE_PASSWORD}
                     </h3>
                     <p className="text-sm text-neutral-500">
-                      {TEXT_CONSTANTS.SETTINGS.COMING_SOON}
+                      {TEXT_CONSTANTS.SETTINGS.CHANGE_PASSWORD_DESCRIPTION}
                     </p>
                   </div>
                 </div>
                 <button
-                  onClick={() => handleButtonClick('changePassword')}
-                  disabled
-                  className="px-4 py-2 text-sm bg-neutral-100 text-neutral-400 rounded-lg cursor-not-allowed"
+                  type="button"
+                  onClick={() => setChangePasswordOpen(true)}
+                  className="btn-primary text-sm"
                 >
                   {TEXT_CONSTANTS.SETTINGS.CHANGE_PASSWORD}
                 </button>
@@ -405,6 +409,12 @@ export default function SettingsPage() {
             </div>
           </div>
         </div>
+
+        <ChangePasswordModal
+          open={changePasswordOpen}
+          onClose={() => setChangePasswordOpen(false)}
+          onSuccess={() => showToast(TEXT_CONSTANTS.SETTINGS.CHANGE_PASSWORD_SUCCESS, 'success')}
+        />
       </AppShell>
     </AuthGuard>
   );

--- a/src/components/settings/ChangePasswordModal.tsx
+++ b/src/components/settings/ChangePasswordModal.tsx
@@ -1,0 +1,205 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import {
+  Dialog,
+  DialogBackdrop,
+  DialogPanel,
+  DialogTitle,
+} from '@headlessui/react';
+import { Eye, EyeOff, X } from 'lucide-react';
+import { changePassword, mapFirebaseAuthError } from '@/lib/firebasePhoneAuth';
+import { TEXT_CONSTANTS } from '@/constants/text';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+const MIN_PASSWORD_LENGTH = 6;
+
+export default function ChangePasswordModal({ open, onClose, onSuccess }: Props) {
+  const [current, setCurrent] = useState('');
+  const [next, setNext] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [showCurrent, setShowCurrent] = useState(false);
+  const [showNext, setShowNext] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Reset all form state whenever the modal re-opens. Avoids leaking the
+  // previous attempt's inputs back into a fresh open.
+  useEffect(() => {
+    if (open) {
+      setCurrent('');
+      setNext('');
+      setConfirm('');
+      setShowCurrent(false);
+      setShowNext(false);
+      setShowConfirm(false);
+      setError(null);
+      setSubmitting(false);
+    }
+  }, [open]);
+
+  const validate = (): string | null => {
+    if (!current || !next || !confirm) return null; // submit will be disabled
+    if (next.length < MIN_PASSWORD_LENGTH) return TEXT_CONSTANTS.SETTINGS.PASSWORD_TOO_SHORT;
+    if (next !== confirm) return TEXT_CONSTANTS.SETTINGS.PASSWORDS_MISMATCH;
+    if (next === current) return TEXT_CONSTANTS.SETTINGS.PASSWORD_UNCHANGED;
+    return null;
+  };
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (submitting) return;
+    const validationError = validate();
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+    setError(null);
+    setSubmitting(true);
+    try {
+      await changePassword(current, next);
+      onSuccess();
+      onClose();
+    } catch (err) {
+      setError(mapFirebaseAuthError(err));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const formInvalid = !current || !next || !confirm;
+
+  return (
+    <Dialog open={open} onClose={submitting ? () => {} : onClose} className="relative z-50">
+      <DialogBackdrop className="fixed inset-0 bg-neutral-900/50 backdrop-blur-sm" />
+      <div className="fixed inset-0 flex items-center justify-center p-4">
+        <DialogPanel className="w-full max-w-md bg-white rounded-2xl shadow-xl p-6">
+          <div className="flex items-start justify-between mb-4 gap-2">
+            <DialogTitle className="text-xl font-bold text-neutral-900">
+              {TEXT_CONSTANTS.SETTINGS.CHANGE_PASSWORD_TITLE}
+            </DialogTitle>
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={submitting}
+              aria-label={TEXT_CONSTANTS.SETTINGS.CANCEL}
+              className="btn-ghost p-1"
+            >
+              <X className="w-5 h-5" aria-hidden="true" />
+            </button>
+          </div>
+          <p className="text-sm text-neutral-600 mb-5">
+            {TEXT_CONSTANTS.SETTINGS.CHANGE_PASSWORD_DESCRIPTION}
+          </p>
+
+          <form onSubmit={onSubmit} className="space-y-4">
+            <PasswordField
+              id="current-password"
+              label={TEXT_CONSTANTS.SETTINGS.CURRENT_PASSWORD}
+              value={current}
+              onChange={setCurrent}
+              show={showCurrent}
+              toggleShow={() => setShowCurrent((v) => !v)}
+              autoComplete="current-password"
+              disabled={submitting}
+            />
+            <PasswordField
+              id="new-password"
+              label={TEXT_CONSTANTS.SETTINGS.NEW_PASSWORD}
+              value={next}
+              onChange={setNext}
+              show={showNext}
+              toggleShow={() => setShowNext((v) => !v)}
+              autoComplete="new-password"
+              disabled={submitting}
+            />
+            <PasswordField
+              id="confirm-new-password"
+              label={TEXT_CONSTANTS.SETTINGS.CONFIRM_NEW_PASSWORD}
+              value={confirm}
+              onChange={setConfirm}
+              show={showConfirm}
+              toggleShow={() => setShowConfirm((v) => !v)}
+              autoComplete="new-password"
+              disabled={submitting}
+            />
+
+            {error && (
+              <div className="text-sm text-danger-700 bg-danger-50 border border-danger-200 rounded-lg px-3 py-2" role="alert">
+                {error}
+              </div>
+            )}
+
+            <div className="flex items-center justify-end gap-3 pt-2">
+              <button
+                type="button"
+                onClick={onClose}
+                disabled={submitting}
+                className="btn-ghost"
+              >
+                {TEXT_CONSTANTS.SETTINGS.CANCEL}
+              </button>
+              <button
+                type="submit"
+                disabled={submitting || formInvalid}
+                className="btn-primary"
+              >
+                {submitting
+                  ? TEXT_CONSTANTS.SETTINGS.CHANGE_PASSWORD_SUBMITTING
+                  : TEXT_CONSTANTS.SETTINGS.CHANGE_PASSWORD_SUBMIT}
+              </button>
+            </div>
+          </form>
+        </DialogPanel>
+      </div>
+    </Dialog>
+  );
+}
+
+interface FieldProps {
+  id: string;
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  show: boolean;
+  toggleShow: () => void;
+  autoComplete: string;
+  disabled: boolean;
+}
+
+function PasswordField({ id, label, value, onChange, show, toggleShow, autoComplete, disabled }: FieldProps) {
+  return (
+    <div>
+      <label htmlFor={id} className="block text-sm font-medium text-neutral-700 mb-1">
+        {label}
+      </label>
+      <div className="relative">
+        <input
+          id={id}
+          type={show ? 'text' : 'password'}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          autoComplete={autoComplete}
+          disabled={disabled}
+          className="input-base pe-10"
+        />
+        <button
+          type="button"
+          onClick={toggleShow}
+          disabled={disabled}
+          aria-label={show ? TEXT_CONSTANTS.SETTINGS.HIDE_PASSWORD : TEXT_CONSTANTS.SETTINGS.SHOW_PASSWORD}
+          className="absolute end-2 top-1/2 -translate-y-1/2 text-neutral-500 hover:text-neutral-700 p-1"
+          tabIndex={-1}
+        >
+          {show ? <EyeOff className="w-4 h-4" aria-hidden="true" /> : <Eye className="w-4 h-4" aria-hidden="true" />}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/constants/text.en.ts
+++ b/src/constants/text.en.ts
@@ -8,6 +8,25 @@
  * Hebrew string at the call site (the runtime is not yet locale-aware).
  */
 export const TEXT_EN = {
+  AUTH: {
+    WRONG_PASSWORD: 'Current password is incorrect.',
+  },
+  SETTINGS: {
+    CHANGE_PASSWORD: 'Change password',
+    CHANGE_PASSWORD_TITLE: 'Change password',
+    CHANGE_PASSWORD_DESCRIPTION: 'Enter your current password, then the new one.',
+    CURRENT_PASSWORD: 'Current password',
+    NEW_PASSWORD: 'New password',
+    CONFIRM_NEW_PASSWORD: 'Confirm new password',
+    PASSWORDS_MISMATCH: 'Passwords do not match.',
+    PASSWORD_TOO_SHORT: 'Password must be at least 6 characters.',
+    PASSWORD_UNCHANGED: 'New password must differ from current.',
+    CHANGE_PASSWORD_SUBMIT: 'Update password',
+    CHANGE_PASSWORD_SUBMITTING: 'Updating...',
+    CHANGE_PASSWORD_SUCCESS: 'Password updated successfully.',
+    SHOW_PASSWORD: 'Show password',
+    HIDE_PASSWORD: 'Hide password',
+  },
   PROFILE: {
     PHONE_NUMBER_LABEL: 'Phone number',
     TEAM: 'Team',

--- a/src/constants/text.ts
+++ b/src/constants/text.ts
@@ -83,6 +83,7 @@ export const TEXT_CONSTANTS = {
     PROVIDER_ALREADY_LINKED: 'שיטת ההתחברות כבר משויכת לחשבון.',
     WEAK_PASSWORD: 'הסיסמה חלשה מדי. בחר סיסמה חזקה יותר.',
     INVALID_EMAIL: 'כתובת אימייל לא תקינה.',
+    WRONG_PASSWORD: 'הסיסמה הנוכחית שגויה.',
     REQUIRES_RECENT_LOGIN: 'הפעולה דורשת התחברות מחדש. אנא התחבר ונסה שוב.',
     REGISTRATION_ABANDONED_FALLBACK: 'הרישום בוטל. ייתכן שיהיה צורך לפנות למנהל כדי להסיר את החשבון.',
     OTP_SESSION_EXPIRED: 'תוקף אימות הטלפון פג. חזור לתחילת הרישום ונסה שוב.',
@@ -1215,6 +1216,21 @@ export const TEXT_CONSTANTS = {
     CHANGE_PROFILE_IMAGE: 'שנה תמונת פרופיל',
     UPDATE_PHONE: 'עדכן מספר טלפון',
     CHANGE_PASSWORD: 'שנה סיסמה',
+
+    // Change-password modal
+    CHANGE_PASSWORD_TITLE: 'שינוי סיסמה',
+    CHANGE_PASSWORD_DESCRIPTION: 'לשינוי הסיסמה הזן את הסיסמה הנוכחית ולאחר מכן את הסיסמה החדשה.',
+    CURRENT_PASSWORD: 'סיסמה נוכחית',
+    NEW_PASSWORD: 'סיסמה חדשה',
+    CONFIRM_NEW_PASSWORD: 'אישור סיסמה חדשה',
+    PASSWORDS_MISMATCH: 'הסיסמאות אינן תואמות.',
+    PASSWORD_TOO_SHORT: 'הסיסמה חייבת להיות באורך של 6 תווים לפחות.',
+    PASSWORD_UNCHANGED: 'הסיסמה החדשה חייבת להיות שונה מהנוכחית.',
+    CHANGE_PASSWORD_SUBMIT: 'עדכן סיסמה',
+    CHANGE_PASSWORD_SUBMITTING: 'מעדכן...',
+    CHANGE_PASSWORD_SUCCESS: 'הסיסמה עודכנה בהצלחה.',
+    SHOW_PASSWORD: 'הצג סיסמה',
+    HIDE_PASSWORD: 'הסתר סיסמה',
     
     // Account Security Section
     ACCOUNT_SECURITY: 'אבטחת חשבון',

--- a/src/lib/__mocks__/firebase.ts
+++ b/src/lib/__mocks__/firebase.ts
@@ -43,6 +43,8 @@ export const sendPasswordResetEmail = jest.fn();
 export const sendEmailVerification = jest.fn();
 export const linkWithCredential = jest.fn();
 export const signInWithPhoneNumber = jest.fn();
+export const reauthenticateWithCredential = jest.fn();
+export const updatePassword = jest.fn();
 
 export class RecaptchaVerifier {
   constructor() {}

--- a/src/lib/__tests__/firebasePhoneAuth.test.ts
+++ b/src/lib/__tests__/firebasePhoneAuth.test.ts
@@ -4,7 +4,10 @@ import {
   EmailAuthProvider,
   sendEmailVerification,
   sendPasswordResetEmail,
+  reauthenticateWithCredential,
+  updatePassword,
 } from 'firebase/auth';
+import { auth } from '@/lib/firebase';
 import {
   sendPhoneOtp,
   confirmPhoneOtp,
@@ -12,6 +15,8 @@ import {
   sendVerificationEmail,
   sendPasswordReset,
   mapFirebaseAuthError,
+  changePassword,
+  RequiresRecentLoginError,
 } from '../firebasePhoneAuth';
 
 const mockSignIn = signInWithPhoneNumber as jest.MockedFunction<typeof signInWithPhoneNumber>;
@@ -19,6 +24,9 @@ const mockLink = linkWithCredential as jest.MockedFunction<typeof linkWithCreden
 const mockCredential = EmailAuthProvider.credential as jest.MockedFunction<typeof EmailAuthProvider.credential>;
 const mockSendEmailVerification = sendEmailVerification as jest.MockedFunction<typeof sendEmailVerification>;
 const mockSendPasswordReset = sendPasswordResetEmail as jest.MockedFunction<typeof sendPasswordResetEmail>;
+const mockReauthenticate = reauthenticateWithCredential as jest.MockedFunction<typeof reauthenticateWithCredential>;
+const mockUpdatePassword = updatePassword as jest.MockedFunction<typeof updatePassword>;
+const mockAuth = auth as unknown as { currentUser: unknown };
 
 describe('firebasePhoneAuth', () => {
   beforeEach(() => {
@@ -60,6 +68,48 @@ describe('firebasePhoneAuth', () => {
     expect(mockSendPasswordReset).toHaveBeenCalledWith(expect.anything(), 'a@b.c');
   });
 
+  describe('changePassword', () => {
+    afterEach(() => {
+      mockAuth.currentUser = null;
+    });
+
+    it('re-authenticates and updates the password', async () => {
+      mockAuth.currentUser = { email: 'a@b.c' };
+      mockCredential.mockReturnValue({ email: 'a@b.c', password: 'old' } as ReturnType<typeof EmailAuthProvider.credential>);
+      mockReauthenticate.mockResolvedValue({} as Awaited<ReturnType<typeof reauthenticateWithCredential>>);
+      mockUpdatePassword.mockResolvedValue();
+
+      await changePassword('old', 'new');
+
+      expect(mockCredential).toHaveBeenCalledWith('a@b.c', 'old');
+      expect(mockReauthenticate).toHaveBeenCalled();
+      expect(mockUpdatePassword).toHaveBeenCalledWith({ email: 'a@b.c' }, 'new');
+    });
+
+    it('throws when there is no signed-in user', async () => {
+      mockAuth.currentUser = null;
+      await expect(changePassword('a', 'b')).rejects.toThrow(/authenticated/);
+    });
+
+    it('translates auth/requires-recent-login into RequiresRecentLoginError', async () => {
+      mockAuth.currentUser = { email: 'a@b.c' };
+      mockCredential.mockReturnValue({ email: 'a@b.c', password: 'old' } as ReturnType<typeof EmailAuthProvider.credential>);
+      mockReauthenticate.mockRejectedValue({ code: 'auth/requires-recent-login' });
+
+      await expect(changePassword('old', 'new')).rejects.toBeInstanceOf(RequiresRecentLoginError);
+      expect(mockUpdatePassword).not.toHaveBeenCalled();
+    });
+
+    it('propagates auth/wrong-password from re-auth', async () => {
+      mockAuth.currentUser = { email: 'a@b.c' };
+      mockCredential.mockReturnValue({ email: 'a@b.c', password: 'old' } as ReturnType<typeof EmailAuthProvider.credential>);
+      mockReauthenticate.mockRejectedValue({ code: 'auth/wrong-password' });
+
+      await expect(changePassword('old', 'new')).rejects.toMatchObject({ code: 'auth/wrong-password' });
+      expect(mockUpdatePassword).not.toHaveBeenCalled();
+    });
+  });
+
   describe('mapFirebaseAuthError', () => {
     it.each([
       ['auth/invalid-phone-number', 'מספר טלפון'],
@@ -70,6 +120,8 @@ describe('firebasePhoneAuth', () => {
       ['auth/email-already-in-use', 'משויכת'],
       ['auth/weak-password', 'חלשה'],
       ['auth/invalid-email', 'תקינה'],
+      ['auth/wrong-password', 'שגויה'],
+      ['auth/invalid-credential', 'שגויה'],
     ])('maps %s to a Hebrew message containing %s', (code, snippet) => {
       const message = mapFirebaseAuthError({ code });
       expect(message).toContain(snippet);

--- a/src/lib/firebasePhoneAuth.ts
+++ b/src/lib/firebasePhoneAuth.ts
@@ -3,6 +3,8 @@ import {
   signInWithPhoneNumber,
   EmailAuthProvider,
   linkWithCredential,
+  reauthenticateWithCredential,
+  updatePassword,
   sendEmailVerification,
   sendPasswordResetEmail,
   signOut,
@@ -100,6 +102,43 @@ export async function signOutCurrentUser(): Promise<void> {
   await signOut(auth);
 }
 
+/**
+ * Change the currently signed-in user's password.
+ *
+ * Performs Firebase's required re-authentication with the email+password
+ * credential first (mandatory for sensitive ops), then calls
+ * `updatePassword`. Throws `RequiresRecentLoginError` when re-auth itself
+ * comes back stale (rare — only happens if the session is severely aged).
+ *
+ * Surfaces:
+ * - `auth/wrong-password` / `auth/invalid-credential` from re-auth when the
+ *   current password is wrong.
+ * - `auth/weak-password` from `updatePassword` when the new password fails
+ *   Firebase's minimum-strength check (default: 6 chars).
+ * - `auth/requires-recent-login` if the credential is still considered
+ *   stale after re-auth (mapped to RequiresRecentLoginError).
+ */
+export async function changePassword(currentPassword: string, newPassword: string): Promise<void> {
+  const user = auth.currentUser;
+  if (!user || !user.email) {
+    throw new Error('No authenticated user with an email provider');
+  }
+  const credential = EmailAuthProvider.credential(user.email, currentPassword);
+  try {
+    await reauthenticateWithCredential(user, credential);
+    await updatePassword(user, newPassword);
+  } catch (error) {
+    const code =
+      error && typeof error === 'object' && 'code' in error
+        ? (error as { code: string }).code
+        : '';
+    if (code === 'auth/requires-recent-login') {
+      throw new RequiresRecentLoginError();
+    }
+    throw error;
+  }
+}
+
 export function mapFirebaseAuthError(error: unknown): string {
   const code =
     error && typeof error === 'object' && 'code' in error
@@ -131,6 +170,10 @@ export function mapFirebaseAuthError(error: unknown): string {
       return TEXT_CONSTANTS.AUTH.WEAK_PASSWORD;
     case 'auth/invalid-email':
       return TEXT_CONSTANTS.AUTH.INVALID_EMAIL;
+    case 'auth/wrong-password':
+    case 'auth/invalid-credential':
+    case 'auth/invalid-login-credentials':
+      return TEXT_CONSTANTS.AUTH.WRONG_PASSWORD;
     case 'auth/requires-recent-login':
       return TEXT_CONSTANTS.AUTH.REQUIRES_RECENT_LOGIN;
     default:


### PR DESCRIPTION
Real Firebase password change wired into the previously-disabled Settings button. No server route needed — the operation runs entirely on the client through firebase/auth.

Flow:
- Settings "שנה סיסמה" button opens new ChangePasswordModal.
- Modal collects current + new + confirm-new with show/hide eye toggles.
- Client validates: all filled, new >= 6 chars (Firebase minimum), new === confirm, new !== current.
- New helper changePassword(current, new) in firebasePhoneAuth.ts: reauthenticateWithCredential(EmailAuthProvider.credential(email, current)) then updatePassword(user, new). Translates auth/requires-recent-login to RequiresRecentLoginError.
- mapFirebaseAuthError extended: auth/wrong-password, auth/invalid-credential, auth/invalid-login-credentials map to WRONG_PASSWORD ("הסיסמה הנוכחית שגויה.").
- Success → useToast success message.

Modal built on Headless UI Dialog per feedback_ui_libs. All form state resets on (re-)open so a reopened modal never leaks previous inputs.

Text:
- TEXT_CONSTANTS.SETTINGS gains CHANGE_PASSWORD_TITLE, _DESCRIPTION, CURRENT_PASSWORD, NEW_PASSWORD, CONFIRM_NEW_PASSWORD, PASSWORDS_MISMATCH, PASSWORD_TOO_SHORT, PASSWORD_UNCHANGED, CHANGE_PASSWORD_SUBMIT, _SUBMITTING, _SUCCESS, SHOW_PASSWORD, HIDE_PASSWORD.
- TEXT_CONSTANTS.AUTH gains WRONG_PASSWORD.
- English mirrors added in src/constants/text.en.ts per feedback_bilingual_text.

Tests:
- 4 new tests in firebasePhoneAuth.test.ts for changePassword (happy path, no signed-in user, requires-recent-login translation, wrong password propagation).
- 2 new rows in the mapFirebaseAuthError table.
- Firebase mock extended with reauthenticateWithCredential + updatePassword.

Docs:
- New docs/codebase/src/components/settings/ChangePasswordModal.md documents flow, error surfaces, UI choices, and bilingual story.
- settings/page.md gains a "Wired actions (real backend)" section marking Change Password as live.

Deferred (out of PR-B scope):
- "Sign me out everywhere" toggle — needs server route to call getAdminAuth().revokeRefreshTokens(uid).
- PASSWORD_CHANGED audit log entry — blocked on PR-D credentialAuditLog.