### PR TITLE
fix(rtl): mobile drawer slid to visual left — anchor on inline-start

### DIFF
--- a/docs/rtl-audit.md
+++ b/docs/rtl-audit.md
@@ -35,6 +35,23 @@ on the **right** (start of reading). Use `justify-start` in that case.
 
 Recurring offender: action-row headers that want the primary CTA on the right.
 
+### Slide-out drawer gotcha — `end-0` + `translate-x` mismatch
+
+CSS logical inset (`end-0`, `start-0`) IS direction-aware, but CSS transforms
+(`translate-x`, Framer Motion's `x`) are **physical** — `translateX(100%)`
+always moves the element 100% of its width to the visual right regardless of
+`dir`. The combination `end-0` + `x: '100%'` slides a drawer to the visual
+left in RTL, away from the hamburger trigger on the right.
+
+For a drawer that opens from the same side as the hamburger button (Hebrew
+default — top-right trigger), use `start-0` + `x: '100%'` so the panel anchors
+on the inline-start (visual right in RTL) and the off-screen state is to the
+visual right of the viewport. Document the physical-vs-logical mix in a
+comment so the next reader doesn't "fix" it.
+
+Recurring offender: mobile sidebar drawers using Framer Motion or a static
+`translate-x-full` toggle.
+
 ## Status
 
 ### ✅ Fixed (2026-05-12, batch 1)
@@ -165,6 +182,24 @@ removed physical classes (`right-3`/`left-3`/`right-0`) to the logical
 classes (`start-3`/`end-3`/`start-0`) that batch 3 actually shipped. Reduced
 failing tests from 10 → 4 (remaining 4 are unrelated validation/tooltip-styling
 issues that pre-date this branch).
+
+### ✅ Fixed (2026-05-14 — `fix/rtl-mobile-menu-clings-to-left`)
+
+Post-audit regression spotted in production: mobile hamburger drawers were
+sliding to the visual **left** in RTL instead of right (away from the
+hamburger trigger). Root cause is documented above in the "Slide-out drawer
+gotcha" — the `end-0` + `translate-x: 100%` combo mismatches logical inset
+with physical transform.
+
+- `src/app/components/AppSidebar.tsx` — primary mobile drawer used by every
+  `AppShell`-wrapped page. `end-0` → `start-0`.
+- `src/components/management/sidebar/ManagementSidebar.tsx` — `/management`
+  page sidebar (uses `lg:relative` to switch to inline layout above the
+  breakpoint, so the inset only applies on mobile). `end-0` → `start-0`.
+- `src/components/ui/HamburgerMenu.tsx` — legacy drawer with no remaining
+  callers in `src/`, fixed for consistency in case it's revived.
+
+All three carry an inline comment explaining the physical-vs-logical mix.
 
 ### Guidelines for new code
 

--- a/src/app/components/AppSidebar.tsx
+++ b/src/app/components/AppSidebar.tsx
@@ -100,7 +100,15 @@ export default function AppSidebar({ mobileOpen, onMobileClose }: AppSidebarProp
               animate={{ x: 0 }}
               exit={{ x: '100%' }}
               transition={{ type: 'tween', duration: 0.25 }}
-              className="fixed top-0 end-0 h-full w-80 max-w-[85vw] bg-white shadow-strong z-[9999] lg:hidden flex flex-col"
+              // `start-0` anchors the panel to the inline-start edge of the
+              // viewport, which in RTL is the visual right — same side as
+              // the hamburger button. With the document direction set to
+              // RTL, `end-0` would clamp the drawer to the visual left,
+              // sliding it away from the trigger. Framer Motion's `x` axis
+              // is physical (not direction-aware), and `initial: 100%`
+              // pushes the panel further to the visual right (off-screen)
+              // before settling to `x: 0` at the anchored right edge.
+              className="fixed top-0 start-0 h-full w-80 max-w-[85vw] bg-white shadow-strong z-[9999] lg:hidden flex flex-col"
               aria-label={TEXT_CONSTANTS.ARIA_LABELS.MAIN_MENU}
             >
               <div className="flex justify-between items-center h-14 px-4 border-b border-neutral-200">

--- a/src/components/management/sidebar/ManagementSidebar.tsx
+++ b/src/components/management/sidebar/ManagementSidebar.tsx
@@ -37,7 +37,13 @@ export default function ManagementSidebar({
   useScrollLock(isOpen && isMobile);
   return (
     <div className={cn(
-      'fixed inset-y-0 end-0 z-50 w-80 bg-white shadow-2xl transform transition-all duration-500 ease-out',
+      // `start-0` anchors to inline-start (visual right in RTL) on the
+      // mobile fixed layout; the lg breakpoint switches to `relative`,
+      // where the inset has no effect and the sidebar flows naturally on
+      // the inline-start side of the management grid. `translate-x-full`
+      // is physical — pushes the panel visually right (off-screen) when
+      // closed.
+      'fixed inset-y-0 start-0 z-50 w-80 bg-white shadow-2xl transform transition-all duration-500 ease-out',
       'lg:relative lg:translate-x-0 lg:w-72 lg:shadow-lg lg:duration-0',
       isOpen ? 'translate-x-0 shadow-2xl' : 'translate-x-full shadow-none'
     )}>

--- a/src/components/ui/HamburgerMenu.tsx
+++ b/src/components/ui/HamburgerMenu.tsx
@@ -97,7 +97,11 @@ export default function HamburgerMenu({
               exit={{ x: '100%' }}
               transition={{ type: 'tween', duration: 0.3 }}
               className={cn(
-                'fixed top-0 end-0 h-full w-80 bg-white shadow-xl z-[9999]',
+                // `start-0` anchors to inline-start = visual right in RTL,
+                // same side as the hamburger trigger. Framer Motion's `x`
+                // is physical, so `100%` translates visually right (off-
+                // screen) before settling.
+                'fixed top-0 start-0 h-full w-80 bg-white shadow-xl z-[9999]',
                 menuClassName
               )}
             >


### PR DESCRIPTION
Mobile hamburger drawers were clinging to the visual left in RTL even though the hamburger trigger is on the visual right. Root cause: the panels combined `end-0` (logical, RTL-aware: visual left) with Framer Motion `x: '100%'` / Tailwind `translate-x-full` (physical, always moves visually right). The two cancelled out and the panel docked on the wrong side.

Fix: anchor on inline-start (`start-0`), which in RTL resolves to the visual right — same side as the trigger. The physical `x: '100%'` / `translate-x-full` now correctly pushes the panel off-screen to the visual right and slides it back in.

- src/app/components/AppSidebar.tsx — primary mobile drawer used by every AppShell-wrapped page. `end-0` → `start-0`.
- src/components/management/sidebar/ManagementSidebar.tsx — /management page sidebar (uses `lg:relative` above the lg breakpoint, so inset only applies on mobile). `end-0` → `start-0`.
- src/components/ui/HamburgerMenu.tsx — legacy drawer with no remaining call sites in `src/`. Fixed for consistency in case it's revived.
- All three carry an inline comment explaining the logical-inset vs physical-transform mix so the next reader doesn't "fix" it.
- docs/rtl-audit.md — new "Slide-out drawer gotcha" entry under Conventions + entry under Status with the three files fixed.