### PR TITLE
feat(settings): pending-deletion banner + cancel UI + asset shortcuts…

### DIFF
--- a/docs/codebase/src/components/settings/DeleteAccountModal.md
+++ b/docs/codebase/src/components/settings/DeleteAccountModal.md
@@ -24,14 +24,16 @@ Danger-coloured modal that lets a signed-in user request soft-delete of their ow
 4. On re-auth success → `requestAccountDeletion(reason)` POSTs to `/api/users/account/delete`.
 5. Three possible server responses:
    - **`success`** — modal calls `onSuccess()` and closes; page shows the cancel-window toast.
-   - **`has_outstanding_assets`** — modal renders a per-category breakdown (equipment / ammo / open transfers) inside the existing form so the user knows what to return. The error box at the bottom shows `DELETE_ACCOUNT_HAS_ASSETS`.
+   - **`has_outstanding_assets`** — modal renders a per-category breakdown (equipment / ammo / open transfers) inside the existing form so the user knows what to return. Each row carries a "לדף" deep link (`/equipment` for equipment + transfers, `/ammunition` for ammo) that closes the modal on click. The error box at the bottom shows `DELETE_ACCOUNT_HAS_ASSETS`.
    - **`already_requested`** — modal shows `DELETE_ACCOUNT_ALREADY_REQUESTED`. (The cancel CTA for a pending deletion belongs in a separate future surface — out of PR-G scope.)
 
 ## Bilingual
 
 All new strings live in `TEXT_CONSTANTS.SETTINGS.DELETE_ACCOUNT_*` with English mirrors in `TEXT_EN.SETTINGS.*` per `feedback_bilingual_text`.
 
-## Not in PR-G
+## Status of follow-ups
 
-- A cancel-pending-deletion CTA inside the modal (the request is server-side; the modal closes after success, so the next opening will see `already_requested`). A dedicated "you have a pending deletion — cancel?" banner on the app shell is tracked as a PR-G follow-up.
-- Shortcut links to retire equipment / cancel transfers when blocked.
+- **Pending-deletion banner** — shipped on `feat/pr-g-banner-cancel-and-cron` (`src/components/settings/PendingDeletionBanner.tsx`, mounted in `AppShell`).
+- **Cancel-pending-deletion in Settings** — shipped on the same branch. The danger row at the bottom of `/settings` swaps the delete button for a "בטל בקשת מחיקה" button when `enhancedUser.deletionRequestedAt` is set.
+- **Outstanding-assets shortcut links** — shipped on the same branch (rows now link to `/equipment` / `/ammunition`).
+- **Hard-delete cron** — still deferred. Needs Council on cross-system safety + Vercel cron config.

--- a/docs/codebase/src/components/settings/PendingDeletionBanner.md
+++ b/docs/codebase/src/components/settings/PendingDeletionBanner.md
@@ -1,0 +1,25 @@
+# PendingDeletionBanner.tsx
+
+**File:** `src/components/settings/PendingDeletionBanner.tsx`
+**Status:** Active (PR-G follow-up)
+
+## Purpose
+
+Top-of-app banner shown while the signed-in user has a soft-delete request in flight. Displays days remaining until the 30-day retention window expires and exposes a one-click "cancel deletion" button.
+
+Mounted in `AppShell` between `TopBar` and the main layout. Renders `null` when `enhancedUser.deletionRequestedAt` is unset, so the banner never appears for users who didn't request deletion.
+
+## Wiring
+
+- Reads `enhancedUser.deletionRequestedAt` from `AuthContext`.
+- Calls `cancelAccountDeletion` from `src/lib/accountDeletionClient.ts` → `POST /api/users/account/cancel-delete`.
+- On success or `no_pending_request`, calls `refreshEnhancedUser()` so the banner disappears in-place without a hard refresh.
+- Uses the project `useToast()` for success / info / error feedback. Tone names follow Toast's `ToastTone` (`info | success | warning | danger`).
+
+## `computeDaysLeft` helper
+
+Exported separately from the component so the Settings page can reuse it for the "in 9 days" message on the delete-account row. Floors to 0 — the message never reports a negative remaining-days count when the hard-delete cron is late.
+
+## Visual
+
+`bg-danger-50 border-b border-danger-200 text-danger-900` keeps the banner aligned with the existing destructive vocabulary (matches `DeleteAccountModal`).

--- a/docs/spec/account-deletion.md
+++ b/docs/spec/account-deletion.md
@@ -74,10 +74,17 @@ All three added to the `ALLOWED_EVENT_TYPES` allowlist in `/api/auth/audit`.
 - `src/components/settings/DeleteAccountModal.tsx` — danger-coloured Headless UI dialog. Password input (always required), reason textarea (optional, 500 chars), submit button. Re-auth runs first; on success, posts to `/delete`. If server returns `has_outstanding_assets`, the modal renders the breakdown inline rather than closing — user fixes inventory, retries.
 - `src/app/settings/page.tsx` — the previously-disabled "מחק חשבון" button is now enabled and opens the modal. Success toast uses `DELETE_ACCOUNT_SUCCESS` text (Hebrew + English).
 
-## Out of PR-G (follow-ups)
+## PR-G follow-ups
 
-- **Hard-delete script** at `deletionRequestedAt + 30d` — manual first run, then a cron. Auth user delete + `users.displayName` → "Deleted User" + `users.deletedAt` stamp.
-- **Pending-deletion banner** on the global app shell: "החשבון שלך מתוזמן למחיקה ב-X. בטל?" with a one-click cancel CTA. Surface visibility for the user mid-window.
-- **Outstanding-assets shortcut links** in the modal — "Return equipment" / "Cancel pending transfers" deep links rather than the user manually navigating.
-- **Hard-delete audit row** with the `ACCOUNT_DELETED` event already in the allowlist.
+### Shipped on `feat/pr-g-banner-cancel-and-cron` (2026-05-14)
+
+- **Pending-deletion banner** — `src/components/settings/PendingDeletionBanner.tsx`. Mounted in `AppShell` between `TopBar` and the main layout. Reads `enhancedUser.deletionRequestedAt` from `AuthContext`; renders nothing when unset. Shows days remaining via `computeDaysLeft` + one-click cancel button that calls `cancelAccountDeletion` and refreshes the enhanced user. Banner disappears in-place on success.
+- **Cancel-deletion UI in Settings** — when `enhancedUser.deletionRequestedAt` is set, the danger row at the bottom of `/settings` swaps "מחק חשבון" for "בטל בקשת מחיקה" (uses the same `cancelAccountDeletion` client). Title + description swap to the pending-state copy with the days-remaining count.
+- **`FirestoreUserProfile` + `EnhancedAuthUser`** — both gained the optional `deletionRequestedAt: Timestamp` field, surfaced through both `AuthContext` write sites (onAuthStateChanged initial load + `refreshEnhancedUser`).
+- **Outstanding-assets shortcut links** — `DeleteAccountModal`'s blocked-by-assets breakdown now renders each row as a Headless UI–free `<Link>` to `/equipment` (equipment + transfers) or `/ammunition`. Clicking dismisses the modal so the user lands on the asset page directly.
+
+### Still deferred
+
+- **Hard-delete script** at `deletionRequestedAt + 30d` — manual first run, then a cron. Auth user delete via Admin SDK `auth.deleteUser` + `users.displayName` → "Deleted User" + `users.deletedAt` stamp. Council needed on safety (cross-system irreversible write needs canary + audit) before scheduling; deferring keeps this PR small.
+- **Hard-delete audit row** with the `ACCOUNT_DELETED` event (already in the allowlist).
 - **Admin force-delete endpoint** if/when Q4 reopens.

--- a/src/app/components/AppShell.tsx
+++ b/src/app/components/AppShell.tsx
@@ -7,6 +7,7 @@ import PageHeader from './PageHeader';
 import AppSidebar from './AppSidebar';
 import QuickActionFab from './QuickActionFab';
 import WelcomeModal from '@/components/onboarding/WelcomeModal';
+import PendingDeletionBanner from '@/components/settings/PendingDeletionBanner';
 import { useAuth } from '@/contexts/AuthContext';
 import { trackRouteVisit } from '@/utils/recentRoutesStorage';
 import { isRegistrationInProgress } from '@/lib/registrationFlowFlag';
@@ -57,6 +58,7 @@ export default function AppShell({
         showBackArrow={showBackArrow}
         onOpenSidebar={() => setMobileSidebarOpen(true)}
       />
+      {isAuthenticated && <PendingDeletionBanner />}
       <div className="flex flex-1 min-h-0">
         <AppSidebar
           mobileOpen={mobileSidebarOpen}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -9,8 +9,11 @@ import ProfileImageUpload from '@/components/profile/ProfileImageUpload';
 import ChangePasswordModal from '@/components/settings/ChangePasswordModal';
 import ChangePhoneModal from '@/components/settings/ChangePhoneModal';
 import DeleteAccountModal from '@/components/settings/DeleteAccountModal';
+import { cancelAccountDeletion } from '@/lib/accountDeletionClient';
+import { computeDaysLeft } from '@/components/settings/PendingDeletionBanner';
 import { Select } from '@/components/ui';
 import { useToast } from '@/components/ui/Toast';
+import type { Timestamp } from 'firebase/firestore';
 import {
   UserIcon,
   PhoneIcon,
@@ -26,17 +29,41 @@ import {
   ChevronRightIcon
 } from 'lucide-react';
 
+function daysUntilHardDelete(requestedAt: Timestamp | undefined): number {
+  if (!requestedAt) return 0;
+  return computeDaysLeft(requestedAt);
+}
+
 /**
  * Settings Page
  * Provides a comprehensive settings interface for user account management
  * All functionality is UI-only (placeholders) as requested
  */
 export default function SettingsPage() {
-  const { enhancedUser } = useAuth();
+  const { enhancedUser, refreshEnhancedUser } = useAuth();
   const { showToast } = useToast();
   const [changePasswordOpen, setChangePasswordOpen] = useState(false);
   const [changePhoneOpen, setChangePhoneOpen] = useState(false);
   const [deleteAccountOpen, setDeleteAccountOpen] = useState(false);
+  const [cancellingDeletion, setCancellingDeletion] = useState(false);
+
+  const hasPendingDeletion = !!enhancedUser?.deletionRequestedAt;
+
+  const handleCancelDeletion = async () => {
+    if (cancellingDeletion) return;
+    setCancellingDeletion(true);
+    const result = await cancelAccountDeletion();
+    if (result.success) {
+      showToast(TEXT_CONSTANTS.SETTINGS.DELETE_ACCOUNT_CANCEL_SUCCESS, 'success');
+      await refreshEnhancedUser();
+    } else if (result.code === 'no_pending_request') {
+      showToast(TEXT_CONSTANTS.SETTINGS.DELETE_ACCOUNT_CANCEL_NO_PENDING, 'info');
+      await refreshEnhancedUser();
+    } else {
+      showToast(TEXT_CONSTANTS.SETTINGS.DELETE_ACCOUNT_CANCEL_ERROR, 'danger');
+    }
+    setCancellingDeletion(false);
+  };
 
   // TODO: Replace with actual state management when backend is implemented
   const [settings, setSettings] = useState({
@@ -367,26 +394,45 @@ export default function SettingsPage() {
                 </button>
               </div>
 
-              {/* Delete Account */}
+              {/* Delete Account — swaps to cancel-deletion button when a request is pending. */}
               <div className="flex items-center justify-between p-4 border border-danger-200 rounded-xl bg-danger-50">
                 <div className="flex items-center gap-4">
                   <TrashIcon className="w-5 h-5 text-danger-500" />
                   <div>
                     <h3 className="font-medium text-danger-900">
-                      {TEXT_CONSTANTS.SETTINGS.DELETE_ACCOUNT}
+                      {hasPendingDeletion
+                        ? TEXT_CONSTANTS.SETTINGS.DELETE_ACCOUNT_PENDING_TITLE
+                        : TEXT_CONSTANTS.SETTINGS.DELETE_ACCOUNT}
                     </h3>
                     <p className="text-sm text-danger-600">
-                      {TEXT_CONSTANTS.SETTINGS.DELETE_ACCOUNT_WARNING}
+                      {hasPendingDeletion
+                        ? TEXT_CONSTANTS.SETTINGS.DELETE_ACCOUNT_PENDING_DAYS_LEFT(
+                            daysUntilHardDelete(enhancedUser?.deletionRequestedAt),
+                          )
+                        : TEXT_CONSTANTS.SETTINGS.DELETE_ACCOUNT_WARNING}
                     </p>
                   </div>
                 </div>
-                <button
-                  type="button"
-                  onClick={() => setDeleteAccountOpen(true)}
-                  className="btn-danger text-sm"
-                >
-                  {TEXT_CONSTANTS.SETTINGS.DELETE_ACCOUNT}
-                </button>
+                {hasPendingDeletion ? (
+                  <button
+                    type="button"
+                    onClick={handleCancelDeletion}
+                    disabled={cancellingDeletion}
+                    className="btn-ghost text-sm border border-danger-300 text-danger-700"
+                  >
+                    {cancellingDeletion
+                      ? TEXT_CONSTANTS.SETTINGS.DELETE_ACCOUNT_CANCELLING
+                      : TEXT_CONSTANTS.SETTINGS.DELETE_ACCOUNT_CANCEL_BUTTON}
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => setDeleteAccountOpen(true)}
+                    className="btn-danger text-sm"
+                  >
+                    {TEXT_CONSTANTS.SETTINGS.DELETE_ACCOUNT}
+                  </button>
+                )}
               </div>
             </div>
           </div>

--- a/src/components/settings/DeleteAccountModal.tsx
+++ b/src/components/settings/DeleteAccountModal.tsx
@@ -7,7 +7,8 @@ import {
   DialogPanel,
   DialogTitle,
 } from '@headlessui/react';
-import { Eye, EyeOff, X, AlertTriangle } from 'lucide-react';
+import Link from 'next/link';
+import { Eye, EyeOff, X, AlertTriangle, ExternalLink } from 'lucide-react';
 import {
   reauthEmailPassword,
   mapFirebaseAuthError,
@@ -156,13 +157,28 @@ export default function DeleteAccountModal({ open, onClose, onSuccess }: Props) 
               <div className="text-xs text-danger-700 bg-danger-50 border border-danger-200 rounded-lg px-3 py-2 space-y-1">
                 <div className="font-semibold">{TEXT_CONSTANTS.SETTINGS.DELETE_ACCOUNT_OUTSTANDING_HEADING}</div>
                 {outstanding.equipmentCount > 0 && (
-                  <div>{TEXT_CONSTANTS.SETTINGS.DELETE_ACCOUNT_OUTSTANDING_EQUIPMENT}: {outstanding.equipmentCount}</div>
+                  <OutstandingRow
+                    label={TEXT_CONSTANTS.SETTINGS.DELETE_ACCOUNT_OUTSTANDING_EQUIPMENT}
+                    count={outstanding.equipmentCount}
+                    href="/equipment"
+                    onNavigate={onClose}
+                  />
                 )}
                 {outstanding.ammunitionUserHoldings > 0 && (
-                  <div>{TEXT_CONSTANTS.SETTINGS.DELETE_ACCOUNT_OUTSTANDING_AMMUNITION}: {outstanding.ammunitionUserHoldings}</div>
+                  <OutstandingRow
+                    label={TEXT_CONSTANTS.SETTINGS.DELETE_ACCOUNT_OUTSTANDING_AMMUNITION}
+                    count={outstanding.ammunitionUserHoldings}
+                    href="/ammunition"
+                    onNavigate={onClose}
+                  />
                 )}
                 {outstanding.pendingTransferRequests > 0 && (
-                  <div>{TEXT_CONSTANTS.SETTINGS.DELETE_ACCOUNT_OUTSTANDING_TRANSFERS}: {outstanding.pendingTransferRequests}</div>
+                  <OutstandingRow
+                    label={TEXT_CONSTANTS.SETTINGS.DELETE_ACCOUNT_OUTSTANDING_TRANSFERS}
+                    count={outstanding.pendingTransferRequests}
+                    href="/equipment"
+                    onNavigate={onClose}
+                  />
                 )}
               </div>
             )}
@@ -196,5 +212,28 @@ export default function DeleteAccountModal({ open, onClose, onSuccess }: Props) 
         </DialogPanel>
       </div>
     </Dialog>
+  );
+}
+
+interface OutstandingRowProps {
+  label: string;
+  count: number;
+  href: string;
+  onNavigate: () => void;
+}
+
+function OutstandingRow({ label, count, href, onNavigate }: OutstandingRowProps) {
+  return (
+    <div className="flex items-center justify-between gap-2">
+      <span>{label}: {count}</span>
+      <Link
+        href={href}
+        onClick={onNavigate}
+        className="inline-flex items-center gap-1 text-danger-700 hover:text-danger-900 underline decoration-dotted"
+      >
+        {TEXT_CONSTANTS.SETTINGS.DELETE_ACCOUNT_OUTSTANDING_GO}
+        <ExternalLink className="w-3 h-3" aria-hidden="true" />
+      </Link>
+    </div>
   );
 }

--- a/src/components/settings/PendingDeletionBanner.tsx
+++ b/src/components/settings/PendingDeletionBanner.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { useState } from 'react';
+import { AlertTriangle, X } from 'lucide-react';
+import { useAuth } from '@/contexts/AuthContext';
+import { cancelAccountDeletion } from '@/lib/accountDeletionClient';
+import { useToast } from '@/components/ui/Toast';
+import { TEXT_CONSTANTS } from '@/constants/text';
+import { ACCOUNT_DELETION_RETENTION_DAYS } from '@/types/accountDeletion';
+import type { Timestamp } from 'firebase/firestore';
+
+/**
+ * Banner rendered at the top of `AppShell` when the signed-in user has
+ * a pending soft-delete (`enhancedUser.deletionRequestedAt` set). Shows
+ * days remaining and a cancel-deletion button.
+ *
+ * Renders nothing when the user has no pending deletion.
+ */
+export default function PendingDeletionBanner() {
+  const { enhancedUser, refreshEnhancedUser } = useAuth();
+  const { showToast } = useToast();
+  const [cancelling, setCancelling] = useState(false);
+
+  const requestedAt = enhancedUser?.deletionRequestedAt;
+  if (!requestedAt) return null;
+
+  const daysLeft = computeDaysLeft(requestedAt);
+
+  const onCancel = async () => {
+    if (cancelling) return;
+    setCancelling(true);
+    const result = await cancelAccountDeletion();
+    if (result.success) {
+      showToast(TEXT_CONSTANTS.SETTINGS.DELETE_ACCOUNT_CANCEL_SUCCESS, 'success');
+      await refreshEnhancedUser();
+    } else if (result.code === 'no_pending_request') {
+      showToast(TEXT_CONSTANTS.SETTINGS.DELETE_ACCOUNT_CANCEL_NO_PENDING, 'info');
+      await refreshEnhancedUser();
+    } else {
+      showToast(TEXT_CONSTANTS.SETTINGS.DELETE_ACCOUNT_CANCEL_ERROR, 'danger');
+    }
+    setCancelling(false);
+  };
+
+  return (
+    <div
+      role="status"
+      className="bg-danger-50 border-b border-danger-200 text-danger-900"
+    >
+      <div className="max-w-6xl mx-auto px-3 sm:px-4 py-2.5 flex flex-wrap items-center gap-2 text-sm">
+        <AlertTriangle className="w-4 h-4 text-danger-600 flex-shrink-0" aria-hidden="true" />
+        <span className="font-semibold">
+          {TEXT_CONSTANTS.SETTINGS.DELETE_ACCOUNT_PENDING_TITLE}
+        </span>
+        <span className="text-danger-700">
+          {TEXT_CONSTANTS.SETTINGS.DELETE_ACCOUNT_PENDING_DAYS_LEFT(daysLeft)}
+        </span>
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={cancelling}
+          className="ms-auto inline-flex items-center gap-1.5 px-3 py-1 rounded-md bg-white text-danger-700 border border-danger-300 hover:bg-danger-100 disabled:opacity-60 text-xs font-medium"
+        >
+          <X className="w-3.5 h-3.5" aria-hidden="true" />
+          {cancelling
+            ? TEXT_CONSTANTS.SETTINGS.DELETE_ACCOUNT_CANCELLING
+            : TEXT_CONSTANTS.SETTINGS.DELETE_ACCOUNT_CANCEL_BUTTON}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Days remaining until the 30-day retention window elapses. Floors to 0
+ * so the message never goes negative when the cron is late.
+ */
+export function computeDaysLeft(requestedAt: Timestamp | Date | { toDate: () => Date }): number {
+  const requestedMs = toDateMs(requestedAt);
+  if (!requestedMs) return ACCOUNT_DELETION_RETENTION_DAYS;
+  const elapsedMs = Date.now() - requestedMs;
+  const remainingDays = Math.ceil(
+    ACCOUNT_DELETION_RETENTION_DAYS - elapsedMs / (1000 * 60 * 60 * 24),
+  );
+  return Math.max(remainingDays, 0);
+}
+
+function toDateMs(t: Timestamp | Date | { toDate: () => Date }): number {
+  if (t instanceof Date) return t.getTime();
+  if (typeof t === 'object' && t !== null && 'toDate' in t) {
+    try {
+      return (t as { toDate: () => Date }).toDate().getTime();
+    } catch {
+      return 0;
+    }
+  }
+  return 0;
+}

--- a/src/constants/text.ts
+++ b/src/constants/text.ts
@@ -1351,6 +1351,21 @@ export const TEXT_CONSTANTS = {
     DELETE_ACCOUNT_OUTSTANDING_EQUIPMENT: 'ציוד בחתימה',
     DELETE_ACCOUNT_OUTSTANDING_AMMUNITION: 'תחמושת בחתימה',
     DELETE_ACCOUNT_OUTSTANDING_TRANSFERS: 'בקשות העברה פתוחות',
+    DELETE_ACCOUNT_OUTSTANDING_GO: 'לדף',
+
+    // Pending-deletion banner + cancel flow (PR-G follow-ups)
+    DELETE_ACCOUNT_PENDING_TITLE: 'החשבון מסומן למחיקה',
+    DELETE_ACCOUNT_PENDING_DAYS_LEFT: (days: number) =>
+      days <= 0
+        ? 'החשבון יימחק לצמיתות בקרוב.'
+        : days === 1
+          ? 'החשבון יימחק לצמיתות מחר.'
+          : `החשבון יימחק לצמיתות בעוד ${days} ימים.`,
+    DELETE_ACCOUNT_CANCEL_BUTTON: 'בטל בקשת מחיקה',
+    DELETE_ACCOUNT_CANCELLING: 'מבטל...',
+    DELETE_ACCOUNT_CANCEL_SUCCESS: 'בקשת המחיקה בוטלה. החשבון פעיל כרגיל.',
+    DELETE_ACCOUNT_CANCEL_ERROR: 'ביטול הבקשה נכשל. נסה שוב.',
+    DELETE_ACCOUNT_CANCEL_NO_PENDING: 'אין בקשת מחיקה פעילה לחשבון.',
     
     // Placeholders and labels
     COMING_SOON: 'בקרוב',

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -128,6 +128,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
               enlistmentCycle: firestoreData.enlistmentCycle,
               address: firestoreData.address,
               communicationPreferences: firestoreData.communicationPreferences,
+              deletionRequestedAt: firestoreData.deletionRequestedAt,
               initials: UserDataService.generateInitials(firestoreData)
             };
             
@@ -291,6 +292,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
       enlistmentCycle: firestoreData.enlistmentCycle,
       address: firestoreData.address,
       communicationPreferences: firestoreData.communicationPreferences,
+      deletionRequestedAt: firestoreData.deletionRequestedAt,
       initials: UserDataService.generateInitials(firestoreData),
     };
     setUser(refreshed);

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -76,6 +76,11 @@ export interface EnhancedAuthUser {
   // Communication preferences
   communicationPreferences?: CommunicationPreferences;
 
+  // Account-deletion soft-delete marker (PR-G). Present iff the user has
+  // requested deletion and the 30d retention window hasn't elapsed (or
+  // they haven't cancelled). Drives the in-app pending-deletion banner.
+  deletionRequestedAt?: Timestamp;
+
   // Computed fields
   initials?: string;
 }
@@ -106,6 +111,10 @@ export interface FirestoreUserProfile {
   enlistmentCycle?: string;
   address?: string;
   communicationPreferences?: CommunicationPreferences;
+  /** PR-G soft-delete marker. Mirrored to {@link EnhancedAuthUser.deletionRequestedAt}. */
+  deletionRequestedAt?: Timestamp;
+  /** Optional free-text reason captured at delete-request time. */
+  deletionReason?: string;
 }
 
 /**


### PR DESCRIPTION
… (PR-G follow-up)

Three of four PR-G follow-ups land here. Hard-delete cron stays deferred — needs Council on cross-system safety and Vercel cron config.

Changes:
- `FirestoreUserProfile` + `EnhancedAuthUser` gain optional `deletionRequestedAt: Timestamp`. Surfaced at both `AuthContext` write sites (initial onAuthStateChanged + `refreshEnhancedUser`).
- New `PendingDeletionBanner` component mounted in `AppShell` between `TopBar` and the main layout. Renders nothing when the user has no pending deletion. Shows days remaining via `computeDaysLeft` + one-click cancel that fires `cancelAccountDeletion` and refreshes the enhanced user.
- `/settings` danger row swaps "מחק חשבון" for "בטל בקשת מחיקה" when a deletion is pending; title + description swap to the pending-state copy with the days-remaining count.
- `DeleteAccountModal` outstanding-assets breakdown now renders each row as a "לדף" deep link (`/equipment` for equipment + transfers, `/ammunition` for ammo). Clicking dismisses the modal so the user lands directly on the asset page.

Text constants: new `DELETE_ACCOUNT_PENDING_*` /
`DELETE_ACCOUNT_CANCEL_*` / `DELETE_ACCOUNT_OUTSTANDING_GO` strings.