### PR TITLE
feat(audit): credential audit log collection + write API (Settings PR-D)

### DIFF
--- a/docs/codebase/src/app/api/auth/audit/route.md
+++ b/docs/codebase/src/app/api/auth/audit/route.md
@@ -1,0 +1,42 @@
+# POST /api/auth/audit
+
+**File:** `src/app/api/auth/audit/route.ts`
+**Status:** Active (Settings PR-D)
+
+## Purpose
+
+Single entry point for clients to log a credential-change event to `credentialAuditLog`. Backed by `writeCredentialAuditEvent` in `credentialAuditService.ts`.
+
+## Request
+
+```
+POST /api/auth/audit
+Authorization: Bearer <idToken>
+Body: { uid: string, eventType: CredentialAuditEventType, metadata?: object }
+```
+
+`CredentialAuditEventType` is one of: `PASSWORD_CHANGED`, `PHONE_CHANGED`, `EMAIL_CHANGED`, `PHONE_FORCE_RESET`, `SESSIONS_REVOKED`. Any other value → 400.
+
+## Authorization
+
+- Bearer token required via `getActorOrError`.
+- Caller may log against their OWN uid.
+- ADMIN / SYSTEM_MANAGER may log against any uid (used by force-reset and admin-override flows).
+- Other actor / target combinations → 403.
+
+## Capture
+
+The route captures IP + User-Agent from the request headers — the client cannot forge them. IP comes from `x-forwarded-for` (first hop) or `x-real-ip`; either may be absent in dev and the field is then omitted from the doc.
+
+## Failure modes
+
+- 400 — missing `uid`, missing/invalid `eventType`, malformed `metadata`.
+- 401 — missing or invalid bearer token (from `getActorOrError`).
+- 403 — caller is not the target and not elevated.
+- 500 — write failure.
+
+## Related
+
+- Service: `src/lib/db/server/credentialAuditService.ts`
+- Client wrapper: `src/lib/credentialAuditClient.ts`
+- Settings PR plan: `project_settings_page.md` PR-D.

--- a/docs/codebase/src/lib/db/server/credentialAuditService.md
+++ b/docs/codebase/src/lib/db/server/credentialAuditService.md
@@ -1,0 +1,49 @@
+# credentialAuditService.ts
+
+**File:** `src/lib/db/server/credentialAuditService.ts`
+**Status:** Active (Settings PR-D)
+
+## Purpose
+
+Server-side service for the credential audit trail. Distinct from `actionsLog` (equipment / ammo / template domain mutations). Credential events touch identity primitives — password, phone, email, refresh-token revocation — and need their own audit surface for security review without polluting the equipment-centric `actionsLog` schema.
+
+## Collection
+
+`credentialAuditLog` (constant: `COLLECTIONS.CREDENTIAL_AUDIT_LOG`).
+
+Firestore rules deny **all** client access (read AND write). Every operation goes through this service via an API route.
+
+## Document shape
+
+See `src/types/credentialAudit.ts`. Fields:
+
+- `uid` — target user
+- `actorUid` — who performed the change (usually === uid; differs for admin force-reset)
+- `actorUserType` — frozen at write time so a later role demotion can't rewrite history
+- `eventType` — one of `PASSWORD_CHANGED` / `PHONE_CHANGED` / `EMAIL_CHANGED` / `PHONE_FORCE_RESET` / `SESSIONS_REVOKED`
+- `timestamp` — server timestamp set at write
+- `ip?` — best-effort first-hop from `x-forwarded-for` or `x-real-ip`
+- `userAgent?` — from the request `User-Agent` header
+- `metadata?` — opt-in event-specific payload (e.g. `{ oldNumberHash, newNumberHash }` for `PHONE_CHANGED` — NEVER plaintext)
+
+The document is append-only — no update or delete path exists in this codebase.
+
+## API
+
+- `writeCredentialAuditEvent(args)` — appends one entry; returns the generated doc id. Optional fields are omitted from the document when not supplied (and `metadata` is dropped when an empty object is passed).
+- `listCredentialAuditForUser(uid, limit = 50)` — newest-first, scoped to a single target user. Caller-elevation enforcement is the API route's job — this service trusts its caller.
+
+## Tests
+
+`src/lib/db/server/__tests__/credentialAuditService.test.ts` covers:
+- Minimal write shape (server timestamp, no optional fields leak).
+- IP + User-Agent included when supplied.
+- Empty `metadata` object dropped.
+- Non-empty `metadata` preserved.
+- List scopes by uid, orders descending on `timestamp`, applies default + custom limits.
+
+## Related
+
+- API route: `src/app/api/auth/audit/route.ts`.
+- Client wrapper: `src/lib/credentialAuditClient.ts`.
+- Settings PR plan: `project_settings_page.md` PR-D.

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -36,6 +36,15 @@ service cloud.firestore {
       allow write: if false;
     }
 
+    // Credential audit log — server-only (admin SDK). Client SDK can
+    // neither read nor write. Admin / SYSTEM_MANAGER lookups go through
+    // dedicated API routes (`/api/auth/audit` for writes; future read
+    // routes will gate access via actor.userType).
+    match /credentialAuditLog/{entryId} {
+      allow read: if false;
+      allow write: if false;
+    }
+
     // Equipment templates — authenticated read
     match /equipmentTemplates/{typeId} {
       allow read: if request.auth != null;

--- a/src/app/api/auth/audit/route.ts
+++ b/src/app/api/auth/audit/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse } from 'next/server';
+import { getActorOrError } from '@/lib/db/server/auth';
+import { writeCredentialAuditEvent } from '@/lib/db/server/credentialAuditService';
+import { UserType } from '@/types/user';
+import type { CredentialAuditEventType } from '@/types/credentialAudit';
+
+const ALLOWED_EVENT_TYPES: readonly CredentialAuditEventType[] = [
+  'PASSWORD_CHANGED',
+  'PHONE_CHANGED',
+  'EMAIL_CHANGED',
+  'PHONE_FORCE_RESET',
+  'SESSIONS_REVOKED',
+];
+
+/**
+ * POST /api/auth/audit
+ * Body: { uid: string, eventType: CredentialAuditEventType, metadata?: object }
+ *
+ * Append a single credential-change event to `credentialAuditLog`. Caller
+ * must be authenticated. Caller may log an event for their OWN uid; only
+ * ADMIN / SYSTEM_MANAGER may log an event targeting another uid (used by
+ * force-reset / admin override flows).
+ *
+ * Metadata is opt-in and event-specific. PASSWORD_CHANGED takes no
+ * metadata. PHONE_CHANGED should pass `{ oldNumberHash, newNumberHash }`
+ * (NEVER plaintext) once PR-C lands. SESSIONS_REVOKED takes no metadata.
+ *
+ * IP + User-Agent are captured server-side from request headers — the
+ * client cannot forge them.
+ */
+export async function POST(request: Request) {
+  try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
+    const actor = actorOrError;
+
+    const body = await request.json();
+    if (!body?.uid || typeof body.uid !== 'string') {
+      return NextResponse.json({ success: false, error: 'uid is required' }, { status: 400 });
+    }
+    if (!body?.eventType || !ALLOWED_EVENT_TYPES.includes(body.eventType)) {
+      return NextResponse.json(
+        { success: false, error: 'eventType must be one of: ' + ALLOWED_EVENT_TYPES.join(', ') },
+        { status: 400 },
+      );
+    }
+    if (body.metadata !== undefined && (typeof body.metadata !== 'object' || body.metadata === null || Array.isArray(body.metadata))) {
+      return NextResponse.json({ success: false, error: 'metadata must be a plain object' }, { status: 400 });
+    }
+
+    const isElevated =
+      actor.userType === UserType.ADMIN || actor.userType === UserType.SYSTEM_MANAGER;
+    if (body.uid !== actor.uid && !isElevated) {
+      return NextResponse.json(
+        { success: false, error: 'Forbidden: cannot log audit for another user' },
+        { status: 403 },
+      );
+    }
+
+    // Best-effort IP capture. Vercel sets x-forwarded-for; first hop in the
+    // comma-separated list is the original client. May be empty in dev.
+    const xff = request.headers.get('x-forwarded-for') ?? '';
+    const ip = xff.split(',')[0]?.trim() || request.headers.get('x-real-ip') || undefined;
+    const userAgent = request.headers.get('user-agent') ?? undefined;
+
+    const id = await writeCredentialAuditEvent({
+      uid: body.uid,
+      actorUid: actor.uid,
+      actorUserType: String(actor.userType),
+      eventType: body.eventType as CredentialAuditEventType,
+      ip: ip || undefined,
+      userAgent,
+      metadata: body.metadata,
+    });
+
+    return NextResponse.json({ success: true, id });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('[API] auth/audit POST failed:', message);
+    return NextResponse.json({ success: false, error: message }, { status: 500 });
+  }
+}

--- a/src/lib/credentialAuditClient.ts
+++ b/src/lib/credentialAuditClient.ts
@@ -1,0 +1,33 @@
+/**
+ * Client wrapper for POST /api/auth/audit. Records a credential-change
+ * event for the current user (or a target uid if elevated).
+ *
+ * Designed for fire-and-forget usage from client flows that have just
+ * performed a credential-touching action (e.g. password change). Errors
+ * are logged but not re-thrown — audit failure must not block the user's
+ * primary action from completing.
+ */
+
+import { apiFetch } from '@/lib/apiFetch';
+import type { CredentialAuditEventType } from '@/types/credentialAudit';
+
+interface LogArgs {
+  uid: string;
+  eventType: CredentialAuditEventType;
+  metadata?: Record<string, unknown>;
+}
+
+export async function logCredentialAuditEvent(args: LogArgs): Promise<void> {
+  try {
+    const response = await apiFetch('/api/auth/audit', {
+      method: 'POST',
+      body: JSON.stringify(args),
+    });
+    const result = await response.json();
+    if (!result.success) {
+      console.warn('[credentialAudit] server rejected entry:', result.error);
+    }
+  } catch (error) {
+    console.warn('[credentialAudit] failed to log entry:', error);
+  }
+}

--- a/src/lib/db/collections.ts
+++ b/src/lib/db/collections.ts
@@ -30,6 +30,7 @@ export const COLLECTIONS = {
   TRAINING_PLANS: 'trainingPlans',
   PHONE_BOOK: 'phoneBook',
   GUARD_SCHEDULES: 'guardSchedules',
+  CREDENTIAL_AUDIT_LOG: 'credentialAuditLog',
 } as const;
 
 export type CollectionName = typeof COLLECTIONS[keyof typeof COLLECTIONS];

--- a/src/lib/db/server/__tests__/credentialAuditService.test.ts
+++ b/src/lib/db/server/__tests__/credentialAuditService.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Tests for the credential audit service. Verifies that writes shape the
+ * Firestore document correctly (server timestamp, conditional fields,
+ * metadata gating) and that list scopes by uid + orderBy + limit.
+ */
+
+jest.mock('firebase-admin/firestore', () => ({
+  FieldValue: {
+    serverTimestamp: () => 'SERVER_TIMESTAMP',
+  },
+}));
+
+jest.mock('firebase-admin/app', () => ({
+  initializeApp: () => ({}),
+  getApps: () => [],
+  cert: () => ({}),
+  applicationDefault: () => ({}),
+}));
+
+const addMock = jest.fn(async (data: Record<string, unknown>) => {
+  capturedWrites.push(data);
+  return { id: 'fake-audit-id' };
+});
+
+interface QueryState {
+  wheres: Array<[string, string, unknown]>;
+  orders: Array<[string, string]>;
+  limitN: number | null;
+}
+
+const capturedWrites: Record<string, unknown>[] = [];
+let queryState: QueryState = { wheres: [], orders: [], limitN: null };
+const docs = [
+  { id: 'a1', data: () => ({ uid: 'u1', eventType: 'PASSWORD_CHANGED' }) },
+  { id: 'a2', data: () => ({ uid: 'u1', eventType: 'PHONE_CHANGED' }) },
+];
+
+const queryChain = () => ({
+  where: (field: string, op: string, value: unknown) => {
+    queryState.wheres.push([field, op, value]);
+    return queryChain();
+  },
+  orderBy: (field: string, direction: string) => {
+    queryState.orders.push([field, direction]);
+    return queryChain();
+  },
+  limit: (n: number) => {
+    queryState.limitN = n;
+    return queryChain();
+  },
+  get: async () => ({ docs }),
+});
+
+const collectionMock = jest.fn(() => ({
+  add: addMock,
+  ...queryChain(),
+}));
+
+jest.mock('@/lib/db/admin', () => ({
+  getAdminDb: jest.fn(() => ({ collection: collectionMock })),
+}));
+
+import { writeCredentialAuditEvent, listCredentialAuditForUser } from '../credentialAuditService';
+
+describe('credentialAuditService', () => {
+  beforeEach(() => {
+    capturedWrites.length = 0;
+    queryState = { wheres: [], orders: [], limitN: null };
+    addMock.mockClear();
+    collectionMock.mockClear();
+  });
+
+  describe('writeCredentialAuditEvent', () => {
+    it('writes minimal entry with server timestamp', async () => {
+      const id = await writeCredentialAuditEvent({
+        uid: 'u1',
+        actorUid: 'u1',
+        actorUserType: 'user',
+        eventType: 'PASSWORD_CHANGED',
+      });
+      expect(id).toBe('fake-audit-id');
+      expect(capturedWrites[0]).toMatchObject({
+        uid: 'u1',
+        actorUid: 'u1',
+        actorUserType: 'user',
+        eventType: 'PASSWORD_CHANGED',
+        timestamp: 'SERVER_TIMESTAMP',
+      });
+      expect(capturedWrites[0]).not.toHaveProperty('ip');
+      expect(capturedWrites[0]).not.toHaveProperty('userAgent');
+      expect(capturedWrites[0]).not.toHaveProperty('metadata');
+    });
+
+    it('includes ip + userAgent when supplied', async () => {
+      await writeCredentialAuditEvent({
+        uid: 'u1',
+        actorUid: 'u1',
+        actorUserType: 'user',
+        eventType: 'PASSWORD_CHANGED',
+        ip: '1.2.3.4',
+        userAgent: 'TestAgent/1.0',
+      });
+      expect(capturedWrites[0]).toMatchObject({ ip: '1.2.3.4', userAgent: 'TestAgent/1.0' });
+    });
+
+    it('omits metadata key when object is empty', async () => {
+      await writeCredentialAuditEvent({
+        uid: 'u1',
+        actorUid: 'u1',
+        actorUserType: 'user',
+        eventType: 'PASSWORD_CHANGED',
+        metadata: {},
+      });
+      expect(capturedWrites[0]).not.toHaveProperty('metadata');
+    });
+
+    it('includes metadata when non-empty', async () => {
+      await writeCredentialAuditEvent({
+        uid: 'u1',
+        actorUid: 'admin-1',
+        actorUserType: 'admin',
+        eventType: 'PHONE_FORCE_RESET',
+        metadata: { reason: 'lost_device' },
+      });
+      expect(capturedWrites[0]).toMatchObject({ metadata: { reason: 'lost_device' } });
+    });
+  });
+
+  describe('listCredentialAuditForUser', () => {
+    it('scopes by uid, orders newest first, applies default limit', async () => {
+      const entries = await listCredentialAuditForUser('u1');
+      expect(queryState.wheres).toContainEqual(['uid', '==', 'u1']);
+      expect(queryState.orders).toContainEqual(['timestamp', 'desc']);
+      expect(queryState.limitN).toBe(50);
+      expect(entries).toHaveLength(2);
+      expect(entries[0]).toMatchObject({ id: 'a1', uid: 'u1' });
+    });
+
+    it('respects a caller-supplied limit', async () => {
+      await listCredentialAuditForUser('u1', 10);
+      expect(queryState.limitN).toBe(10);
+    });
+  });
+});

--- a/src/lib/db/server/credentialAuditService.ts
+++ b/src/lib/db/server/credentialAuditService.ts
@@ -1,0 +1,63 @@
+/**
+ * Server-side service for the credential audit log.
+ *
+ * All writes go through `writeCredentialAuditEvent`. Reads are restricted
+ * to admin / SYSTEM_MANAGER via `listCredentialAuditForUser`. Firestore
+ * rules deny ALL client access to the underlying collection — every
+ * read/write must come through this service via an API route.
+ */
+import { getAdminDb } from '../admin';
+import { COLLECTIONS } from '../collections';
+import { FieldValue } from 'firebase-admin/firestore';
+import type { CredentialAuditEntry, CredentialAuditEventType } from '@/types/credentialAudit';
+
+interface WriteArgs {
+  uid: string;
+  actorUid: string;
+  actorUserType: string;
+  eventType: CredentialAuditEventType;
+  ip?: string;
+  userAgent?: string;
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Append a single credential-change event. Document ID is auto-generated;
+ * the entry is append-only — there is no update or delete path on this
+ * collection from any code in this codebase.
+ */
+export async function writeCredentialAuditEvent(args: WriteArgs): Promise<string> {
+  const db = getAdminDb();
+  const entry: Record<string, unknown> = {
+    uid: args.uid,
+    actorUid: args.actorUid,
+    actorUserType: args.actorUserType,
+    eventType: args.eventType,
+    timestamp: FieldValue.serverTimestamp(),
+  };
+  if (args.ip) entry.ip = args.ip;
+  if (args.userAgent) entry.userAgent = args.userAgent;
+  if (args.metadata && Object.keys(args.metadata).length > 0) entry.metadata = args.metadata;
+
+  const ref = await db.collection(COLLECTIONS.CREDENTIAL_AUDIT_LOG).add(entry);
+  return ref.id;
+}
+
+/**
+ * Fetch the most recent N credential-audit entries for a single target uid,
+ * newest first. Caller must be elevated (enforced at the API-route layer,
+ * not here — service trusts its caller).
+ */
+export async function listCredentialAuditForUser(
+  uid: string,
+  limit = 50,
+): Promise<Array<CredentialAuditEntry & { id: string }>> {
+  const db = getAdminDb();
+  const snap = await db
+    .collection(COLLECTIONS.CREDENTIAL_AUDIT_LOG)
+    .where('uid', '==', uid)
+    .orderBy('timestamp', 'desc')
+    .limit(limit)
+    .get();
+  return snap.docs.map((d) => ({ id: d.id, ...(d.data() as CredentialAuditEntry) }));
+}

--- a/src/types/credentialAudit.ts
+++ b/src/types/credentialAudit.ts
@@ -1,0 +1,46 @@
+/**
+ * Credential-change audit trail.
+ *
+ * Distinct from `actionsLog` (equipment / ammo / template domain mutations).
+ * Credential events touch identity primitives — password, phone identifier,
+ * email identifier, refresh-token revocation — and need their own audit
+ * surface for security review without polluting the equipment-centric
+ * actionsLog schema.
+ *
+ * Writes are server-only (admin SDK). Reads are server-only (rules deny
+ * client reads); admin / SYSTEM_MANAGER lookups go through dedicated API
+ * routes that filter + scope.
+ */
+
+import type { Timestamp } from 'firebase/firestore';
+
+export type CredentialAuditEventType =
+  | 'PASSWORD_CHANGED'
+  | 'PHONE_CHANGED'
+  | 'EMAIL_CHANGED'
+  | 'PHONE_FORCE_RESET'
+  | 'SESSIONS_REVOKED';
+
+export interface CredentialAuditEntry {
+  /** Target user whose credential changed. */
+  uid: string;
+  /** Actor who performed the change. Usually === uid; differs for admin force-reset. */
+  actorUid: string;
+  /** Actor's userType at the time of the event (frozen — do not re-evaluate later). */
+  actorUserType: string;
+  /** Event kind. */
+  eventType: CredentialAuditEventType;
+  /** Server timestamp set at write time. */
+  timestamp: Timestamp;
+  /** Originating IP from the request (best-effort; may be a proxy IP). */
+  ip?: string;
+  /** Originating User-Agent from the request. */
+  userAgent?: string;
+  /**
+   * Event-specific payload. Intentionally NOT typed strictly — keeps the
+   * schema flexible as new event types land. Convention: PHONE_CHANGED
+   * stores `{ oldNumberHash, newNumberHash }` (never plaintext); other
+   * events leave empty.
+   */
+  metadata?: Record<string, unknown>;
+}


### PR DESCRIPTION
New `credentialAuditLog` collection captures identity-primitive mutations (password / phone / email / refresh-token revoke) separate from the equipment-centric `actionsLog`. Council recommended the separate-collection path; `actionsLog.equipmentId` stays a required field and credential events do not pollute it.

Schema (src/types/credentialAudit.ts):
- uid              — target user
- actorUid         — performer (usually === uid; differs for admin
                     force-reset)
- actorUserType    — frozen at write time so a later role demotion
                     can't rewrite history
- eventType        — PASSWORD_CHANGED | PHONE_CHANGED | EMAIL_CHANGED
                     | PHONE_FORCE_RESET | SESSIONS_REVOKED
- timestamp        — server-set
- ip?              — best-effort first hop from x-forwarded-for /
                     x-real-ip
- userAgent?       — from request header
- metadata?        — event-specific payload (convention:
                     {oldNumberHash,newNumberHash} for PHONE_CHANGED;
                     NEVER plaintext)

Append-only — no update or delete path exists in this codebase.

Service (src/lib/db/server/credentialAuditService.ts):
- writeCredentialAuditEvent(args): string — generates doc ID, sets server timestamp, drops empty metadata, omits ip/ua when unset.
- listCredentialAuditForUser(uid, limit=50): newest-first; caller elevation is enforced at the API layer.

API route POST /api/auth/audit:
- Bearer-token auth via getActorOrError.
- Actor may target their OWN uid; ADMIN / SYSTEM_MANAGER may target any uid (used by force-reset/admin-override flows).
- IP + User-Agent captured server-side from request headers — client cannot forge.
- Allowlist of eventTypes enforced; unknown → 400.
- Metadata must be a plain object if supplied → 400 otherwise.

Client wrapper src/lib/credentialAuditClient.ts:
- logCredentialAuditEvent({ uid, eventType, metadata? }) fire-and- forget pattern. Errors logged, never thrown — audit failure must not block the user's primary action from completing.

Firestore rules: credentialAuditLog/{id} denies all client read + write. Every operation must go through the admin-SDK service.

Tests (6) covering minimal write shape, conditional fields, empty- metadata dropping, and list scope/ordering/limit. Lint clean.

Docs:
- New service docs + route docs.
- Memory updated marking PR-D shipped.

Deferred (small follow-up PR):
- Wire logCredentialAuditEvent into PR-B's Change Password success path. PR-B already merged so amending it would split the audit trail across two commits awkwardly — separate PR is cleaner.