### PR TITLE
fix(appCheck): quiet dev console when site key missing

### DIFF
--- a/docs/bugs.md
+++ b/docs/bugs.md
@@ -3,16 +3,8 @@
 
 ## Open
 
-19. **App Check init warning floods console on localhost (admin route)**
-    - **Repro:** `npm run dev` → navigate to `/management`. Console emits the warning below on every page load:
-      ```
-      [appCheck] NEXT_PUBLIC_RECAPTCHA_SITE_KEY is not set — App Check is disabled.
-      Phone Auth and Firestore traffic will not carry an attestation token.
-      See ENV_SETUP.md for the provisioning steps.
-      ```
-      Origin: `src/lib/appCheck.ts:45` → called from `src/lib/firebase.ts:28` on first import.
-    - **Why this matters:** Warning is correct in prod, but in local dev the env var is intentionally absent. Right now every dev hits it on every admin reload — noise that hides real warnings. Should be a dev-only `console.info` or gated on `process.env.NODE_ENV !== 'development'`, OR loud only when running on a non-localhost host.
-    - **Fix sketch:** In `ensureAppCheckInitialized`, when site key is missing AND `process.env.NODE_ENV === 'development'`, downgrade to a single `console.info('[appCheck] disabled in dev; set NEXT_PUBLIC_RECAPTCHA_SITE_KEY for parity testing')` and suppress the longer warning. Keep the loud warning for production builds.
+19. ~~**App Check init warning floods console on localhost (admin route)**~~
+    - **FIXED (2026-05-14 on `fix/appcheck-dev-warning-noise`):** `ensureAppCheckInitialized` (`src/lib/appCheck.ts:43`) now branches on `process.env.NODE_ENV`. Dev emits a single-line `console.info('[appCheck] disabled (no NEXT_PUBLIC_RECAPTCHA_SITE_KEY in dev)')`; prod / preview keep the original multi-line `console.warn`. Still gated by `warnedMissingKey` so it logs at most once per page load.
 
 20. **Admin management tabs have no overflow indicator**
     - **Repro:** Open `/management` on a narrow viewport (or any width where the tab strip overflows). Only the first 2-3 tabs are visible. Nothing in the UI signals that more tabs exist beyond what's rendered.

--- a/docs/codebase/src/lib/appCheck.md
+++ b/docs/codebase/src/lib/appCheck.md
@@ -11,7 +11,9 @@ Initialize Firebase App Check on the client. App Check attaches a per-request re
 
 `ensureAppCheckInitialized()` runs once per page load, idempotent. SSR-safe: no-ops on the server side. Fires only when `window` is defined AND `NEXT_PUBLIC_RECAPTCHA_SITE_KEY` is set.
 
-If the env var is missing, the function logs a single warning and returns `null`. The app keeps working — Firebase calls just travel without an attestation token until the operator provisions a site key. This lets the codebase ship App Check incrementally without breaking any dev environment that hasn't been provisioned.
+If the env var is missing, the function logs once and returns `null`. The app keeps working — Firebase calls just travel without an attestation token until the operator provisions a site key. This lets the codebase ship App Check incrementally without breaking any dev environment that hasn't been provisioned.
+
+**Log level depends on environment.** Production / preview builds emit a multi-line `console.warn` so the missing key is loud. `NODE_ENV === 'development'` emits a single-line `console.info` instead, because dev workstations are intentionally unprovisioned (bug #19 — the loud warn drowned out other dev-time signals on every `/management` reload).
 
 ## Wired from `firebase.ts`
 

--- a/src/lib/appCheck.ts
+++ b/src/lib/appCheck.ts
@@ -42,11 +42,15 @@ export function ensureAppCheckInitialized(): AppCheck | null {
   const siteKey = process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY;
   if (!siteKey) {
     if (!warnedMissingKey) {
-      console.warn(
-        '[appCheck] NEXT_PUBLIC_RECAPTCHA_SITE_KEY is not set — App Check is disabled. ' +
-          'Phone Auth and Firestore traffic will not carry an attestation token. ' +
-          'See ENV_SETUP.md for the provisioning steps.',
-      );
+      if (process.env.NODE_ENV === 'development') {
+        console.info('[appCheck] disabled (no NEXT_PUBLIC_RECAPTCHA_SITE_KEY in dev)');
+      } else {
+        console.warn(
+          '[appCheck] NEXT_PUBLIC_RECAPTCHA_SITE_KEY is not set — App Check is disabled. ' +
+            'Phone Auth and Firestore traffic will not carry an attestation token. ' +
+            'See ENV_SETUP.md for the provisioning steps.',
+        );
+      }
       warnedMissingKey = true;
     }
     return null;


### PR DESCRIPTION
bug #19. `ensureAppCheckInitialized` now branches on `NODE_ENV`:
- development → single-line `console.info` (one-shot per page)
- production / preview → original multi-line `console.warn` (one-shot)

Dev workstations are intentionally unprovisioned, so the loud warn-on-every-`/management`-reload drowned out real signals.