### PR TITLE
feat(templates): two-level Disclosure grouping by category (bug #22)

### DIFF
--- a/docs/bugs.md
+++ b/docs/bugs.md
@@ -17,13 +17,8 @@
     - Phone rendered via existing `formatPhoneForDisplay`.
     - **Council outcome (4 agents — name-side dot / leading icon glyph / row tint / suffix text-badge):** 3/4 converged on **asymmetric** rendering (no signal on registered rows, show signal only on unregistered). Picked variant: text-badge "ממתין" via the existing `VIEW_PENDING_BADGE` constant — reuses bug #4's vocabulary, self-describing (no SR-only fallback needed), matches the "צ" inline-tag precedent in `EquipmentTable`.
 
-22. **Manage Equipment Templates list has no category grouping**
-    - **Repro:** `/management` → "Equipment Templates" tab. Templates render as a flat list. Hard to scan; users see hundreds of items mixed across categories.
-    - **Fix scope:** Group templates by category. 4 design options below; user picks one:
-      1. **Two-level Disclosure** — collapsible category section → expand to see templates as nested Disclosure rows. Matches existing Headless UI Disclosure pattern in the tab today.
-      2. **Side nav + main panel** — left rail with category list (single-select), main panel renders flat templates for the selected category. Familiar admin-style.
-      3. **Sticky group headers (iOS-style)** — single scrolling list with sticky `<h3>` headers between groups. Templates stay in one flow; jump via header click.
-      4. **Tab strip per category** — horizontal tab strip at top, one tab per category. Selecting a category swaps the main list. Subcategory chips below if needed.
+22. ~~**Manage Equipment Templates list has no category grouping**~~
+    - **FIXED (2026-05-14 on `feat/equipment-templates-grouped-by-category`):** user picked option 1 (two-level Disclosure). `TemplatesTab.tsx` `section()` helper now wraps each template list in a category-level `<Disclosure>`: outer button shows resolved category name + count, panel reveals the existing per-template `Disclosure` rows. Categories sort by resolved Hebrew name; uncategorised templates fall into a "ללא קטגוריה" bucket sorted last; unresolved IDs render with `text-warning-700` so orphan refs surface visibly. Same renderer used by all three sections (canonical / proposed / pending) so they stay visually consistent.
 
 > **Note (2026-04-29):** Incomplete-registration leak fixed on `fix/incomplete-registration-leak`. Bugs addressed in one branch:
 > - **Orphan Firebase Auth user on abandon** — `RegistrationModal` now calls `deleteCurrentUser()` on close/back/unmount; falls back to `signOutCurrentUser()` if `auth/requires-recent-login`. New helpers in `src/lib/firebasePhoneAuth.ts`, sessionStorage flag in `src/lib/registrationFlowFlag.ts`.

--- a/docs/codebase/src/components/management/tabs/TemplatesTab.md
+++ b/docs/codebase/src/components/management/tabs/TemplatesTab.md
@@ -12,15 +12,24 @@ Manager review surface for equipment templates. Phase 5 deliverable. Replaces th
 
 A single fetch returns all templates and the component bins them client-side. Re-fetched after each mutation.
 
-## Row layout
+## Layout: two-level Disclosure (bug #22, option 1)
 
-Each template row is a Headless UI `Disclosure` inside a list. Collapsed
-state shows only the template name + the per-row action buttons (so the
-row never overflows narrow screens). Expanding the row reveals
-description, resolved category / subcategory names, the
-requiresSerialNumber / requiresDailyStatusCheck flags, the default
-catalog number, and the raw status. Action buttons live outside the
-disclosure trigger so clicking them does not toggle the panel.
+Each section renders its templates **grouped by category**. The outer
+list is a `<ul>` of category-level `Disclosure` items; each category
+collapses to a header showing the resolved category name + count, and
+expanding it reveals the per-template `Disclosure` rows for that
+category. Categories sort alphabetically by their resolved Hebrew name
+via `String.localeCompare(b, 'he')`; templates with no category land in
+a "ללא קטגוריה" bucket sorted last. Unresolved category IDs use
+`text-warning-700` so orphan refs surface visibly.
+
+Each template row is itself a Headless UI `Disclosure`. Collapsed state
+shows only the template name + the per-row action buttons (so the row
+never overflows narrow screens). Expanding the row reveals description,
+resolved category / subcategory names, the requiresSerialNumber /
+requiresDailyStatusCheck flags, the default catalog number, and the raw
+status. Action buttons live outside the disclosure trigger so clicking
+them does not toggle the panel.
 
 ## Actions
 

--- a/src/components/management/tabs/TemplatesTab.tsx
+++ b/src/components/management/tabs/TemplatesTab.tsx
@@ -401,27 +401,102 @@ export default function TemplatesTab() {
     );
   };
 
+  /**
+   * Group templates by their category ID. Returns sorted buckets so the
+   * outer Disclosure list reads alphabetically by resolved category name
+   * (Hebrew locale). Unresolved category IDs sort last under a fixed
+   * sentinel label.
+   *
+   * Two-level Disclosure layout (bug #22, option 1): outer Disclosure per
+   * category collapses to a header "{name} ({count})"; expanding reveals
+   * the existing per-template Disclosure rows via `renderRow`.
+   */
+  const groupByCategory = (items: EquipmentType[]): Array<{
+    key: string;
+    label: React.ReactNode;
+    items: EquipmentType[];
+  }> => {
+    const UNKNOWN = '__unknown__';
+    const buckets = new Map<string, EquipmentType[]>();
+    for (const t of items) {
+      const key = t.category || UNKNOWN;
+      const arr = buckets.get(key);
+      if (arr) arr.push(t);
+      else buckets.set(key, [t]);
+    }
+    const entries = Array.from(buckets.entries()).map(([key, list]) => {
+      if (key === UNKNOWN) {
+        return {
+          key,
+          label: <span className="text-warning-700">ללא קטגוריה</span>,
+          items: list,
+          sortName: '￿',
+        };
+      }
+      const resolved = categoryName(key);
+      return {
+        key,
+        label: resolved ?? (
+          <span className="text-warning-700" title="קטגוריה לא נמצאה">{key}</span>
+        ),
+        items: list,
+        sortName: resolved ?? key,
+      };
+    });
+    entries.sort((a, b) => a.sortName.localeCompare(b.sortName, 'he'));
+    return entries.map(({ key, label, items: list }) => ({ key, label, items: list }));
+  };
+
+  const renderCategoryGroup = (
+    group: { key: string; label: React.ReactNode; items: EquipmentType[] },
+    actions: (t: EquipmentType) => React.ReactNode,
+  ) => (
+    <Disclosure key={group.key} as="li" className="border-b border-neutral-200 last:border-b-0">
+      {({ open }) => (
+        <>
+          <DisclosureButton className="w-full flex items-center gap-3 px-4 py-3 hover:bg-neutral-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 text-start">
+            <ChevronDown
+              className={cn(
+                'w-4 h-4 text-neutral-500 transition-transform',
+                open && 'rotate-180',
+              )}
+              aria-hidden="true"
+            />
+            <span className="text-sm font-semibold text-neutral-900 flex-1">{group.label}</span>
+            <span className="text-xs text-neutral-500">({group.items.length})</span>
+          </DisclosureButton>
+          <DisclosurePanel as="ul" className="divide-y divide-neutral-200 bg-white border-t border-neutral-200">
+            {group.items.map((t) => renderRow(t, actions(t)))}
+          </DisclosurePanel>
+        </>
+      )}
+    </Disclosure>
+  );
+
   const section = (
     title: string,
     items: EquipmentType[],
     actions: (t: EquipmentType) => React.ReactNode,
     emptyMessage: string
-  ) => (
-    <Card padding="sm" className="overflow-hidden">
-      <div className="px-4 py-3 bg-neutral-50 border-b border-neutral-200 flex items-center justify-between">
-        <h4 className="text-md font-semibold text-neutral-900">
-          {title} <span className="text-neutral-500 text-sm">({items.length})</span>
-        </h4>
-      </div>
-      {items.length === 0 ? (
-        <div className="p-6 text-center text-sm text-neutral-500">{emptyMessage}</div>
-      ) : (
-        <ul className="divide-y divide-neutral-200">
-          {items.map((t) => renderRow(t, actions(t)))}
-        </ul>
-      )}
-    </Card>
-  );
+  ) => {
+    const groups = items.length > 0 ? groupByCategory(items) : [];
+    return (
+      <Card padding="sm" className="overflow-hidden">
+        <div className="px-4 py-3 bg-neutral-50 border-b border-neutral-200 flex items-center justify-between">
+          <h4 className="text-md font-semibold text-neutral-900">
+            {title} <span className="text-neutral-500 text-sm">({items.length})</span>
+          </h4>
+        </div>
+        {items.length === 0 ? (
+          <div className="p-6 text-center text-sm text-neutral-500">{emptyMessage}</div>
+        ) : (
+          <ul className="divide-y divide-neutral-200">
+            {groups.map((g) => renderCategoryGroup(g, actions))}
+          </ul>
+        )}
+      </Card>
+    );
+  };
 
   // Modal wrapper
   const modal = (title: string, content: React.ReactNode) => (


### PR DESCRIPTION
User picked option 1 (two-level Disclosure) from the 4 grouping options proposed in the bug.

`TemplatesTab.tsx` `section()` now wraps each template list in a category-level Headless UI `<Disclosure>`:
- Outer button: ChevronDown + resolved category name + `(count)`.
- Panel: the existing per-template Disclosure rows for that category, rendered via `renderRow` so behavior stays identical (collapse-by- default, action buttons outside the trigger, same expanded-panel fields).

Categories sort alphabetically by their resolved Hebrew name (`localeCompare(b, 'he')`). Uncategorised templates fall into a "ללא קטגוריה" bucket sorted last. Unresolved category IDs render with `text-warning-700` + `title="קטגוריה לא נמצאה"` so orphan refs surface visibly (same pattern as the existing `renderCategoryCell`).

All three sections (canonical / proposed / pending) flow through the same renderer, so the visual treatment stays consistent.