### PR TITLE
feat(management): mobile-priority expandable UsersTab + pending badge…

### DIFF
--- a/docs/bugs.md
+++ b/docs/bugs.md
@@ -19,10 +19,11 @@
     - **Why this matters:** Users miss whole admin features (System Config, Permissions, Templates, etc.). They scroll horizontally only if they discover it accidentally.
     - **Fix scope:** Keep the horizontal scroll (don't switch to dropdown — user likes the tab strip). Need a discoverability signal: shadow fade on the trailing edge, or chevron buttons that scroll the strip programmatically, or a small "X more" indicator on the trailing edge. **Council needed** to pick the minimal-noise approach.
 
-21. **Admin UsersTab table not mobile-friendly**
-    - **Repro:** `/management` → "Manage Users" tab on a narrow viewport. Table is 6 columns (User+email | Role | Rank | Team | Status | Actions). On mobile the role + email columns sit far to the side; user must horizontally scroll the whole page to read them.
-    - **Fix scope:** Switch to the same mobile-priority pattern as `EquipmentTable` — fixed-height vertically scrolling container, each row is compact (Name + indicator dot + minimal status), clicking the row expands to reveal email, role, rank, team, actions. Phone column should also be added (data missing today; pull from `users.phoneNumber` ∪ `authorized_personnel.phoneNumber` when registered=false).
-    - **Council needed** for the registered-vs-unregistered indicator badge (minimal-noise design).
+21. ~~**Admin UsersTab table not mobile-friendly**~~
+    - **FIXED (2026-05-14 on `feat/users-tab-expandable-mobile-friendly`):** rewrote `UsersTab.tsx` to a list of expandable cards mirroring `EquipmentTable`. Compact card shows status dot + initials + name + pending-registration badge + role; click to expand reveals email / rank / role / team / phone / status / actions. Container is `max-h-[28rem] overflow-y-auto` so the section keeps the page short.
+    - New hook `src/hooks/useUsersAndPersonnel.ts` merges `users` ∪ `authorized_personnel` keyed by `militaryPersonalNumberHash`, so unregistered soldiers appear in the list. Phone falls back from `users.phoneNumber` to `authorized_personnel.phoneNumber`. The legacy `useUsers` hook stays unchanged for `EmailTab` / `CustomUserSelectionModal` / ammunition consumers (they need email-able registered-only rows).
+    - Phone rendered via existing `formatPhoneForDisplay`.
+    - **Council outcome (4 agents — name-side dot / leading icon glyph / row tint / suffix text-badge):** 3/4 converged on **asymmetric** rendering (no signal on registered rows, show signal only on unregistered). Picked variant: text-badge "ממתין" via the existing `VIEW_PENDING_BADGE` constant — reuses bug #4's vocabulary, self-describing (no SR-only fallback needed), matches the "צ" inline-tag precedent in `EquipmentTable`.
 
 22. **Manage Equipment Templates list has no category grouping**
     - **Repro:** `/management` → "Equipment Templates" tab. Templates render as a flat list. Hard to scan; users see hundreds of items mixed across categories.

--- a/docs/codebase/src/components/management/tabs/UsersTab.md
+++ b/docs/codebase/src/components/management/tabs/UsersTab.md
@@ -1,27 +1,51 @@
 # UsersTab.tsx
 
-**File:** `src/components/management/tabs/UsersTab.tsx`  
-**Lines:** 325 ⚠️ LONG  
+**File:** `src/components/management/tabs/UsersTab.tsx`
 **Status:** Active
 
 ## Purpose
 
-User management table with search, role/status filtering, and summary statistics (total users, active, managers, new this month). Displays a responsive table of all users from `useUsers()` hook.
+Admin users management — mobile-priority expandable rows (bug #21).
+
+Replaces the prior 6-column desktop-only table with a scrollable list where each row is a card. Compact card shows status dot + initials + name + pending-registration badge + role line; clicking the card expands a panel revealing email, rank, role, team, phone, status, and edit/delete actions.
+
+## Data source
+
+Uses `useUsersAndPersonnel()` — a merged view of `users` ∪ `authorized_personnel`. Unregistered soldiers (those who have a pre-authorization entry but haven't completed signup) appear in the list with the same shape as registered users; their phone falls back to `authorized_personnel.phoneNumber` when `users.phoneNumber` is missing.
+
+Other consumers that need registered-only / email-able rows (`EmailTab`, `CustomUserSelectionModal`, ammunition page) keep using the existing `useUsers` hook unchanged.
+
+## Registered-vs-unregistered indicator (Council outcome)
+
+A 4-agent Council compared:
+1. name-side dot (color)
+2. leading icon glyph (Hourglass)
+3. faint row tint
+4. suffix text-badge
+
+Three out of four agents converged on **asymmetric** rendering — show nothing on the common registered case, show a signal only on the anomaly. The picked variant is a small `bg-warning-100 text-warning-800` text-badge reading `ממתין` next to the name, reusing the `VIEW_PENDING_BADGE` constant from bug #4's registration badge work (vocabulary consistency). Plain text removes the need for SR-only fallback, and the "צ" tag pattern in `EquipmentTable` is the existing precedent for inline text-badges.
 
 ## State
 
 | State | Type | Purpose |
 |-------|------|---------|
-| `searchTerm` | `string` | Text search across users |
-| `selectedRole` | `string` | Role filter dropdown |
-| `selectedStatus` | `string` | Status filter dropdown |
+| `searchTerm` | `string` | Free-text search over name / email / phone |
+| `selectedRole` | `RoleFilter` | Role filter dropdown |
+| `selectedStatus` | `StatusFilter` | Status filter dropdown |
+| `expandedHash` | `string \| null` | Currently expanded row (one-at-a-time pattern, mirrors `EquipmentTable`) |
 
 ## Firebase Operations
 
-- **Read:** `useUsers()` — reads from `users` collection
+- **Read:** `useUsersAndPersonnel()` → fetches `users` and `authorized_personnel` in parallel.
+
+## Visual contract
+
+- List container is `max-h-[28rem] overflow-y-auto` so the section keeps the page short on long admin views.
+- Status is encoded twice for redundancy: a status dot in the compact row + a colored pill in the expanded panel.
+- Role displays with a tone-coded pill (`danger` for admin, `info` for managers/officers, `neutral` otherwise) — preserves the prior color vocabulary.
+- Stats grid below the list uses 4 cards: total / active / inactive / pending-registration. The pending card uses the same `STATS_PENDING` constant the admin dashboard uses.
 
 ## Known Issues
 
-- Extensive inline Hebrew throughout.
-- Role mapping duplicated (lines 23-31).
-- 325 lines — at the split threshold.
+- `getTeamFromRole` is still a derived placeholder (mapping `UserRole` to a Hebrew team category label). The real `FirestoreUserProfile.teamId` exists but isn't resolved to a team name here yet — same scope deferral as the prior tab.
+- Edit / delete actions are still placeholder buttons (no handlers). Hook into `AdminFirestoreService.updateAuthorizedPersonnel` once the admin write flow is wired into management.

--- a/docs/codebase/src/hooks/useUsersAndPersonnel.md
+++ b/docs/codebase/src/hooks/useUsersAndPersonnel.md
@@ -1,0 +1,60 @@
+# useUsersAndPersonnel.ts
+
+**File:** `src/hooks/useUsersAndPersonnel.ts`
+**Status:** Active
+
+## Purpose
+
+Returns a merged view of the `users` and `authorized_personnel` collections for the admin `UsersTab` (bug #21 — table needed to surface unregistered soldiers and pull phone from either collection).
+
+Each row carries a `registered: boolean` flag so the UI can render a `ממתין` ("pending") badge on rows that exist in `authorized_personnel` but not yet in `users`.
+
+## Why not extend `useUsers`?
+
+`useUsers` already feeds `EmailTab`, `CustomUserSelectionModal`, and the ammunition page — all of which need email-addressable, registered-only rows. Pulling unregistered personnel into that list would silently break those callers (no email to send to / no `uid` to grant permission to). A separate hook keeps the contract clean.
+
+## Join key
+
+`authorized_personnel` doc ID == `militaryPersonalNumberHash`. `FirestoreUserProfile.militaryPersonalNumberHash` references the same value. The hook builds a `Map<hash, FirestoreUserProfile>` from the `users` snapshot, then walks `authorized_personnel` and joins each row.
+
+Edge case: a `users` doc with no matching `authorized_personnel` row (unusual but possible during data migrations) is still emitted as a registered row, with `team` / `roleDisplay` derived from `users.role`.
+
+## Field resolution
+
+Each `UserWithRegistration` field uses `users` first, falling back to `authorized_personnel`:
+
+| Field | Source priority |
+|---|---|
+| `uid` | `users.uid` → `null` if unregistered |
+| `email` | `users.email` → `authorized_personnel.email` → `null` |
+| `phoneNumber` | `users.phoneNumber` → `authorized_personnel.phoneNumber` → `''` |
+| `rank` | `users.rank` → `authorized_personnel.rank` → `'לא מוגדר'` |
+| `role` | `users.role` → `authorized_personnel.approvedRole` → `UserRole.SOLDIER` |
+| `status` | `users.status` → `authorized_personnel.status` → `'active'` |
+| `registered` | `users` doc present AND `authorized_personnel.registered !== false` |
+
+`roleDisplay` and `team` are derived from `role` via the in-file lookup tables. The team mapping is a placeholder (matches the prior `useUsers` behavior) until team resolution is wired through `FirestoreUserProfile.teamId`.
+
+## Sort
+
+Unregistered rows sort *after* registered rows. Within each group, the order is `lastName.localeCompare(b.lastName, 'he')` then `firstName.localeCompare(...)`.
+
+## Returns
+
+```ts
+interface UseUsersAndPersonnelReturn {
+  rows: UserWithRegistration[];
+  loading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+}
+```
+
+`refresh()` re-fetches both collections in parallel. The hook fires once on mount via a `useEffect` calling `refresh`.
+
+## Firebase Operations
+
+- **Read** `users` collection (full snapshot).
+- **Read** `authorized_personnel` collection (full snapshot).
+
+Both reads happen in parallel via `Promise.all`. No writes.

--- a/src/components/management/tabs/UsersTab.tsx
+++ b/src/components/management/tabs/UsersTab.tsx
@@ -1,141 +1,131 @@
 /**
- * Users management tab component - extracted from management page
+ * Users management tab — mobile-priority expandable rows (bug #21).
+ *
+ * Replaces the 6-column desktop-only table with a list of cards that
+ * mirrors `EquipmentTable` on mobile: compact row shows status dot +
+ * name (+ "ממתין" pending-registration badge), and clicking the row
+ * reveals Email / Role / Rank / Team / Phone / Actions in an
+ * expanded panel.
+ *
+ * The data source is `useUsersAndPersonnel`, which merges the `users`
+ * collection with `authorized_personnel` so unregistered soldiers are
+ * surfaced too (phone falls back to `authorized_personnel.phoneNumber`
+ * when `users.phoneNumber` is missing).
  */
-import React, { useState, useMemo } from 'react';
-import { Users, AlertCircle, RefreshCw } from 'lucide-react';
-import { useUsers } from '@/hooks/useUsers';
+import React, { useMemo, useState } from 'react';
+import { Users, AlertCircle, RefreshCw, ChevronDown } from 'lucide-react';
+import { useUsersAndPersonnel, type UserWithRegistration } from '@/hooks/useUsersAndPersonnel';
 import { TEXT_CONSTANTS } from '@/constants/text';
 import { Select } from '@/components/ui';
+import { formatPhoneForDisplay } from '@/utils/validationUtils';
+import { cn } from '@/lib/cn';
+
+type RoleFilter = 'all' | 'admin' | 'manager' | 'user' | 'team_leader' | 'officer' | 'commander' | 'equipment_manager';
+type StatusFilter = 'all' | 'active' | 'inactive' | 'transferred' | 'discharged';
+
+const ROLE_FILTER_MATCHES: Record<Exclude<RoleFilter, 'all'>, string[]> = {
+  admin: ['admin', 'מנהל מערכת', 'מנהל'],
+  manager: ['manager', 'מנהל', 'מפקד', 'קצין'],
+  user: ['soldier', 'user', 'חייל', 'משתמש'],
+  team_leader: ['team_leader', 'מפקד צוות'],
+  officer: ['officer', 'קצין'],
+  commander: ['commander', 'מפקד'],
+  equipment_manager: ['equipment_manager', 'מנהל ציוד'],
+};
+
+const STATUS_BADGE: Record<UserWithRegistration['status'], string> = {
+  active: 'bg-success-100 text-success-800',
+  inactive: 'bg-danger-100 text-danger-800',
+  transferred: 'bg-warning-100 text-warning-800',
+  discharged: 'bg-neutral-100 text-neutral-800',
+};
+
+const STATUS_DOT: Record<UserWithRegistration['status'], string> = {
+  active: 'bg-success-500',
+  inactive: 'bg-danger-500',
+  transferred: 'bg-warning-500',
+  discharged: 'bg-neutral-400',
+};
+
+const ROLE_BADGE_TONE = (role: string): string => {
+  const r = role.toLowerCase();
+  if (r.includes('admin') || role.includes('מנהל מערכת')) return 'bg-danger-100 text-danger-800';
+  if (r.includes('manager') || role.includes('מנהל') || role.includes('קצין') || role.includes('מפקד')) return 'bg-info-100 text-info-800';
+  return 'bg-neutral-100 text-neutral-800';
+};
 
 export default function UsersTab() {
   const [searchTerm, setSearchTerm] = useState('');
-  const [selectedRole, setSelectedRole] = useState('all');
-  const [selectedStatus, setSelectedStatus] = useState('all');
+  const [selectedRole, setSelectedRole] = useState<RoleFilter>('all');
+  const [selectedStatus, setSelectedStatus] = useState<StatusFilter>('all');
+  const [expandedHash, setExpandedHash] = useState<string | null>(null);
 
-  // Fetch users from Firestore
-  const { users, loading, error, fetchUsers } = useUsers();
+  const { rows, loading, error, refresh } = useUsersAndPersonnel();
 
-  // Helper function to check if user role matches selected filter
-  const doesRoleMatch = (userRole: string, selectedFilter: string): boolean => {
-    if (selectedFilter === 'all') return true;
-    
-    // Map filter values to Hebrew role names for comparison
-    const roleMapping: { [key: string]: string[] } = {
-      'admin': ['מנהל מערכת', 'מנהל'],
-      'manager': ['מנהל', 'מפקד', 'קצין'],
-      'user': ['חייל', 'משתמש'],
-      'team_leader': ['מפקד צוות'],
-      'officer': ['קצין'],
-      'commander': ['מפקד'],
-      'equipment_manager': ['מנהל ציוד']
-    };
-    
-    const matchingRoles = roleMapping[selectedFilter] || [];
-    return matchingRoles.some(role => userRole.includes(role));
+  const roleMatches = (row: UserWithRegistration): boolean => {
+    if (selectedRole === 'all') return true;
+    const needles = ROLE_FILTER_MATCHES[selectedRole];
+    const haystack = `${row.role} ${row.roleDisplay}`.toLowerCase();
+    return needles.some((n) => haystack.includes(n.toLowerCase()));
   };
 
-  // Filter users based on search and filters
-  const filteredUsers = useMemo(() => {
-    return users.filter(user => {
-      const matchesSearch = searchTerm === '' || 
-        user.fullName.toLowerCase().includes(searchTerm.toLowerCase()) ||
-        user.email.toLowerCase().includes(searchTerm.toLowerCase());
-      
-      const matchesRole = doesRoleMatch(user.role, selectedRole);
-      
-      const matchesStatus = selectedStatus === 'all' || user.status === selectedStatus;
-      
+  const filtered = useMemo(() => {
+    const term = searchTerm.trim().toLowerCase();
+    return rows.filter((u) => {
+      const matchesSearch =
+        term === '' ||
+        u.fullName.toLowerCase().includes(term) ||
+        (u.email?.toLowerCase().includes(term) ?? false) ||
+        u.phoneNumber.includes(term);
+      const matchesRole = roleMatches(u);
+      const matchesStatus = selectedStatus === 'all' || u.status === selectedStatus;
       return matchesSearch && matchesRole && matchesStatus;
     });
-  }, [users, searchTerm, selectedRole, selectedStatus]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rows, searchTerm, selectedRole, selectedStatus]);
 
-  // Calculate statistics
   const stats = useMemo(() => {
-    const total = users.length;
-    const active = users.filter(u => u.status === 'active').length;
-    const inactive = users.filter(u => u.status === 'inactive').length;
-    const pending = users.filter(u => u.status === 'transferred').length;
-    
+    const total = rows.length;
+    const active = rows.filter((u) => u.status === 'active').length;
+    const inactive = rows.filter((u) => u.status === 'inactive').length;
+    const pending = rows.filter((u) => !u.registered).length;
     return { total, active, inactive, pending };
-  }, [users]);
+  }, [rows]);
 
-  // Role display mapping
-  const getRoleDisplayName = (role: string) => {
-    const roleMap: { [key: string]: string } = {
-      'admin': TEXT_CONSTANTS.MANAGEMENT.USERS.ROLE_ADMIN,
-      'manager': TEXT_CONSTANTS.MANAGEMENT.USERS.ROLE_MANAGER,
-      'user': TEXT_CONSTANTS.MANAGEMENT.USERS.ROLE_USER,
-      'team_leader': TEXT_CONSTANTS.MANAGEMENT.USERS.ROLE_TEAM_LEADER,
-      'squad_leader': TEXT_CONSTANTS.MANAGEMENT.USERS.ROLE_SQUAD_LEADER,
-      'sergeant': TEXT_CONSTANTS.MANAGEMENT.USERS.ROLE_SERGEANT,
-      'officer': TEXT_CONSTANTS.MANAGEMENT.USERS.ROLE_OFFICER,
-      'commander': TEXT_CONSTANTS.MANAGEMENT.USERS.ROLE_COMMANDER,
-      'equipment_manager': TEXT_CONSTANTS.MANAGEMENT.USERS.ROLE_EQUIPMENT_MANAGER
-    };
-    return roleMap[role.toLowerCase()] || role;
-  };
-
-  // Status display mapping
-  const getStatusDisplayName = (status: string) => {
-    const statusMap: { [key: string]: string } = {
-      'active': TEXT_CONSTANTS.MANAGEMENT.USERS.STATUS_ACTIVE,
-      'inactive': TEXT_CONSTANTS.MANAGEMENT.USERS.STATUS_INACTIVE,
-      'transferred': TEXT_CONSTANTS.MANAGEMENT.USERS.STATUS_TRANSFERRED,
-      'discharged': TEXT_CONSTANTS.MANAGEMENT.USERS.STATUS_DISCHARGED
-    };
-    return statusMap[status] || status;
-  };
-
-  // Get user initials for avatar
-  const getUserInitials = (fullName: string) => {
-    const names = fullName.trim().split(' ');
-    if (names.length >= 2) {
-      return names[0][0] + names[names.length - 1][0];
-    }
-    return names[0][0] || '?';
-  };
-
-  // Loading state
   if (loading) {
     return (
-      <div className="space-y-6">
-        <div className="flex items-center justify-center py-12">
-          <RefreshCw className="w-8 h-8 text-primary-600 animate-spin me-3" />
-          <span className="text-lg text-neutral-600">{TEXT_CONSTANTS.MANAGEMENT.USERS.LOADING_USERS}</span>
-        </div>
+      <div className="flex items-center justify-center py-12">
+        <RefreshCw className="w-8 h-8 text-primary-600 animate-spin me-3" />
+        <span className="text-lg text-neutral-600">{TEXT_CONSTANTS.MANAGEMENT.USERS.LOADING_USERS}</span>
       </div>
     );
   }
 
-  // Error state
   if (error) {
     return (
-      <div className="space-y-6">
-        <div className="bg-danger-50 border border-danger-200 rounded-lg p-6">
-          <div className="flex items-center">
-            <AlertCircle className="w-6 h-6 text-danger-600 me-3" />
-            <div>
-              <h3 className="text-lg font-medium text-danger-800">{TEXT_CONSTANTS.MANAGEMENT.USERS.ERROR_LOADING_TITLE}</h3>
-              <p className="text-sm text-danger-600 mt-1">{error}</p>
-            </div>
+      <div className="bg-danger-50 border border-danger-200 rounded-lg p-6">
+        <div className="flex items-center">
+          <AlertCircle className="w-6 h-6 text-danger-600 me-3" />
+          <div>
+            <h3 className="text-lg font-medium text-danger-800">{TEXT_CONSTANTS.MANAGEMENT.USERS.ERROR_LOADING_TITLE}</h3>
+            <p className="text-sm text-danger-600 mt-1">{error}</p>
           </div>
-          <button
-            onClick={() => fetchUsers(true)}
-            className="mt-4 px-4 py-2 bg-danger-600 hover:bg-danger-700 text-white font-medium rounded-lg transition-colors"
-          >
-            {TEXT_CONSTANTS.MANAGEMENT.USERS.TRY_AGAIN_BUTTON}
-          </button>
         </div>
+        <button
+          onClick={() => refresh()}
+          className="mt-4 px-4 py-2 bg-danger-600 hover:bg-danger-700 text-white font-medium rounded-lg transition-colors"
+        >
+          {TEXT_CONSTANTS.MANAGEMENT.USERS.TRY_AGAIN_BUTTON}
+        </button>
       </div>
     );
   }
 
   return (
     <div className="space-y-6">
-      {/* Header Actions */}
       <div className="flex items-center justify-start gap-2 flex-wrap">
         <button
-          onClick={() => fetchUsers(true)}
+          onClick={() => refresh()}
           className="px-4 py-2 bg-neutral-600 hover:bg-neutral-700 text-white font-medium rounded-lg transition-colors shadow-sm flex items-center"
           disabled={loading}
         >
@@ -147,7 +137,6 @@ export default function UsersTab() {
         </button>
       </div>
 
-      {/* Filters */}
       <div className="bg-white rounded-lg border border-neutral-200 p-4">
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           <div>
@@ -164,7 +153,7 @@ export default function UsersTab() {
             <label className="block text-sm font-medium text-neutral-700 mb-2">תפקיד</label>
             <Select
               value={selectedRole === 'all' ? null : selectedRole}
-              onChange={(v) => setSelectedRole(v ?? 'all')}
+              onChange={(v) => setSelectedRole((v as RoleFilter) ?? 'all')}
               options={[
                 { value: 'admin', label: TEXT_CONSTANTS.MANAGEMENT.USERS.ROLE_ADMIN },
                 { value: 'manager', label: TEXT_CONSTANTS.MANAGEMENT.USERS.ROLE_MANAGER },
@@ -183,7 +172,7 @@ export default function UsersTab() {
             <label className="block text-sm font-medium text-neutral-700 mb-2">סטטוס</label>
             <Select
               value={selectedStatus === 'all' ? null : selectedStatus}
-              onChange={(v) => setSelectedStatus(v ?? 'all')}
+              onChange={(v) => setSelectedStatus((v as StatusFilter) ?? 'all')}
               options={[
                 { value: 'active', label: TEXT_CONSTANTS.MANAGEMENT.USERS.STATUS_ACTIVE },
                 { value: 'inactive', label: TEXT_CONSTANTS.MANAGEMENT.USERS.STATUS_INACTIVE },
@@ -196,128 +185,178 @@ export default function UsersTab() {
             />
           </div>
         </div>
-        
-        {/* Results count */}
+
         <div className="mt-4 text-sm text-neutral-600">
-          {TEXT_CONSTANTS.MANAGEMENT.USERS.SHOWING_RESULTS(filteredUsers.length, users.length)}
+          {TEXT_CONSTANTS.MANAGEMENT.USERS.SHOWING_RESULTS(filtered.length, rows.length)}
         </div>
       </div>
 
-      {/* Users Table */}
       <div className="bg-white rounded-lg border border-neutral-200 overflow-hidden">
-        <div className="overflow-x-auto">
-          <table className="min-w-full divide-y divide-neutral-200">
-            <thead className="bg-neutral-50">
-              <tr>
-                <th className="px-6 py-3 text-start text-xs font-medium text-neutral-500 uppercase tracking-wider">{TEXT_CONSTANTS.MANAGEMENT.USERS.USER_COLUMN}</th>
-                <th className="px-6 py-3 text-start text-xs font-medium text-neutral-500 uppercase tracking-wider">{TEXT_CONSTANTS.MANAGEMENT.USERS.ROLE_COLUMN}</th>
-                <th className="px-6 py-3 text-start text-xs font-medium text-neutral-500 uppercase tracking-wider">{TEXT_CONSTANTS.MANAGEMENT.USERS.RANK_COLUMN}</th>
-                <th className="px-6 py-3 text-start text-xs font-medium text-neutral-500 uppercase tracking-wider">{TEXT_CONSTANTS.MANAGEMENT.USERS.TEAM_COLUMN}</th>
-                <th className="px-6 py-3 text-start text-xs font-medium text-neutral-500 uppercase tracking-wider">{TEXT_CONSTANTS.MANAGEMENT.USERS.STATUS_COLUMN}</th>
-                <th className="px-6 py-3 text-start text-xs font-medium text-neutral-500 uppercase tracking-wider">{TEXT_CONSTANTS.MANAGEMENT.USERS.ACTIONS_COLUMN}</th>
-              </tr>
-            </thead>
-            <tbody className="bg-white divide-y divide-neutral-200">
-              {filteredUsers.length === 0 ? (
-                <tr>
-                  <td colSpan={6} className="px-6 py-12 text-center text-neutral-500">
-                    {users.length === 0 ? TEXT_CONSTANTS.MANAGEMENT.USERS.NO_USERS_SYSTEM : TEXT_CONSTANTS.MANAGEMENT.USERS.NO_USERS_FOUND}
-                  </td>
-                </tr>
-              ) : (
-                filteredUsers.map((user) => (
-                  <tr key={user.uid} className="hover:bg-neutral-50">
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      <div className="flex items-center">
-                        <div className="w-8 h-8 bg-primary-100 rounded-full flex items-center justify-center me-3">
-                          <span className="text-sm font-bold text-primary-600">
-                            {getUserInitials(user.fullName)}
-                          </span>
-                        </div>
-                        <div>
-                          <div className="text-sm font-medium text-neutral-900">{user.fullName}</div>
-                          <div className="text-sm text-neutral-500">{user.email}</div>
-                        </div>
-                      </div>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      <span className={`px-2 py-1 text-xs font-medium rounded-full ${
-                        user.role.includes('admin') || user.role.includes('מנהל מערכת') ? 'bg-danger-100 text-danger-800' :
-                        user.role.includes('manager') || user.role.includes('מנהל') || user.role.includes('קצין') || user.role.includes('מפקד') ? 'bg-info-100 text-info-800' :
-                        'bg-neutral-100 text-neutral-800'
-                      }`}>
-                        {getRoleDisplayName(user.role)}
-                      </span>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-neutral-900">{user.rank}</td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-neutral-900">{user.team}</td>
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      <span className={`px-2 py-1 text-xs font-medium rounded-full ${
-                        user.status === 'active' ? 'bg-success-100 text-success-800' :
-                        user.status === 'inactive' ? 'bg-danger-100 text-danger-800' :
-                        user.status === 'transferred' ? 'bg-warning-100 text-warning-800' :
-                        'bg-neutral-100 text-neutral-800'
-                      }`}>
-                        {getStatusDisplayName(user.status)}
-                      </span>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm space-x-2">
-                      <button className="text-info-600 hover:text-info-900 me-2">{TEXT_CONSTANTS.MANAGEMENT.USERS.EDIT_ACTION}</button>
-                      <button className="text-danger-600 hover:text-danger-900">{TEXT_CONSTANTS.MANAGEMENT.USERS.DELETE_ACTION}</button>
-                    </td>
-                  </tr>
-                ))
-              )}
-            </tbody>
-          </table>
-        </div>
+        {filtered.length === 0 ? (
+          <div className="px-6 py-12 text-center text-neutral-500">
+            {rows.length === 0
+              ? TEXT_CONSTANTS.MANAGEMENT.USERS.NO_USERS_SYSTEM
+              : TEXT_CONSTANTS.MANAGEMENT.USERS.NO_USERS_FOUND}
+          </div>
+        ) : (
+          <ul className="max-h-[28rem] overflow-y-auto divide-y divide-neutral-100">
+            {filtered.map((row) => (
+              <UserRow
+                key={row.hash}
+                row={row}
+                expanded={expandedHash === row.hash}
+                onToggle={() =>
+                  setExpandedHash((cur) => (cur === row.hash ? null : row.hash))
+                }
+              />
+            ))}
+          </ul>
+        )}
       </div>
 
-      {/* Statistics */}
-      <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-        <div className="bg-white rounded-lg border border-neutral-200 p-4">
-          <div className="flex items-center">
-            <Users className="w-8 h-8 text-info-600" />
-            <div className="ms-4">
-              <div className="text-2xl font-bold text-neutral-900">{stats.total}</div>
-              <div className="text-sm text-neutral-600">{TEXT_CONSTANTS.MANAGEMENT.USERS.TOTAL_USERS}</div>
-            </div>
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <StatCard tone="info" icon={<Users className="w-8 h-8 text-info-600" />} value={stats.total} label={TEXT_CONSTANTS.MANAGEMENT.USERS.TOTAL_USERS} />
+        <StatCard tone="success" value={stats.active} label={TEXT_CONSTANTS.MANAGEMENT.USERS.ACTIVE_USERS} glyph="✓" />
+        <StatCard tone="danger" value={stats.inactive} label={TEXT_CONSTANTS.MANAGEMENT.USERS.INACTIVE_USERS} glyph="×" />
+        <StatCard tone="warning" value={stats.pending} label={TEXT_CONSTANTS.ADMIN.STATS_PENDING} glyph="⏳" />
+      </div>
+    </div>
+  );
+}
+
+interface UserRowProps {
+  row: UserWithRegistration;
+  expanded: boolean;
+  onToggle: () => void;
+}
+
+function UserRow({ row, expanded, onToggle }: UserRowProps) {
+  const initials = getInitials(row.fullName);
+  return (
+    <li>
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={onToggle}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onToggle();
+          }
+        }}
+        className={cn(
+          'px-3 py-3 flex items-center gap-3 cursor-pointer transition-colors',
+          expanded ? 'bg-primary-50' : 'hover:bg-neutral-50'
+        )}
+      >
+        <span
+          className={cn('w-2.5 h-2.5 rounded-full flex-shrink-0', STATUS_DOT[row.status])}
+          title={statusLabel(row.status)}
+          aria-label={statusLabel(row.status)}
+        />
+        <div className="w-8 h-8 bg-primary-100 rounded-full flex items-center justify-center flex-shrink-0">
+          <span className="text-xs font-bold text-primary-600">{initials}</span>
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-1.5">
+            <span className="text-sm font-medium text-neutral-900 truncate">{row.fullName}</span>
+            {!row.registered && (
+              <span className="text-[10px] px-1.5 py-0.5 rounded bg-warning-100 text-warning-800 flex-shrink-0">
+                {TEXT_CONSTANTS.ADMIN.VIEW_PENDING_BADGE}
+              </span>
+            )}
+          </div>
+          <div className="text-xs text-neutral-500 truncate">{row.roleDisplay}</div>
+        </div>
+        <ChevronDown
+          className={cn(
+            'w-4 h-4 text-neutral-400 flex-shrink-0 transition-transform',
+            expanded ? 'rotate-180' : ''
+          )}
+          aria-hidden
+        />
+      </div>
+      {expanded && (
+        <div className="px-4 pb-4 pt-2 border-t border-neutral-100 grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm bg-neutral-50/40">
+          <DetailField label={TEXT_CONSTANTS.MANAGEMENT.USERS.USER_COLUMN} value={row.email ?? '—'} />
+          <DetailField label={TEXT_CONSTANTS.MANAGEMENT.USERS.RANK_COLUMN} value={row.rank} />
+          <DetailField label={TEXT_CONSTANTS.MANAGEMENT.USERS.ROLE_COLUMN}>
+            <span className={cn('px-2 py-1 text-xs font-medium rounded-full', ROLE_BADGE_TONE(row.roleDisplay))}>
+              {row.roleDisplay}
+            </span>
+          </DetailField>
+          <DetailField label={TEXT_CONSTANTS.MANAGEMENT.USERS.TEAM_COLUMN} value={row.team} />
+          <DetailField label="טלפון" value={row.phoneNumber ? formatPhoneForDisplay(row.phoneNumber) : '—'} />
+          <DetailField label={TEXT_CONSTANTS.MANAGEMENT.USERS.STATUS_COLUMN}>
+            <span className={cn('px-2 py-1 text-xs font-medium rounded-full', STATUS_BADGE[row.status])}>
+              {statusLabel(row.status)}
+            </span>
+          </DetailField>
+          <div className="sm:col-span-2 flex items-center gap-2 pt-2 border-t border-neutral-100">
+            <button className="text-info-600 hover:text-info-900 text-sm">
+              {TEXT_CONSTANTS.MANAGEMENT.USERS.EDIT_ACTION}
+            </button>
+            <button className="text-danger-600 hover:text-danger-900 text-sm">
+              {TEXT_CONSTANTS.MANAGEMENT.USERS.DELETE_ACTION}
+            </button>
           </div>
         </div>
-        <div className="bg-white rounded-lg border border-neutral-200 p-4">
-          <div className="flex items-center">
-            <div className="w-8 h-8 bg-success-100 rounded-full flex items-center justify-center">
-              <span className="text-success-600 font-bold">✓</span>
-            </div>
-            <div className="ms-4">
-              <div className="text-2xl font-bold text-success-600">{stats.active}</div>
-              <div className="text-sm text-neutral-600">{TEXT_CONSTANTS.MANAGEMENT.USERS.ACTIVE_USERS}</div>
-            </div>
+      )}
+    </li>
+  );
+}
+
+function DetailField({ label, value, children }: { label: string; value?: string; children?: React.ReactNode }) {
+  return (
+    <div>
+      <div className="text-[10px] uppercase tracking-wider text-neutral-500">{label}</div>
+      {children ?? <div className="text-neutral-900">{value ?? '—'}</div>}
+    </div>
+  );
+}
+
+function StatCard({ tone, value, label, icon, glyph }: { tone: 'info' | 'success' | 'danger' | 'warning'; value: number; label: string; icon?: React.ReactNode; glyph?: string }) {
+  const toneText: Record<typeof tone, string> = {
+    info: 'text-info-600',
+    success: 'text-success-600',
+    danger: 'text-danger-600',
+    warning: 'text-warning-600',
+  };
+  const toneBg: Record<typeof tone, string> = {
+    info: 'bg-info-100',
+    success: 'bg-success-100',
+    danger: 'bg-danger-100',
+    warning: 'bg-warning-100',
+  };
+  return (
+    <div className="bg-white rounded-lg border border-neutral-200 p-4">
+      <div className="flex items-center">
+        {icon ?? (
+          <div className={cn('w-8 h-8 rounded-full flex items-center justify-center', toneBg[tone])}>
+            <span className={cn('font-bold', toneText[tone])}>{glyph}</span>
           </div>
-        </div>
-        <div className="bg-white rounded-lg border border-neutral-200 p-4">
-          <div className="flex items-center">
-            <div className="w-8 h-8 bg-danger-100 rounded-full flex items-center justify-center">
-              <span className="text-danger-600 font-bold">×</span>
-            </div>
-            <div className="ms-4">
-              <div className="text-2xl font-bold text-danger-600">{stats.inactive}</div>
-              <div className="text-sm text-neutral-600">{TEXT_CONSTANTS.MANAGEMENT.USERS.INACTIVE_USERS}</div>
-            </div>
-          </div>
-        </div>
-        <div className="bg-white rounded-lg border border-neutral-200 p-4">
-          <div className="flex items-center">
-            <div className="w-8 h-8 bg-warning-100 rounded-full flex items-center justify-center">
-              <span className="text-warning-600 font-bold">⏳</span>
-            </div>
-            <div className="ms-4">
-              <div className="text-2xl font-bold text-warning-600">{stats.pending}</div>
-              <div className="text-sm text-neutral-600">{TEXT_CONSTANTS.MANAGEMENT.USERS.TRANSFERRED_USERS}</div>
-            </div>
-          </div>
+        )}
+        <div className="ms-4">
+          <div className={cn('text-2xl font-bold', toneText[tone])}>{value}</div>
+          <div className="text-sm text-neutral-600">{label}</div>
         </div>
       </div>
     </div>
   );
+}
+
+function statusLabel(s: UserWithRegistration['status']): string {
+  const m = TEXT_CONSTANTS.MANAGEMENT.USERS;
+  switch (s) {
+    case 'active': return m.STATUS_ACTIVE;
+    case 'inactive': return m.STATUS_INACTIVE;
+    case 'transferred': return m.STATUS_TRANSFERRED;
+    case 'discharged': return m.STATUS_DISCHARGED;
+  }
+}
+
+function getInitials(fullName: string): string {
+  const names = fullName.trim().split(/\s+/);
+  if (names.length >= 2) return (names[0][0] || '') + (names[names.length - 1][0] || '');
+  return names[0]?.[0] ?? '?';
 }

--- a/src/hooks/useUsersAndPersonnel.ts
+++ b/src/hooks/useUsersAndPersonnel.ts
@@ -1,0 +1,182 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { db } from '@/lib/firebase';
+import { collection, getDocs, query } from 'firebase/firestore';
+import { FirestoreUserProfile } from '@/types/user';
+import { AuthorizedPersonnel } from '@/types/admin';
+import { UserRole } from '@/types/equipment';
+import { ADMIN_CONFIG } from '@/constants/admin';
+
+/**
+ * Merged view of `users` ∪ `authorized_personnel` for the admin UsersTab.
+ *
+ * The two collections share `militaryPersonalNumberHash`:
+ *  - `authorized_personnel` doc ID is the hash.
+ *  - `users.militaryPersonalNumberHash` is the same value.
+ *
+ * Registered rows draw their canonical fields from `users` and fall back
+ * to `authorized_personnel` only when a users-side value is missing
+ * (e.g. phone is sometimes only on the personnel doc).
+ *
+ * Unregistered rows come solely from `authorized_personnel` — `uid` and
+ * `email` may be `null`.
+ *
+ * Other callers that need email-able / registered-only rows (EmailTab,
+ * CustomUserSelectionModal, ammunition page) keep using `useUsers`; this
+ * hook is intentionally separate so they don't accidentally email
+ * unregistered personnel.
+ */
+export interface UserWithRegistration {
+  hash: string;
+  uid: string | null;
+  fullName: string;
+  firstName: string;
+  lastName: string;
+  email: string | null;
+  phoneNumber: string;
+  rank: string;
+  role: UserRole;
+  roleDisplay: string;
+  team: string;
+  status: 'active' | 'inactive' | 'transferred' | 'discharged';
+  registered: boolean;
+}
+
+export interface UseUsersAndPersonnelReturn {
+  rows: UserWithRegistration[];
+  loading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+}
+
+const ROLE_DISPLAY: Record<UserRole, string> = {
+  [UserRole.SOLDIER]: 'חייל',
+  [UserRole.TEAM_LEADER]: 'מפקד צוות',
+  [UserRole.SQUAD_LEADER]: 'מפקד כיתה',
+  [UserRole.SERGEANT]: 'סמל',
+  [UserRole.OFFICER]: 'קצין',
+  [UserRole.COMMANDER]: 'מפקד',
+  [UserRole.EQUIPMENT_MANAGER]: 'מנהל ציוד',
+};
+
+const TEAM_FROM_ROLE: Record<UserRole, string> = {
+  [UserRole.SOLDIER]: 'כללי',
+  [UserRole.TEAM_LEADER]: 'מפקדי צוות',
+  [UserRole.SQUAD_LEADER]: 'מפקדים',
+  [UserRole.SERGEANT]: 'מפקדים',
+  [UserRole.OFFICER]: 'מטה',
+  [UserRole.COMMANDER]: 'מטה',
+  [UserRole.EQUIPMENT_MANAGER]: 'לוגיסטיקה',
+};
+
+function roleDisplay(role: UserRole | undefined): string {
+  if (!role) return ROLE_DISPLAY[UserRole.SOLDIER];
+  return ROLE_DISPLAY[role] ?? String(role);
+}
+
+function teamFromRole(role: UserRole | undefined): string {
+  if (!role) return TEAM_FROM_ROLE[UserRole.SOLDIER];
+  return TEAM_FROM_ROLE[role] ?? 'כללי';
+}
+
+export function useUsersAndPersonnel(): UseUsersAndPersonnelReturn {
+  const [rows, setRows] = useState<UserWithRegistration[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const usersCol = collection(db, ADMIN_CONFIG.FIRESTORE_USERS_COLLECTION);
+      const personnelCol = collection(db, ADMIN_CONFIG.FIRESTORE_PERSONNEL_COLLECTION);
+
+      const [usersSnap, personnelSnap] = await Promise.all([
+        getDocs(query(usersCol)),
+        getDocs(query(personnelCol)),
+      ]);
+
+      const usersByHash = new Map<string, FirestoreUserProfile>();
+      usersSnap.docs.forEach((d) => {
+        const data = d.data() as FirestoreUserProfile;
+        if (data.militaryPersonalNumberHash) {
+          usersByHash.set(data.militaryPersonalNumberHash, data);
+        }
+      });
+
+      const seenHashes = new Set<string>();
+      const merged: UserWithRegistration[] = [];
+
+      personnelSnap.docs.forEach((d) => {
+        const personnel = { id: d.id, ...(d.data() as AuthorizedPersonnel) };
+        const hash = personnel.militaryPersonalNumberHash || d.id;
+        const userDoc = usersByHash.get(hash);
+        seenHashes.add(hash);
+
+        const registered = !!userDoc && personnel.registered !== false;
+        const role: UserRole = (userDoc?.role as UserRole | undefined)
+          ?? personnel.approvedRole
+          ?? UserRole.SOLDIER;
+
+        merged.push({
+          hash,
+          uid: userDoc?.uid ?? null,
+          fullName: `${userDoc?.firstName ?? personnel.firstName} ${userDoc?.lastName ?? personnel.lastName}`.trim(),
+          firstName: userDoc?.firstName ?? personnel.firstName ?? '',
+          lastName: userDoc?.lastName ?? personnel.lastName ?? '',
+          email: userDoc?.email ?? personnel.email ?? null,
+          phoneNumber: userDoc?.phoneNumber || personnel.phoneNumber || '',
+          rank: userDoc?.rank || personnel.rank || 'לא מוגדר',
+          role,
+          roleDisplay: roleDisplay(role),
+          team: teamFromRole(role),
+          status: userDoc?.status ?? personnel.status ?? 'active',
+          registered,
+        });
+      });
+
+      usersSnap.docs.forEach((d) => {
+        const data = d.data() as FirestoreUserProfile;
+        const hash = data.militaryPersonalNumberHash;
+        if (!hash || seenHashes.has(hash)) return;
+        const role: UserRole = (data.role as UserRole) ?? UserRole.SOLDIER;
+        merged.push({
+          hash,
+          uid: data.uid,
+          fullName: `${data.firstName} ${data.lastName}`.trim(),
+          firstName: data.firstName,
+          lastName: data.lastName,
+          email: data.email,
+          phoneNumber: data.phoneNumber || '',
+          rank: data.rank || 'לא מוגדר',
+          role,
+          roleDisplay: roleDisplay(role),
+          team: teamFromRole(role),
+          status: data.status ?? 'active',
+          registered: true,
+        });
+      });
+
+      merged.sort((a, b) => {
+        if (a.registered !== b.registered) return a.registered ? -1 : 1;
+        const last = a.lastName.localeCompare(b.lastName, 'he');
+        if (last !== 0) return last;
+        return a.firstName.localeCompare(b.firstName, 'he');
+      });
+
+      setRows(merged);
+    } catch (err) {
+      console.error('[useUsersAndPersonnel] fetch failed', err);
+      setError('שגיאה בטעינת רשימת המשתמשים');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  return { rows, loading, error, refresh };
+}


### PR DESCRIPTION
… (bug #21)

`UsersTab` was a 6-column desktop table forcing horizontal scroll on mobile. Rewritten as a vertically-scrolling list of expandable cards mirroring `EquipmentTable`:
- Compact row: status dot + initials + name + pending badge + role line.
- Click row to reveal email / rank / role / team / phone / status / actions.
- `max-h-[28rem] overflow-y-auto` keeps section short.

New hook `useUsersAndPersonnel` merges `users` ∪ `authorized_personnel` keyed by `militaryPersonalNumberHash`, so unregistered soldiers appear in the list. Phone falls back from `users.phoneNumber` to `authorized_personnel.phoneNumber`. Legacy `useUsers` stays unchanged (EmailTab / CustomUserSelectionModal / ammunition consumers need email-able registered-only rows).

Council outcome (4 agents — name-side dot / leading icon glyph / row tint / suffix text-badge): 3/4 converged on asymmetric rendering (no signal on registered, signal only on unregistered). Picked: text-badge "ממתין" via existing `VIEW_PENDING_BADGE` constant, reusing bug #4 vocabulary.