### PR TITLE
fix(management): scroll affordance for sidebar tab list (bug #20)

### DIFF
--- a/docs/bugs.md
+++ b/docs/bugs.md
@@ -14,10 +14,10 @@
     - **Why this matters:** Warning is correct in prod, but in local dev the env var is intentionally absent. Right now every dev hits it on every admin reload — noise that hides real warnings. Should be a dev-only `console.info` or gated on `process.env.NODE_ENV !== 'development'`, OR loud only when running on a non-localhost host.
     - **Fix sketch:** In `ensureAppCheckInitialized`, when site key is missing AND `process.env.NODE_ENV === 'development'`, downgrade to a single `console.info('[appCheck] disabled in dev; set NEXT_PUBLIC_RECAPTCHA_SITE_KEY for parity testing')` and suppress the longer warning. Keep the loud warning for production builds.
 
-20. **Admin management tabs have no overflow indicator**
-    - **Repro:** Open `/management` on a narrow viewport (or any width where the tab strip overflows). Only the first 2-3 tabs are visible. Nothing in the UI signals that more tabs exist beyond what's rendered.
-    - **Why this matters:** Users miss whole admin features (System Config, Permissions, Templates, etc.). They scroll horizontally only if they discover it accidentally.
-    - **Fix scope:** Keep the horizontal scroll (don't switch to dropdown — user likes the tab strip). Need a discoverability signal: shadow fade on the trailing edge, or chevron buttons that scroll the strip programmatically, or a small "X more" indicator on the trailing edge. **Council needed** to pick the minimal-noise approach.
+20. ~~**Admin management tabs have no overflow indicator**~~
+    - **FIXED (2026-05-14 on `fix/admin-tabs-overflow-indicator`):** root cause was *vertical* overflow on the management sidebar nav, not horizontal as originally described. `ManagementSidebar` root lacked `flex flex-col`, so `SidebarNavigation`'s `flex-1` was dead and the 14-tab list silently clipped on short viewports.
+    - **Fix:** `ManagementSidebar.tsx` root now `flex flex-col`. `SidebarNavigation.tsx` wraps the `<nav>` in a `relative flex-1 min-h-0` container; `<nav>` is `overflow-y-auto`. Top + bottom `aria-hidden` gradient overlays (`from-white to-transparent` / mirror) fade in only when `scrollTop > 4` or content extends below the viewport. `ResizeObserver` + `scroll` listener keep the overlay state in sync.
+    - **Council outcome:** all 3 agents (shadow-fade / chevron-buttons / "+N more" badge) converged on shadow-fade as the right primary signal — lowest LOC, decorative (`aria-hidden`), RTL-safe (top/bottom is logical-neutral), survives resize without stale state.
 
 21. **Admin UsersTab table not mobile-friendly**
     - **Repro:** `/management` → "Manage Users" tab on a narrow viewport. Table is 6 columns (User+email | Role | Rank | Team | Status | Actions). On mobile the role + email columns sit far to the side; user must horizontally scroll the whole page to read them.

--- a/docs/codebase/src/components/management/sidebar/ManagementSidebar.md
+++ b/docs/codebase/src/components/management/sidebar/ManagementSidebar.md
@@ -1,12 +1,15 @@
 # ManagementSidebar.tsx
 
-**File:** `src/components/management/sidebar/ManagementSidebar.tsx`  
-**Lines:** 49  
+**File:** `src/components/management/sidebar/ManagementSidebar.tsx`
 **Status:** Active
 
 ## Purpose
 
 Container component for the management dashboard sidebar. Composes `SidebarHeader`, `SidebarNavigation`, and `SidebarFooter`. Handles responsive open/close with backdrop overlay on mobile.
+
+## Layout
+
+Root is `flex flex-col` so `SidebarNavigation`'s `flex-1 min-h-0` actually constrains the scroll area (bug #20 — before the fix, `flex-1` was dead and the tab list silently clipped on short viewports).
 
 ## Props
 

--- a/docs/codebase/src/components/management/sidebar/SidebarNavigation.md
+++ b/docs/codebase/src/components/management/sidebar/SidebarNavigation.md
@@ -1,7 +1,6 @@
 # SidebarNavigation.tsx
 
-**File:** `src/components/management/sidebar/SidebarNavigation.tsx`  
-**Lines:** 76  
+**File:** `src/components/management/sidebar/SidebarNavigation.tsx`
 **Status:** Active
 
 ## Purpose
@@ -15,6 +14,17 @@ Renders categorized tab navigation items with sorting and hover effects. Tabs ar
 | `activeTab` | `string` | ✅ | Currently active tab ID |
 | `tabsByCategory` | `Record<string, ManagementTab[]>` | ✅ | Tabs grouped by category |
 | `onTabChange` | `(tabId: string) => void` | ✅ | Tab selection handler |
+
+## Scroll affordance (bug #20)
+
+The tab list can grow to 14 items across 4 categories — on short viewports it overflows the sidebar height. The `<nav>` is `overflow-y-auto min-h-0`, wrapped in a `relative flex-1` container with two `aria-hidden` gradient overlays:
+
+- **Top fade** (`from-white to-transparent`) appears when `scrollTop > 4`.
+- **Bottom fade** (`from-transparent to-white`) appears when content extends below the viewport.
+
+Scroll state is recomputed on `scroll` events and on `ResizeObserver` callbacks against the nav element. Overlays use `transition-opacity` so they fade in/out smoothly. They're decorative — keyboard / wheel / touch scrolling remains the actual mechanism.
+
+Pre-requisite: `ManagementSidebar` root is `flex flex-col` so the nav's `flex-1` constrains height. Without it the nav stretched freely and content was silently clipped.
 
 ## Known Issues
 

--- a/src/components/management/sidebar/ManagementSidebar.tsx
+++ b/src/components/management/sidebar/ManagementSidebar.tsx
@@ -42,8 +42,10 @@ export default function ManagementSidebar({
       // where the inset has no effect and the sidebar flows naturally on
       // the inline-start side of the management grid. `translate-x-full`
       // is physical — pushes the panel visually right (off-screen) when
-      // closed.
-      'fixed inset-y-0 start-0 z-50 w-80 bg-white shadow-2xl transform transition-all duration-500 ease-out',
+      // closed. `flex flex-col` activates `flex-1 min-h-0` on the
+      // navigation so the tab list can scroll independently when the
+      // 14-tab content exceeds viewport height (bug #20).
+      'fixed inset-y-0 start-0 z-50 w-80 bg-white shadow-2xl transform transition-all duration-500 ease-out flex flex-col',
       'lg:relative lg:translate-x-0 lg:w-72 lg:shadow-lg lg:duration-0',
       isOpen ? 'translate-x-0 shadow-2xl' : 'translate-x-full shadow-none'
     )}>

--- a/src/components/management/sidebar/SidebarNavigation.tsx
+++ b/src/components/management/sidebar/SidebarNavigation.tsx
@@ -1,7 +1,15 @@
 /**
  * Sidebar navigation component - renders categorized tabs
+ *
+ * Scroll behavior (bug #20): the tab list can grow to 14 items across
+ * 4 categories. On short viewports it overflows the sidebar height. The
+ * `<nav>` is `overflow-y-auto min-h-0` (parent `ManagementSidebar` is
+ * `flex flex-col`, so `flex-1` actually constrains height now), and
+ * top / bottom fade overlays signal that more content exists above or
+ * below the viewport. Overlays only render when there's actually
+ * content to scroll to.
  */
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { cn } from '@/lib/cn';
 import type { ManagementTab } from '@/types/management';
 
@@ -11,7 +19,6 @@ export interface SidebarNavigationProps {
   onTabChange: (tabId: string) => void;
 }
 
-// Category configurations
 const CATEGORIES = [
   { id: 'user-management', name: 'ניהול משתמשים', order: 1 },
   { id: 'equipment', name: 'ציוד', order: 2 },
@@ -19,57 +26,99 @@ const CATEGORIES = [
   { id: 'communication', name: 'תקשורת', order: 4 },
 ];
 
+const SCROLL_TOLERANCE_PX = 4;
+
 export default function SidebarNavigation({
   activeTab,
   tabsByCategory,
   onTabChange,
 }: SidebarNavigationProps) {
   const sortedCategories = CATEGORIES.sort((a, b) => a.order - b.order);
+  const navRef = useRef<HTMLElement>(null);
+  const [canScrollUp, setCanScrollUp] = useState(false);
+  const [canScrollDown, setCanScrollDown] = useState(false);
+
+  useEffect(() => {
+    const el = navRef.current;
+    if (!el) return;
+
+    const update = () => {
+      const { scrollTop, scrollHeight, clientHeight } = el;
+      setCanScrollUp(scrollTop > SCROLL_TOLERANCE_PX);
+      setCanScrollDown(scrollTop + clientHeight < scrollHeight - SCROLL_TOLERANCE_PX);
+    };
+
+    update();
+    el.addEventListener('scroll', update, { passive: true });
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    return () => {
+      el.removeEventListener('scroll', update);
+      ro.disconnect();
+    };
+  }, [tabsByCategory]);
 
   return (
-    <nav className="flex-1 px-4 py-2 space-y-6">
-      {sortedCategories.map((category) => {
-        const categoryTabs = tabsByCategory[category.id] || [];
-        if (categoryTabs.length === 0) return null;
+    <div className="relative flex-1 min-h-0">
+      <nav ref={navRef} className="h-full overflow-y-auto px-4 py-2 space-y-6">
+        {sortedCategories.map((category) => {
+          const categoryTabs = tabsByCategory[category.id] || [];
+          if (categoryTabs.length === 0) return null;
 
-        return (
-          <div key={category.id}>
-            {/* Category Title */}
-            <h3 className="text-xs font-semibold text-neutral-400 uppercase tracking-wider mb-3">
-              {category.name}
-            </h3>
-            
-            {/* Gradient Divider */}
-            <div className="h-px bg-gradient-to-r from-transparent via-neutral-300 to-transparent mb-4" />
-            
-            {/* Category Tabs */}
-            <div className="space-y-1">
-              {categoryTabs.map((tab) => {
-                const isActive = activeTab === tab.id;
-                const Icon = tab.icon;
-                
-                return (
-                  <button
-                    key={tab.id}
-                    onClick={() => onTabChange(tab.id)}
-                    className={cn(
-                      'w-full flex items-center px-3 py-2.5 text-sm font-medium rounded-lg transition-all duration-200',
-                      'hover:bg-primary-50 hover:text-primary-700',
-                      'focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2',
-                      isActive
-                        ? 'bg-primary-100 text-primary-700 border-e-2 border-primary-600'
-                        : 'text-neutral-700 hover:text-primary-700'
-                    )}
-                  >
-                    <Icon className="w-5 h-5 me-3 flex-shrink-0" />
-                    <span className="flex-1 text-start">{tab.label}</span>
-                  </button>
-                );
-              })}
+          return (
+            <div key={category.id}>
+              {/* Category Title */}
+              <h3 className="text-xs font-semibold text-neutral-400 uppercase tracking-wider mb-3">
+                {category.name}
+              </h3>
+
+              {/* Gradient Divider */}
+              <div className="h-px bg-gradient-to-r from-transparent via-neutral-300 to-transparent mb-4" />
+
+              {/* Category Tabs */}
+              <div className="space-y-1">
+                {categoryTabs.map((tab) => {
+                  const isActive = activeTab === tab.id;
+                  const Icon = tab.icon;
+
+                  return (
+                    <button
+                      key={tab.id}
+                      onClick={() => onTabChange(tab.id)}
+                      className={cn(
+                        'w-full flex items-center px-3 py-2.5 text-sm font-medium rounded-lg transition-all duration-200',
+                        'hover:bg-primary-50 hover:text-primary-700',
+                        'focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2',
+                        isActive
+                          ? 'bg-primary-100 text-primary-700 border-e-2 border-primary-600'
+                          : 'text-neutral-700 hover:text-primary-700'
+                      )}
+                    >
+                      <Icon className="w-5 h-5 me-3 flex-shrink-0" />
+                      <span className="flex-1 text-start">{tab.label}</span>
+                    </button>
+                  );
+                })}
+              </div>
             </div>
-          </div>
-        );
-      })}
-    </nav>
+          );
+        })}
+      </nav>
+
+      <div
+        aria-hidden
+        className={cn(
+          'pointer-events-none absolute inset-x-0 top-0 h-6 bg-gradient-to-b from-white to-transparent transition-opacity duration-150',
+          canScrollUp ? 'opacity-100' : 'opacity-0'
+        )}
+      />
+      <div
+        aria-hidden
+        className={cn(
+          'pointer-events-none absolute inset-x-0 bottom-0 h-6 bg-gradient-to-t from-white to-transparent transition-opacity duration-150',
+          canScrollDown ? 'opacity-100' : 'opacity-0'
+        )}
+      />
+    </div>
   );
 }


### PR DESCRIPTION
The 14-tab sidebar nav silently clipped on short viewports because `ManagementSidebar` root lacked `flex flex-col` — so `SidebarNavigation`'s `flex-1` was dead, the nav grew freely, and content below the fold was unreachable.

Fix:
- `ManagementSidebar` root → `flex flex-col`.
- `SidebarNavigation` → wrap `<nav>` in `relative flex-1 min-h-0`; `<nav>` is `overflow-y-auto`.
- Top + bottom `aria-hidden` gradient overlays (`from-white to-transparent` / mirror) fade in conditionally based on scrollTop / scrollHeight, via a scroll listener + ResizeObserver.

Council (3 agents — fade / chevron-buttons / "+N more" badge) converged on shadow-fade: lowest LOC, RTL-safe (top/bottom is logical-neutral), decorative (aria-hidden), survives resize without stale state.