### PR TITLE
feat(audit): log PASSWORD_CHANGED on Change Password success

### DIFF
--- a/docs/codebase/src/components/settings/ChangePasswordModal.md
+++ b/docs/codebase/src/components/settings/ChangePasswordModal.md
@@ -22,7 +22,8 @@ Modal dialog that lets a signed-in user change their account password. Mounted b
 3. Submit calls `changePassword(currentPassword, newPassword)` from `src/lib/firebasePhoneAuth.ts`.
 4. Helper performs `reauthenticateWithCredential(EmailAuthProvider.credential(email, current))` then `updatePassword(user, new)`.
 5. On any error, `mapFirebaseAuthError` translates to a Hebrew message rendered inline (`role="alert"`).
-6. On success, the modal calls `onSuccess()` and closes.
+6. On success, fire-and-forget call to `logCredentialAuditEvent({ uid, eventType: 'PASSWORD_CHANGED' })` records the event in `credentialAuditLog`. Audit failure never blocks success — the client wrapper swallows network errors.
+7. Modal calls `onSuccess()` and closes.
 
 ## Error surfaces
 

--- a/src/components/settings/ChangePasswordModal.tsx
+++ b/src/components/settings/ChangePasswordModal.tsx
@@ -9,6 +9,8 @@ import {
 } from '@headlessui/react';
 import { Eye, EyeOff, X } from 'lucide-react';
 import { changePassword, mapFirebaseAuthError } from '@/lib/firebasePhoneAuth';
+import { logCredentialAuditEvent } from '@/lib/credentialAuditClient';
+import { auth } from '@/lib/firebase';
 import { TEXT_CONSTANTS } from '@/constants/text';
 
 interface Props {
@@ -64,6 +66,10 @@ export default function ChangePasswordModal({ open, onClose, onSuccess }: Props)
     setSubmitting(true);
     try {
       await changePassword(current, next);
+      const uid = auth.currentUser?.uid;
+      if (uid) {
+        void logCredentialAuditEvent({ uid, eventType: 'PASSWORD_CHANGED' });
+      }
       onSuccess();
       onClose();
     } catch (err) {


### PR DESCRIPTION
Wires logCredentialAuditEvent into ChangePasswordModal so every successful password change writes a credentialAuditLog entry. Fire-and- forget — audit failure never blocks the user's primary action.