### PR TITLE
chore(scripts): operator-callable purge scripts for phone-change pend…

### DIFF
--- a/docs/spec/phone-change.md
+++ b/docs/spec/phone-change.md
@@ -180,11 +180,11 @@ Stacked commits inside the PR for review clarity:
 ## Follow-ups (out of PR-C)
 
 - Rate-limit OTP sends keyed on `(actorUid, destinationPhone, ip)`. (Council "should-have".)
-- `phoneChangePending` cron purge for stale > 24h reservations.
-- `credentialAuditLog` 1y TTL purge job (Q5=a).
+- ✅ `phoneChangePending` purge for stale > 24h reservations — operator-callable script at `scripts/purge-phone-change-pending.js` (2026-05-13). Cron promotion is next.
+- ✅ `credentialAuditLog` 1y TTL purge — operator-callable script at `scripts/purge-credential-audit-log.js` (2026-05-13). Cron promotion is next.
 - Old-phone notification (email + SMS) — depends on PR-E notification sender pick.
-- Auth↔Firestore phone reconciler cron.
+- Auth↔Firestore phone reconciler cron. (Manual script `scripts/reconcile-phone.js` exists; cron promotion is next.)
 - `auth/credential-already-in-use` → "phone already linked" UX with sign-in offer.
 - Admin force-phone-reset endpoint (Q4=b separate PR with 4-eyes).
 - App Check + reCAPTCHA Enterprise initialization (not present in codebase yet — Council "should-have").
-- `cachedVerifier` reset on Settings-page mount (Council polish).
+- ✅ `cachedVerifier` reset on Settings-page mount (Council polish) — done inside `ChangePhoneModal` `useEffect(open)`.

--- a/scripts/purge-credential-audit-log.js
+++ b/scripts/purge-credential-audit-log.js
@@ -1,0 +1,140 @@
+/**
+ * Operator-callable purge for old `credentialAuditLog` entries.
+ *
+ * PR-D shipped the credential audit log; PR-C added PHONE_CHANGED rows.
+ * Council answer Q5=a — 1 year retention. This script enforces that:
+ * any entry whose `timestamp` is older than 365 days is deleted.
+ *
+ * Designed for manual operator runs first; promotion to a Cloud
+ * Scheduler / Cloud Function cron is the next step. Idempotent.
+ *
+ * Usage:
+ *   node scripts/purge-credential-audit-log.js [--project <id>] [--dry-run] [--age-days <n>]
+ *
+ * Flags:
+ *   --project <id>   Override project id (defaults to NEXT_PUBLIC_FIREBASE_PROJECT_ID).
+ *   --dry-run        Log planned deletes without persisting.
+ *   --age-days <n>   Override the retention window (default 365).
+ */
+const admin = require('firebase-admin');
+const { readFileSync } = require('fs');
+const path = require('path');
+
+function loadEnvLocal() {
+  try {
+    const file = readFileSync(path.resolve(process.cwd(), '.env.local'), 'utf8');
+    for (const line of file.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#')) continue;
+      const eq = trimmed.indexOf('=');
+      if (eq < 0) continue;
+      const key = trimmed.slice(0, eq).trim();
+      let value = trimmed.slice(eq + 1).trim();
+      if (
+        (value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))
+      ) {
+        value = value.slice(1, -1);
+      }
+      if (!(key in process.env)) process.env[key] = value;
+    }
+  } catch {
+    // .env.local missing
+  }
+}
+
+function parseServiceAccount(raw) {
+  try { return JSON.parse(raw); } catch { /* try base64 */ }
+  try {
+    const decoded = Buffer.from(raw, 'base64').toString('utf8');
+    return JSON.parse(decoded);
+  } catch (e) {
+    throw new Error(`GOOGLE_SERVICE_ACCOUNT_JSON is neither plain JSON nor base64-encoded JSON: ${e.message}`);
+  }
+}
+
+loadEnvLocal();
+
+const args = process.argv.slice(2);
+const projectIdx = args.indexOf('--project');
+const cliProjectId = projectIdx >= 0 ? args[projectIdx + 1] : undefined;
+const projectId = cliProjectId || process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID;
+const dryRun = args.includes('--dry-run');
+const ageIdx = args.indexOf('--age-days');
+const ageDays = ageIdx >= 0 ? Number(args[ageIdx + 1]) : 365;
+
+if (!projectId) {
+  console.error('Missing project id (pass --project or set NEXT_PUBLIC_FIREBASE_PROJECT_ID in .env.local)');
+  process.exit(1);
+}
+if (!Number.isFinite(ageDays) || ageDays <= 0) {
+  console.error(`Invalid --age-days value (got "${args[ageIdx + 1]}")`);
+  process.exit(1);
+}
+
+const saRaw = process.env.GOOGLE_SERVICE_ACCOUNT_JSON;
+if (!saRaw) {
+  console.error('Missing GOOGLE_SERVICE_ACCOUNT_JSON in .env.local');
+  process.exit(1);
+}
+
+admin.initializeApp({
+  credential: admin.credential.cert(parseServiceAccount(saRaw)),
+  projectId,
+});
+
+const db = admin.firestore();
+
+async function purge() {
+  const cutoffMs = Date.now() - ageDays * 24 * 60 * 60 * 1000;
+  const cutoffTs = admin.firestore.Timestamp.fromMillis(cutoffMs);
+  console.log(`[purge-credential-audit-log] cutoff=${new Date(cutoffMs).toISOString()} dry=${dryRun}`);
+
+  // Stream the query in pages — `credentialAuditLog` may grow large.
+  const PAGE_SIZE = 500;
+  let totalDeleted = 0;
+  let totalFailed = 0;
+  let lastDoc = null;
+
+  // Loop until a page returns zero hits.
+  while (true) {
+    let query = db
+      .collection('credentialAuditLog')
+      .where('timestamp', '<', cutoffTs)
+      .orderBy('timestamp', 'asc')
+      .limit(PAGE_SIZE);
+    if (lastDoc) query = query.startAfter(lastDoc);
+
+    const snap = await query.get();
+    if (snap.empty) break;
+
+    if (dryRun) {
+      for (const d of snap.docs) console.log(`[dry] would delete credentialAuditLog/${d.id}`);
+      totalDeleted += snap.size;
+      // Dry-run still needs to advance the cursor so the loop terminates.
+      lastDoc = snap.docs[snap.docs.length - 1];
+      if (snap.size < PAGE_SIZE) break;
+      continue;
+    }
+
+    const batch = db.batch();
+    for (const d of snap.docs) batch.delete(d.ref);
+    try {
+      await batch.commit();
+      totalDeleted += snap.size;
+    } catch (e) {
+      totalFailed += snap.size;
+      console.error('[fail] batch delete:', e.message);
+    }
+
+    lastDoc = snap.docs[snap.docs.length - 1];
+    if (snap.size < PAGE_SIZE) break;
+  }
+
+  console.log(`[purge-credential-audit-log] done. deleted=${totalDeleted} failed=${totalFailed} (${dryRun ? 'dry-run' : 'apply mode'})`);
+}
+
+purge().then(() => process.exit(0)).catch((e) => {
+  console.error('[purge-credential-audit-log] fatal:', e);
+  process.exit(1);
+});

--- a/scripts/purge-phone-change-pending.js
+++ b/scripts/purge-phone-change-pending.js
@@ -1,0 +1,133 @@
+/**
+ * Operator-callable purge for stale `phoneChangePending` reservations.
+ *
+ * PR-C's two-phase flow writes `phoneChangePending/{uid}` on initiate
+ * and deletes it on confirm. If the user closes the modal between the
+ * two steps and the client's `cancel` POST never reaches the server
+ * (offline / hard refresh), the pending doc sits there indefinitely.
+ *
+ * The initiate route's 60s rate-limit already overwrites the slot on
+ * the same user's next attempt, so stale docs don't block the user.
+ * But operationally they're noise — this script sweeps anything older
+ * than 24 hours.
+ *
+ * Designed for manual operator runs first; promotion to a Cloud
+ * Scheduler / Cloud Function cron is the next step.
+ *
+ * Usage:
+ *   node scripts/purge-phone-change-pending.js [--project <id>] [--dry-run] [--age-hours <n>]
+ *
+ * Flags:
+ *   --project <id>   Override project id (defaults to NEXT_PUBLIC_FIREBASE_PROJECT_ID).
+ *   --dry-run        Log planned deletes without persisting.
+ *   --age-hours <n>  Override the staleness threshold (default 24).
+ */
+const admin = require('firebase-admin');
+const { readFileSync } = require('fs');
+const path = require('path');
+
+function loadEnvLocal() {
+  try {
+    const file = readFileSync(path.resolve(process.cwd(), '.env.local'), 'utf8');
+    for (const line of file.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#')) continue;
+      const eq = trimmed.indexOf('=');
+      if (eq < 0) continue;
+      const key = trimmed.slice(0, eq).trim();
+      let value = trimmed.slice(eq + 1).trim();
+      if (
+        (value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))
+      ) {
+        value = value.slice(1, -1);
+      }
+      if (!(key in process.env)) process.env[key] = value;
+    }
+  } catch {
+    // .env.local missing
+  }
+}
+
+function parseServiceAccount(raw) {
+  try { return JSON.parse(raw); } catch { /* try base64 */ }
+  try {
+    const decoded = Buffer.from(raw, 'base64').toString('utf8');
+    return JSON.parse(decoded);
+  } catch (e) {
+    throw new Error(`GOOGLE_SERVICE_ACCOUNT_JSON is neither plain JSON nor base64-encoded JSON: ${e.message}`);
+  }
+}
+
+loadEnvLocal();
+
+const args = process.argv.slice(2);
+const projectIdx = args.indexOf('--project');
+const cliProjectId = projectIdx >= 0 ? args[projectIdx + 1] : undefined;
+const projectId = cliProjectId || process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID;
+const dryRun = args.includes('--dry-run');
+const ageIdx = args.indexOf('--age-hours');
+const ageHours = ageIdx >= 0 ? Number(args[ageIdx + 1]) : 24;
+
+if (!projectId) {
+  console.error('Missing project id (pass --project or set NEXT_PUBLIC_FIREBASE_PROJECT_ID in .env.local)');
+  process.exit(1);
+}
+if (!Number.isFinite(ageHours) || ageHours <= 0) {
+  console.error(`Invalid --age-hours value (got "${args[ageIdx + 1]}")`);
+  process.exit(1);
+}
+
+const saRaw = process.env.GOOGLE_SERVICE_ACCOUNT_JSON;
+if (!saRaw) {
+  console.error('Missing GOOGLE_SERVICE_ACCOUNT_JSON in .env.local');
+  process.exit(1);
+}
+
+admin.initializeApp({
+  credential: admin.credential.cert(parseServiceAccount(saRaw)),
+  projectId,
+});
+
+const db = admin.firestore();
+
+async function purge() {
+  const cutoffMs = Date.now() - ageHours * 60 * 60 * 1000;
+  const cutoffTs = admin.firestore.Timestamp.fromMillis(cutoffMs);
+  console.log(`[purge-phone-change-pending] cutoff=${new Date(cutoffMs).toISOString()} dry=${dryRun}`);
+
+  const snap = await db
+    .collection('phoneChangePending')
+    .where('createdAt', '<', cutoffTs)
+    .get();
+
+  console.log(`[purge-phone-change-pending] found ${snap.size} stale reservation(s)`);
+
+  let deleted = 0;
+  let failed = 0;
+  const BATCH_SIZE = 400;
+  for (let i = 0; i < snap.docs.length; i += BATCH_SIZE) {
+    const chunk = snap.docs.slice(i, i + BATCH_SIZE);
+    if (dryRun) {
+      for (const d of chunk) console.log(`[dry] would delete phoneChangePending/${d.id}`);
+      deleted += chunk.length;
+      continue;
+    }
+    const batch = db.batch();
+    for (const d of chunk) batch.delete(d.ref);
+    try {
+      await batch.commit();
+      deleted += chunk.length;
+    } catch (e) {
+      failed += chunk.length;
+      console.error('[fail] batch delete:', e.message);
+    }
+  }
+
+  console.log(`[purge-phone-change-pending] done. deleted=${deleted} failed=${failed} (${dryRun ? 'dry-run' : 'apply mode'})`);
+}
+
+purge().then(() => process.exit(0)).catch((e) => {
+  console.error('[purge-phone-change-pending] fatal:', e);
+  process.exit(1);
+});


### PR DESCRIPTION
…ing + audit log

Two PR-C follow-up scripts. Both follow the same `.env.local`-based firebase-admin bootstrap as `scripts/backfill-phone-book.js` and `scripts/reconcile-phone.js`. Manual operator runs first; promotion to Cloud Scheduler / Cloud Function cron is the next step.

- scripts/purge-phone-change-pending.js — deletes any `phoneChangePending/{uid}` doc whose `createdAt` is older than the threshold (default 24h, override with --age-hours). Stale docs don't block the user (the 60s initiate rate-limit overwrites the slot on the next attempt) but they're operational noise. Single batch when the result fits; chunks at 400 otherwise.
- scripts/purge-credential-audit-log.js — deletes any `credentialAuditLog` entry older than the retention window (default 365 days per Council Q5=a, override with --age-days). Streams in 500-doc pages with `startAfter` so the script bounded-memory for a large log.

Both default to apply mode; pass --dry-run to preview deletes. Both read `GOOGLE_SERVICE_ACCOUNT_JSON` + `NEXT_PUBLIC_FIREBASE_PROJECT_ID` from `.env.local`.

Spec follow-up checkboxes updated in docs/spec/phone-change.md.