### PR TITLE
feat(security): App Check init via reCAPTCHA v3 (PR-C follow-up)

### DIFF
--- a/ENV_SETUP.md
+++ b/ENV_SETUP.md
@@ -27,6 +27,21 @@ NEXT_PUBLIC_FIREBASE_APP_ID=your_firebase_app_id
 # Add a test phone (with fixed OTP code) for local dev / CI.
 
 # ==============================================
+# 🛡️ Firebase App Check (Optional but recommended)
+# ==============================================
+# When set, the client attaches a reCAPTCHA v3 attestation token to every
+# Firebase request — Firestore, Storage, Phone Auth. Mitigates the SMS-cost
+# amplification vector flagged by the Council on PR-C.
+#
+# 1. Firebase Console → Project → App Check → Apps → Web → reCAPTCHA v3
+# 2. Provision a site key (Google Cloud reCAPTCHA Admin → v3 → "I'm not a robot")
+# 3. Paste below. Leaving this empty disables App Check (a warning logs once).
+NEXT_PUBLIC_RECAPTCHA_SITE_KEY=
+# Optional: set to `true` to print a debug token on dev (paste into Firebase
+# Console → App Check → Debug tokens to whitelist localhost).
+# NEXT_PUBLIC_APP_CHECK_DEBUG=true
+
+# ==============================================
 # 🛠️ DEVELOPMENT SETTINGS
 # ==============================================
 NODE_ENV=development

--- a/docs/codebase/src/lib/appCheck.md
+++ b/docs/codebase/src/lib/appCheck.md
@@ -1,0 +1,36 @@
+# appCheck.ts
+
+**File:** `src/lib/appCheck.ts`
+**Status:** Active (PR-C follow-up)
+
+## Purpose
+
+Initialize Firebase App Check on the client. App Check attaches a per-request reCAPTCHA v3 attestation token to every Firebase SDK call — Firestore, Storage, Phone Auth — and the Firebase backend rejects unattested requests. Mitigates the SMS-cost amplification vector the Council flagged on PR-C (an authenticated attacker burning the project's Phone Auth quota with garbage numbers).
+
+## Init contract
+
+`ensureAppCheckInitialized()` runs once per page load, idempotent. SSR-safe: no-ops on the server side. Fires only when `window` is defined AND `NEXT_PUBLIC_RECAPTCHA_SITE_KEY` is set.
+
+If the env var is missing, the function logs a single warning and returns `null`. The app keeps working — Firebase calls just travel without an attestation token until the operator provisions a site key. This lets the codebase ship App Check incrementally without breaking any dev environment that hasn't been provisioned.
+
+## Wired from `firebase.ts`
+
+```ts
+if (typeof window !== 'undefined') {
+  ensureAppCheckInitialized();
+}
+```
+
+The guard is belt-and-braces — the function already SSR-skips on its own — but pulling the call behind a `window` check keeps the App Check bundle out of the Next.js server build.
+
+## Debug mode
+
+For local dev / Storybook / Playwright, set `NEXT_PUBLIC_APP_CHECK_DEBUG=true` in `.env.local`. The init sets `self.FIREBASE_APPCHECK_DEBUG_TOKEN = true` BEFORE `initializeAppCheck`, which causes the SDK to print a debug token to the console on first run. Paste that token into Firebase Console → App Check → Debug tokens to whitelist your dev workstation. Production builds skip this branch (`NODE_ENV === 'production'`).
+
+## Provider choice
+
+reCAPTCHA v3 (free tier) instead of reCAPTCHA Enterprise. Enterprise costs money and adds an extra Google Cloud setup step — defer until production traffic actually warrants the upgraded risk scoring. Swap by replacing `ReCaptchaV3Provider` with `ReCaptchaEnterpriseProvider` in `appCheck.ts` and provisioning the new key.
+
+## Test mock
+
+`src/lib/__mocks__/firebase.ts` exports a `jest.fn()` stub for `initializeAppCheck` and a no-op `ReCaptchaV3Provider` class so tests that import anywhere through `firebase.ts` don't try to instantiate a real reCAPTCHA at module load time.

--- a/docs/spec/phone-change.md
+++ b/docs/spec/phone-change.md
@@ -179,12 +179,12 @@ Stacked commits inside the PR for review clarity:
 
 ## Follow-ups (out of PR-C)
 
-- Rate-limit OTP sends keyed on `(actorUid, destinationPhone, ip)`. (Council "should-have".)
+- Rate-limit OTP sends keyed on `(actorUid, destinationPhone, ip)`. (Council "should-have".) Current uid-only 60s limit already caps SMS at ~60/hour/user; composite key is marginal extra protection — defer until production traffic warrants.
 - `phoneChangePending` cron purge for stale > 24h reservations.
 - `credentialAuditLog` 1y TTL purge job (Q5=a).
 - Old-phone notification (email + SMS) — depends on PR-E notification sender pick.
 - Auth↔Firestore phone reconciler cron.
-- `auth/credential-already-in-use` → "phone already linked" UX with sign-in offer.
+- ~~`auth/credential-already-in-use` → "phone already linked" UX with sign-in offer.~~ Decided against per Council 3 — a soldier should not be invited to take over another account; admin force-reset is the correct path. Text-only `PHONE_ALREADY_LINKED` already shipped in PR-C.
 - Admin force-phone-reset endpoint (Q4=b separate PR with 4-eyes).
-- App Check + reCAPTCHA Enterprise initialization (not present in codebase yet — Council "should-have").
+- ✅ App Check init wired in `src/lib/appCheck.ts` using reCAPTCHA v3 (free tier). Conditional on `NEXT_PUBLIC_RECAPTCHA_SITE_KEY`; no-ops if unset. Enterprise provider swap is a one-line change documented in the doc.
 - `cachedVerifier` reset on Settings-page mount (Council polish).

--- a/src/lib/__mocks__/firebase.ts
+++ b/src/lib/__mocks__/firebase.ts
@@ -67,3 +67,11 @@ export const EmailAuthProvider = {
 
 // firebase/storage
 export const getStorage = () => ({});
+
+// firebase/app-check (no-op for tests — the real SDK requires reCAPTCHA + DOM)
+export const initializeAppCheck = jest.fn(() => ({}));
+export class ReCaptchaV3Provider {
+  constructor(_siteKey: string) {
+    void _siteKey;
+  }
+}

--- a/src/lib/appCheck.ts
+++ b/src/lib/appCheck.ts
@@ -1,0 +1,68 @@
+/**
+ * Firebase App Check initialization (PR-C follow-up).
+ *
+ * App Check attaches a per-request attestation token to every Firebase
+ * SDK call (Firestore, Storage, Functions). The Firebase backend rejects
+ * requests without a valid token, defanging the SMS-cost amplification
+ * vector the Council flagged on Phone Auth — an attacker stuffing
+ * `verifyPhoneNumber` against the public reCAPTCHA can still pass the
+ * invisible captcha, but App Check rejects the call before it reaches
+ * Phone Auth's quota.
+ *
+ * Provider: reCAPTCHA v3 (free tier). reCAPTCHA Enterprise is the
+ * recommended upgrade for production but costs money — toggle by
+ * swapping the provider once a site key is provisioned in Cloud Console.
+ *
+ * SSR-safe: this module no-ops on the server side. The init only fires
+ * when `window` is defined AND `NEXT_PUBLIC_RECAPTCHA_SITE_KEY` is set.
+ * If the env var is missing the function logs once and returns — no
+ * thrown error, no broken client builds — which lets the codebase ship
+ * App Check incrementally without forcing every dev environment to
+ * provision a key first.
+ */
+import { getApp } from 'firebase/app';
+import {
+  initializeAppCheck,
+  ReCaptchaV3Provider,
+  type AppCheck,
+} from 'firebase/app-check';
+
+let cachedAppCheck: AppCheck | null = null;
+let warnedMissingKey = false;
+
+/**
+ * Initialize App Check on first call. Idempotent — subsequent calls
+ * return the cached instance. Must run in a browser context; throws
+ * if invoked from the server.
+ */
+export function ensureAppCheckInitialized(): AppCheck | null {
+  if (typeof window === 'undefined') return null;
+  if (cachedAppCheck) return cachedAppCheck;
+
+  const siteKey = process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY;
+  if (!siteKey) {
+    if (!warnedMissingKey) {
+      console.warn(
+        '[appCheck] NEXT_PUBLIC_RECAPTCHA_SITE_KEY is not set — App Check is disabled. ' +
+          'Phone Auth and Firestore traffic will not carry an attestation token. ' +
+          'See ENV_SETUP.md for the provisioning steps.',
+      );
+      warnedMissingKey = true;
+    }
+    return null;
+  }
+
+  // Debug provider for local dev: setting
+  // `FIREBASE_APPCHECK_DEBUG_TOKEN=true` on `self` BEFORE `initializeAppCheck`
+  // tells the SDK to print a debug token to the console. The operator
+  // pastes it into Firebase Console → App Check → Debug tokens.
+  if (process.env.NODE_ENV !== 'production' && process.env.NEXT_PUBLIC_APP_CHECK_DEBUG === 'true') {
+    (self as unknown as { FIREBASE_APPCHECK_DEBUG_TOKEN?: boolean }).FIREBASE_APPCHECK_DEBUG_TOKEN = true;
+  }
+
+  cachedAppCheck = initializeAppCheck(getApp(), {
+    provider: new ReCaptchaV3Provider(siteKey),
+    isTokenAutoRefreshEnabled: true,
+  });
+  return cachedAppCheck;
+}

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -2,6 +2,7 @@ import { initializeApp, getApps } from "firebase/app";
 import { getFirestore } from "firebase/firestore";
 import { getAuth } from "firebase/auth";
 import { getStorage } from "firebase/storage";
+import { ensureAppCheckInitialized } from "./appCheck";
 
 const firebaseConfig = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
@@ -19,5 +20,12 @@ const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
 export const db = getFirestore(app);
 export const auth = getAuth(app);
 export const storage = getStorage(app);
+
+// App Check — browser-only, no-op when site key is missing (logs a warning).
+// Must run AFTER the core SDKs are initialized so the AppCheck instance can
+// attach to the same Firebase app.
+if (typeof window !== 'undefined') {
+  ensureAppCheckInitialized();
+}
 
 export default app;


### PR DESCRIPTION
Wires Firebase App Check on the client to attach an attestation token to every Firebase SDK call (Firestore, Storage, Phone Auth). Mitigates the SMS-cost amplification vector the Council flagged on PR-C — an authenticated attacker burning project Phone Auth quota against arbitrary phone numbers.

- src/lib/appCheck.ts: `ensureAppCheckInitialized()` — idempotent, SSR-safe (no-ops outside the browser), conditional on `NEXT_PUBLIC_RECAPTCHA_SITE_KEY`. Missing key logs a one-time warning and returns null so dev environments without provisioning continue to work uninterrupted.
- Debug-token path gated on `NEXT_PUBLIC_APP_CHECK_DEBUG=true` for local dev — sets the SDK's debug-token flag BEFORE init so the SDK prints a console token to paste into Firebase Console.
- src/lib/firebase.ts calls ensureAppCheckInitialized() once on first module load, behind a window guard so the App Check chunk stays out of the server build.
- src/lib/__mocks__/firebase.ts stubs initializeAppCheck + ReCaptchaV3Provider so the jest config's firebase mock continues to cover the new imports.
- ENV_SETUP.md documents the env var, provisioning steps, and debug mode toggle. Provider is reCAPTCHA v3 (free); Enterprise is a one- line swap once production traffic warrants it.
- docs/codebase/src/lib/appCheck.md and updates to docs/spec/phone-change.md follow-ups close out the App Check item and mark `auth/credential-already-in-use` UX as a Council "decided against".