### PR TITLE
feat(soldier-status): audit fields + history subcollection

### DIFF
--- a/docs/codebase/src/lib/db/server/soldierStatusService.md
+++ b/docs/codebase/src/lib/db/server/soldierStatusService.md
@@ -17,7 +17,7 @@ doc-id lookup, no extra index needed.
 | Export | Purpose |
 |--------|---------|
 | `serverListRoster()` | Joins `users` ∪ `authorized_personnel`, deduplicates by hash (preferring `users` for display fields), and overlays each soldier's current status. Sorted by Hebrew full name. |
-| `serverUpdateSoldierStatus(hashedId, input)` | Upserts `soldierStatus/{hashedId}`. Validates the status enum, the `customStatus` presence rule, and that the hashed id matches at least one row in `users` or `authorized_personnel`. |
+| `serverUpdateSoldierStatus(hashedId, input, actor?)` | Upserts `soldierStatus/{hashedId}`. Validates the status enum, the `customStatus` presence rule, and that the hashed id matches at least one row in `users` or `authorized_personnel`. When `actor` is supplied, also stamps audit fields and appends a row to the `history` subcollection. |
 | `SoldierStatusValidationError` | Named error with `status` (400 or 404) for API routes to map cleanly. |
 
 ## Firebase Operations
@@ -34,11 +34,35 @@ soldierStatus/{militaryPersonalNumberHash}
   status: 'בית' | 'משמר' | 'אחר'
   customStatus?: string   // present iff status === 'אחר'
   updatedAt: Timestamp    // server timestamp
+  updatedBy?: string      // uid of writer (added 2026-05-14)
+  updatedByName?: string  // best-effort display name resolved from users/{uid}
 ```
 
-Audit fields (`updatedBy`, `updatedByName`) and per-soldier history are
-intentionally deferred — see project memory `project_status_route_migration`
-and the deferred-follow-ups section of the migration plan.
+### History subcollection (added 2026-05-14)
+
+```
+soldierStatus/{hash}/history/{autoId}
+  status: SoldierStatus
+  customStatus?: string
+  updatedAt: Timestamp
+  updatedBy: string
+  updatedByName?: string
+  previousStatus?: SoldierStatus    // absent on the first ever write
+  previousCustomStatus?: string
+```
+
+Append-only audit log; one entry per status mutation. The current doc mirrors
+the latest entry, so the history collection answers "who and when" questions
+for past states. Writes are sequential (read prior doc → write current →
+append history) rather than transactional — the roster is small and the
+mutation cadence is low, so the risk of two concurrent PUTs interleaving is
+negligible.
+
+`actor.displayName` is preferred when supplied (the `/api/soldier-status/[id]`
+route passes `ApiActor.displayName`); otherwise the service joins
+`users/{actor.uid}` for `firstName + lastName`. When neither resolves, the
+current doc clears any stale `updatedByName` via `FieldValue.delete()` and the
+history row carries no `updatedByName`.
 
 ## Validation rules baked into `serverUpdateSoldierStatus`
 

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -203,6 +203,16 @@ service cloud.firestore {
     match /soldierStatus/{soldierId} {
       allow read: if request.auth != null;
       allow write: if false;
+
+      // History subcollection — append-only audit trail written by the
+      // /api/soldier-status PUT route via the admin SDK. Authenticated
+      // users can read it (so a future GET /api/soldier-status/[id]/history
+      // can hydrate from the client SDK if desired); writes go through
+      // the admin SDK only.
+      match /history/{historyId} {
+        allow read: if request.auth != null;
+        allow write: if false;
+      }
     }
 
     // Training plans — authenticated read; writes server-only via /api/training-plans.

--- a/src/app/api/soldier-status/[id]/route.ts
+++ b/src/app/api/soldier-status/[id]/route.ts
@@ -16,8 +16,10 @@ interface PutBody {
  *
  * Bearer-gated. Any authenticated user can update a soldier's status. The id
  * in the URL is the soldier's militaryPersonalNumberHash (matches
- * authorized_personnel doc-id). Audit fields are intentionally NOT persisted
- * — deferred until the audit scope is decided.
+ * authorized_personnel doc-id). The actor's uid is captured on the status
+ * doc (`updatedBy`) and an audit row is appended to
+ * `soldierStatus/{id}/history/{autoId}` — see `soldierStatusService` for
+ * field shapes.
  */
 export async function PUT(
   request: Request,
@@ -26,6 +28,7 @@ export async function PUT(
   try {
     const actorOrError = await getActorOrError(request);
     if (actorOrError instanceof NextResponse) return actorOrError;
+    const actor = actorOrError;
 
     const { id } = await params;
     if (!id) {
@@ -43,10 +46,14 @@ export async function PUT(
       );
     }
 
-    await serverUpdateSoldierStatus(id, {
-      status: body.status as SoldierStatus,
-      ...(typeof body.customStatus === 'string' ? { customStatus: body.customStatus } : {}),
-    });
+    await serverUpdateSoldierStatus(
+      id,
+      {
+        status: body.status as SoldierStatus,
+        ...(typeof body.customStatus === 'string' ? { customStatus: body.customStatus } : {}),
+      },
+      { uid: actor.uid, displayName: actor.displayName },
+    );
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/src/lib/__tests__/soldierStatusService.test.ts
+++ b/src/lib/__tests__/soldierStatusService.test.ts
@@ -77,37 +77,47 @@ function buildAdminDb() {
     return api;
   }
 
+  let autoIdCounter = 0;
+
+  function buildCollection(name: string) {
+    return {
+      doc(id?: string) {
+        const generatedId = id ?? `auto-${++autoIdCounter}`;
+        const fullKey = `${name}/${generatedId}`;
+        return {
+          id: generatedId,
+          async get() {
+            const rec = store.get(fullKey);
+            return {
+              exists: !!rec,
+              id: generatedId,
+              data: () => rec?.data ?? {},
+            };
+          },
+          async set(data: Record<string, unknown>, options?: { merge?: boolean }) {
+            const cur = store.get(fullKey);
+            const merged: Record<string, unknown> = options?.merge && cur ? { ...cur.data } : {};
+            for (const [k, v] of Object.entries(data)) {
+              if (v === 'DELETE_SENTINEL') {
+                delete merged[k];
+              } else {
+                merged[k] = v;
+              }
+            }
+            store.set(fullKey, { id: generatedId, data: merged });
+          },
+          collection(subName: string) {
+            return buildCollection(`${fullKey}/${subName}`);
+          },
+        };
+      },
+      ...makeQuery(name),
+    };
+  }
+
   return {
     collection(name: string) {
-      return {
-        doc(id: string) {
-          const fullKey = `${name}/${id}`;
-          return {
-            id,
-            async get() {
-              const rec = store.get(fullKey);
-              return {
-                exists: !!rec,
-                id,
-                data: () => rec?.data ?? {},
-              };
-            },
-            async set(data: Record<string, unknown>, options?: { merge?: boolean }) {
-              const cur = store.get(fullKey);
-              const merged: Record<string, unknown> = options?.merge && cur ? { ...cur.data } : {};
-              for (const [k, v] of Object.entries(data)) {
-                if (v === 'DELETE_SENTINEL') {
-                  delete merged[k];
-                } else {
-                  merged[k] = v;
-                }
-              }
-              store.set(fullKey, { id, data: merged });
-            },
-          };
-        },
-        ...makeQuery(name),
-      };
+      return buildCollection(name);
     },
   };
 }
@@ -271,5 +281,99 @@ describe('serverUpdateSoldierStatus', () => {
     const stored = store.get('soldierStatus/hash-a')!.data;
     expect(stored.status).toBe('בית');
     expect(stored.customStatus).toBeUndefined();
+  });
+
+  describe('audit fields + history subcollection', () => {
+    function historyEntries() {
+      return [...store.entries()]
+        .filter(([key]) => key.startsWith('soldierStatus/hash-a/history/'))
+        .map(([, rec]) => rec.data);
+    }
+
+    it('does not stamp updatedBy when actor is omitted (legacy callers)', async () => {
+      await serverUpdateSoldierStatus('hash-a', { status: 'בית' });
+      const stored = store.get('soldierStatus/hash-a')!.data;
+      expect(stored.updatedBy).toBeUndefined();
+      expect(historyEntries()).toHaveLength(0);
+    });
+
+    it('stamps updatedBy + uses actor.displayName when provided', async () => {
+      await serverUpdateSoldierStatus(
+        'hash-a',
+        { status: 'משמר' },
+        { uid: 'uid-99', displayName: 'אבי כהן' },
+      );
+      const stored = store.get('soldierStatus/hash-a')!.data;
+      expect(stored.updatedBy).toBe('uid-99');
+      expect(stored.updatedByName).toBe('אבי כהן');
+    });
+
+    it('resolves updatedByName from users/{uid} when displayName is omitted', async () => {
+      store.set('users/uid-99', {
+        id: 'uid-99',
+        data: { firstName: 'דנה', lastName: 'לוי' },
+      });
+      await serverUpdateSoldierStatus(
+        'hash-a',
+        { status: 'בית' },
+        { uid: 'uid-99' },
+      );
+      const stored = store.get('soldierStatus/hash-a')!.data;
+      expect(stored.updatedByName).toBe('דנה לוי');
+    });
+
+    it('appends a history row carrying writer + previous values', async () => {
+      // first write — no previous state
+      await serverUpdateSoldierStatus(
+        'hash-a',
+        { status: 'בית' },
+        { uid: 'uid-1', displayName: 'A' },
+      );
+      let history = historyEntries();
+      expect(history).toHaveLength(1);
+      expect(history[0]).toMatchObject({
+        status: 'בית',
+        updatedBy: 'uid-1',
+        updatedByName: 'A',
+      });
+      expect(history[0].previousStatus).toBeUndefined();
+
+      // second write — previous state populated
+      await serverUpdateSoldierStatus(
+        'hash-a',
+        { status: 'אחר', customStatus: 'קורס' },
+        { uid: 'uid-2', displayName: 'B' },
+      );
+      history = historyEntries();
+      expect(history).toHaveLength(2);
+      expect(history[1]).toMatchObject({
+        status: 'אחר',
+        customStatus: 'קורס',
+        updatedBy: 'uid-2',
+        updatedByName: 'B',
+        previousStatus: 'בית',
+      });
+      expect(history[1].previousCustomStatus).toBeUndefined();
+    });
+
+    it('clears updatedByName when actor has no resolvable name', async () => {
+      // First write with a name in place.
+      await serverUpdateSoldierStatus(
+        'hash-a',
+        { status: 'בית' },
+        { uid: 'uid-1', displayName: 'אבי' },
+      );
+      expect(store.get('soldierStatus/hash-a')!.data.updatedByName).toBe('אבי');
+
+      // Second write with anonymous actor — should clear the stale name.
+      await serverUpdateSoldierStatus(
+        'hash-a',
+        { status: 'משמר' },
+        { uid: 'uid-2' },
+      );
+      const stored = store.get('soldierStatus/hash-a')!.data;
+      expect(stored.updatedByName).toBeUndefined();
+      expect(stored.updatedBy).toBe('uid-2');
+    });
   });
 });

--- a/src/lib/db/server/soldierStatusService.ts
+++ b/src/lib/db/server/soldierStatusService.ts
@@ -9,8 +9,19 @@
  *
  * Roster source: union of `users` (registered profiles, preferred for display)
  * and `authorized_personnel` (admin-managed, fills in non-registered soldiers).
- * Status doc fields are limited to `{ status, customStatus?, updatedAt }`;
- * audit fields and per-soldier history are intentionally deferred.
+ *
+ * Audit fields and a `history/{autoId}` subcollection (added 2026-05-14):
+ *  - The current doc carries `updatedBy` (uid of writer) and optional
+ *    `updatedByName` (display name resolved from `users/{uid}` at write time).
+ *  - Every status mutation also appends a row to
+ *    `soldierStatus/{hash}/history/{autoId}` with the new value, who wrote it,
+ *    and the previous value (so the history is self-contained — no need to
+ *    cross-reference adjacent rows to know what changed).
+ *
+ * Race-condition note: writes are sequential (read prior doc → write current
+ * → append history) rather than transactional. The roster is small and the
+ * mutation cadence is low, so the risk of two concurrent PUTs interleaving is
+ * negligible. Revisit if traffic grows.
  */
 import { getAdminDb } from '../admin';
 import { COLLECTIONS } from '../collections';
@@ -49,6 +60,12 @@ interface StatusDocLite {
   updatedAt?: Timestamp;
 }
 
+export interface SoldierStatusActor {
+  uid: string;
+  /** Pre-resolved display name; falls through to a users-collection lookup if absent. */
+  displayName?: string;
+}
+
 /**
  * Build the joined roster: users ∪ authorized_personnel, deduped by hash,
  * preferring `users` for display fields when both exist. Each entry is
@@ -71,8 +88,6 @@ export async function serverListRoster(): Promise<RosterEntry[]> {
     statusByHash.set(doc.id, doc.data() as StatusDocLite);
   }
 
-  // Hash → roster row. Personnel collection seeds the row first so users can
-  // override display fields below.
   const rowByHash = new Map<string, RosterEntry>();
 
   for (const doc of personnelSnap.docs) {
@@ -106,7 +121,6 @@ export async function serverListRoster(): Promise<RosterEntry[]> {
     });
   }
 
-  // Apply status overlay last so it survives the user→personnel merge above.
   for (const [hash, row] of rowByHash.entries()) {
     const status = statusByHash.get(hash);
     if (!status) continue;
@@ -125,14 +139,42 @@ export async function serverListRoster(): Promise<RosterEntry[]> {
   });
 }
 
+async function resolveActorDisplayName(
+  db: ReturnType<typeof getAdminDb>,
+  actor: SoldierStatusActor,
+): Promise<string | null> {
+  if (actor.displayName && actor.displayName.trim()) {
+    return actor.displayName.trim();
+  }
+  try {
+    const snap = await db.collection(COLLECTIONS.USERS).doc(actor.uid).get();
+    if (!snap.exists) return null;
+    const data = snap.data() as UserDocLite | undefined;
+    const name = `${data?.firstName ?? ''} ${data?.lastName ?? ''}`.trim();
+    return name || null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Upsert `soldierStatus/{hash}` with the new status. Validates input shape and
  * (best-effort) verifies the soldier exists in the roster sources, so we don't
  * silently create orphan status docs for unknown hashes.
+ *
+ * Audit + history (added 2026-05-14): the current doc gains `updatedBy` (uid)
+ * and optional `updatedByName` (display name). A new entry is appended to
+ * `soldierStatus/{hash}/history/{autoId}` with the new state, the writer, and
+ * the previous state, so the audit trail is queryable without diffing
+ * adjacent rows.
+ *
+ * `actor` is optional only for backward compatibility with the existing tests
+ * that pre-date the audit work. New callers should always pass it.
  */
 export async function serverUpdateSoldierStatus(
   hashedId: string,
-  input: UpdateSoldierStatusInput
+  input: UpdateSoldierStatusInput,
+  actor?: SoldierStatusActor,
 ): Promise<void> {
   if (!hashedId || typeof hashedId !== 'string') {
     throw new SoldierStatusValidationError('id is required');
@@ -159,6 +201,14 @@ export async function serverUpdateSoldierStatus(
   }
 
   const ref = db.collection(COLLECTIONS.SOLDIER_STATUS).doc(hashedId);
+
+  // Capture the prior state before we overwrite it — the history row needs
+  // both the new and the previous values so it's self-describing.
+  const priorSnap = await ref.get();
+  const prior = priorSnap.exists ? (priorSnap.data() as StatusDocLite) : null;
+
+  const actorName = actor ? await resolveActorDisplayName(db, actor) : null;
+
   const data: Record<string, unknown> = {
     status: normalized.status,
     updatedAt: FieldValue.serverTimestamp(),
@@ -166,8 +216,32 @@ export async function serverUpdateSoldierStatus(
   if (normalized.customStatus !== undefined) {
     data.customStatus = normalized.customStatus;
   } else {
-    // Clear any stale customStatus from a previous 'אחר' entry.
     data.customStatus = FieldValue.delete();
   }
+  if (actor) {
+    data.updatedBy = actor.uid;
+    if (actorName) {
+      data.updatedByName = actorName;
+    } else {
+      // Clear any stale display name resolved from an earlier write.
+      data.updatedByName = FieldValue.delete();
+    }
+  }
   await ref.set(data, { merge: true });
+
+  if (actor) {
+    const historyEntry: Record<string, unknown> = {
+      status: normalized.status,
+      updatedAt: FieldValue.serverTimestamp(),
+      updatedBy: actor.uid,
+    };
+    if (normalized.customStatus !== undefined) {
+      historyEntry.customStatus = normalized.customStatus;
+    }
+    if (actorName) historyEntry.updatedByName = actorName;
+    if (prior?.status) historyEntry.previousStatus = prior.status;
+    if (prior?.customStatus) historyEntry.previousCustomStatus = prior.customStatus;
+
+    await ref.collection('history').doc().set(historyEntry);
+  }
 }

--- a/src/types/soldierStatus.ts
+++ b/src/types/soldierStatus.ts
@@ -17,6 +17,27 @@ export interface SoldierStatusDoc {
   status: SoldierStatus;
   customStatus?: string;
   updatedAt: Timestamp;
+  /** Audit: uid of the user who wrote this status (added 2026-05-14). */
+  updatedBy?: string;
+  /** Audit: display name of the writer at write time, best-effort joined from `users/{uid}`. */
+  updatedByName?: string;
+}
+
+/**
+ * Stored shape of a `soldierStatus/{hash}/history/{autoId}` document.
+ * Append-only audit log; one entry per status mutation. The current doc
+ * mirrors the latest entry, so the history collection answers "who and
+ * when" questions for past states.
+ */
+export interface SoldierStatusHistoryEntry {
+  status: SoldierStatus;
+  customStatus?: string;
+  updatedAt: Timestamp;
+  updatedBy: string;
+  updatedByName?: string;
+  /** Status that was overwritten by this entry. Absent on the first ever write. */
+  previousStatus?: SoldierStatus;
+  previousCustomStatus?: string;
 }
 
 /** Joined roster row returned by GET /api/soldier-status. */


### PR DESCRIPTION
Picks up the two follow-ups deferred from the soldier-status migration (PR #42).

Service:
- `serverUpdateSoldierStatus(hashedId, input, actor?)` now stamps audit fields on the current doc and appends an entry to a new `soldierStatus/{hash}/history/{autoId}` subcollection. `actor` is optional so legacy callers and existing tests stay unchanged.
- Current doc gains `updatedBy` (uid) and best-effort `updatedByName`. Name source: `actor.displayName` first (ApiActor carries it), then `users/{actor.uid}` `firstName + lastName`. When neither resolves, any stale `updatedByName` is cleared via `FieldValue.delete()`.
- Each history entry carries the new state, the writer, and the previous state (status / customStatus), so it's self-describing — no need to diff adjacent rows. Writes are sequential rather than transactional: roster is small, mutation cadence is low.

Route:
- `PUT /api/soldier-status/[id]` passes `{ uid, displayName }` from the `ApiActor` to the service.

Types:
- `SoldierStatusDoc.updatedBy` / `updatedByName` (both optional).
- New `SoldierStatusHistoryEntry`.
- New `SoldierStatusActor` interface on the service.

Rules:
- `firestore.rules`: nested `match /soldierStatus/{id}/history/{historyId}` allows authenticated reads, denies client writes. Same shape as the parent rule.

Tests:
- Mock extended with subcollection support (`doc().collection()`) and auto-id (`doc()` no-arg).
- 5 new tests cover: legacy callers unchanged, displayName preferred, users-collection name resolution, history row + previous values appended, stale name cleared on anonymous writer.