### PR TITLE
feat(profile-image): localStorage cache to kill avatar flicker on reload

### DIFF
--- a/docs/codebase/src/app/profile/page.md
+++ b/docs/codebase/src/app/profile/page.md
@@ -15,7 +15,7 @@ User profile page (`/profile`). Displays the authenticated user's personal and m
 
 | State | Type | Purpose |
 |-------|------|---------|
-| `profileImageUrl` | `string \| undefined` | Local mirror of `enhancedUser.profileImage`, synced via `useEffect` whenever the source changes |
+| `profileImageUrl` | `string \| undefined` | Local mirror of `enhancedUser.profileImage`. Initial value seeded from `readProfileImageCache(user.uid)` so the avatar paints on reload before Firestore returns. `useEffect` revalidates against `enhancedUser.profileImage` and writes back to the cache. |
 | `phoneNumber` | `string` | Local mirror of `enhancedUser.phoneNumber`, synced via `useEffect`; passed into `ContactInfoSection` |
 
 All other editable state (teamId, enlistmentCycle, address) lives inside the dedicated section components (`MilitaryInfoSection`, `ContactInfoSection`).
@@ -52,5 +52,5 @@ Uses `date-fns` with `he` locale. Handles both `Date` objects and Firestore `Tim
 ## Related queued work
 
 - Image editor v2 (pan + wider zoom + group-photo focus) — still queued.
-- Profile image localStorage cache — still queued.
+- ~~Profile image localStorage cache~~ — shipped. See `docs/codebase/src/lib/profileImageCache.md`.
 - Soldier qualifications + personal logistics — blocked on 6 open product Qs (see `project_soldier_qualifications`).

--- a/docs/codebase/src/app/settings/page.md
+++ b/docs/codebase/src/app/settings/page.md
@@ -17,7 +17,7 @@ Settings page (`/settings`). Provides a comprehensive settings UI covering profi
 | State | Type | Purpose |
 |-------|------|---------|
 | `settings` | `{ emailNotifications, equipmentTransferAlerts, language, theme }` | Local toggle state — not persisted |
-| `profileImageUrl` | `string \| undefined` | Profile image optimistic local state |
+| `profileImageUrl` | `string \| undefined` | Profile image optimistic local state. Seeded from `readProfileImageCache(enhancedUser.uid)` to paint instantly on reload; `useEffect` revalidates against `enhancedUser.profileImage` and writes back. See `docs/codebase/src/lib/profileImageCache.md`. |
 | `changePasswordOpen` | `boolean` | Controls visibility of `<ChangePasswordModal>` |
 
 ## Wired actions (real backend)

--- a/docs/codebase/src/contexts/AuthContext.md
+++ b/docs/codebase/src/contexts/AuthContext.md
@@ -41,6 +41,10 @@ Global authentication state provider. Wraps Firebase Auth with Firestore user pr
 - **Auth:** `signInWithEmailAndPassword`, `signOut`, `onAuthStateChanged`
 - **Read:** `UserDataService.fetchUserDataByUid` — enriches auth user with Firestore profile
 
+## Side effects
+
+- `logout()` calls `clearProfileImageCache(auth.currentUser?.uid)` before `signOut` so the next user signing in on the same device does not see the previous user's avatar painted from localStorage. See `docs/codebase/src/lib/profileImageCache.md`.
+
 ## Known Issues
 
 - Console.log statements left in.

--- a/docs/codebase/src/lib/profileImageCache.md
+++ b/docs/codebase/src/lib/profileImageCache.md
@@ -1,0 +1,34 @@
+# profileImageCache.ts
+
+**File:** `src/lib/profileImageCache.ts`
+**Status:** Active
+
+## Purpose
+
+localStorage cache for the user's resolved profile image download URL. Lets the avatar paint on first render before Firestore returns `enhancedUser.profileImage`, eliminating the icon → image flicker on reload. Stale-while-revalidate: the page seeds initial state from cache, then the `useEffect` overwrites once Firestore returns the authoritative value.
+
+## Storage shape
+
+| Key | Value |
+|-----|-------|
+| `profileImageCache:v1:{uid}` | Resolved download URL (http(s) only). Other schemes are rejected on read and write. |
+
+The URL itself acts as the invalidation hash — uploads write a new Storage path that includes `Date.now()`, so any change in the Firestore field is a different string.
+
+## Exports
+
+| Export | Description |
+|--------|-------------|
+| `readProfileImageCache(uid)` | Returns the cached URL, or `undefined` if missing, non-http(s), uid missing, or storage unavailable. |
+| `writeProfileImageCache(uid, url)` | Writes the URL if it is http(s); removes the entry otherwise. No-ops without a uid or on SSR. Swallows quota / disabled-storage errors. |
+| `clearProfileImageCache(uid)` | Removes the cached entry. Called from `AuthContext.logout`. |
+
+## Call sites
+
+- `src/app/profile/page.tsx` — seeds `profileImageUrl` from cache; writes on `enhancedUser.profileImage` change and on upload.
+- `src/app/settings/page.tsx` — same pattern.
+- `src/contexts/AuthContext.tsx` — clears the entry inside `logout()` before `signOut`.
+
+## Why not a hook
+
+The cache is a thin wrapper around `window.localStorage`. State lives in each page; the cache is only consulted at mount and on `useEffect` runs. Wrapping it in a hook would only add ceremony.

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -11,16 +11,24 @@ import MilitaryInfoSection from '@/components/profile/MilitaryInfoSection';
 import ContactInfoSection from '@/components/profile/ContactInfoSection';
 import { TEXT_CONSTANTS } from '@/constants/text';
 import { updateUserProfile } from '@/lib/userProfileService';
+import { readProfileImageCache, writeProfileImageCache } from '@/lib/profileImageCache';
 
 export default function ProfilePage() {
   const { enhancedUser, user, refreshEnhancedUser } = useAuth();
-  const [profileImageUrl, setProfileImageUrl] = useState<string | undefined>(undefined);
+  // Seed from localStorage so the avatar paints instantly on reload, before
+  // Firestore returns enhancedUser.profileImage. Stale-while-revalidate: the
+  // effect below overwrites once the authoritative value arrives.
+  const [profileImageUrl, setProfileImageUrl] = useState<string | undefined>(() =>
+    readProfileImageCache(user?.uid)
+  );
   const [phoneNumber, setPhoneNumber] = useState<string>('');
 
   useEffect(() => {
     const img = enhancedUser?.profileImage;
-    setProfileImageUrl(img && /^https?:\/\//i.test(img) ? img : undefined);
-  }, [enhancedUser?.profileImage]);
+    const resolved = img && /^https?:\/\//i.test(img) ? img : undefined;
+    setProfileImageUrl(resolved);
+    writeProfileImageCache(enhancedUser?.uid, resolved);
+  }, [enhancedUser?.profileImage, enhancedUser?.uid]);
 
   useEffect(() => {
     setPhoneNumber(enhancedUser?.phoneNumber || '');
@@ -49,6 +57,7 @@ export default function ProfilePage() {
   const handleImageUpdate = async (newImageUrl: string) => {
     setProfileImageUrl(newImageUrl);
     if (!enhancedUser) return;
+    writeProfileImageCache(enhancedUser.uid, newImageUrl);
     try {
       await updateUserProfile(enhancedUser.uid, { profileImage: newImageUrl });
       await refreshEnhancedUser();

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import AuthGuard from '@/components/auth/AuthGuard';
 import AppShell from '@/app/components/AppShell';
@@ -10,6 +10,7 @@ import ChangePasswordModal from '@/components/settings/ChangePasswordModal';
 import ChangePhoneModal from '@/components/settings/ChangePhoneModal';
 import DeleteAccountModal from '@/components/settings/DeleteAccountModal';
 import { cancelAccountDeletion } from '@/lib/accountDeletionClient';
+import { readProfileImageCache, writeProfileImageCache } from '@/lib/profileImageCache';
 import { computeDaysLeft } from '@/components/settings/PendingDeletionBanner';
 import { Select } from '@/components/ui';
 import { useToast } from '@/components/ui/Toast';
@@ -74,11 +75,20 @@ export default function SettingsPage() {
   });
 
   // Profile image state. Drop legacy blob: URLs from the old mock — they error on render.
+  // Seed from localStorage so the avatar paints instantly on reload (Firestore
+  // fetch is async). Effect below revalidates from enhancedUser.profileImage.
   const initialProfileImage =
     enhancedUser?.profileImage && /^https?:\/\//i.test(enhancedUser.profileImage)
       ? enhancedUser.profileImage
-      : undefined;
+      : readProfileImageCache(enhancedUser?.uid);
   const [profileImageUrl, setProfileImageUrl] = useState<string | undefined>(initialProfileImage);
+
+  useEffect(() => {
+    const img = enhancedUser?.profileImage;
+    const resolved = img && /^https?:\/\//i.test(img) ? img : undefined;
+    setProfileImageUrl(resolved);
+    writeProfileImageCache(enhancedUser?.uid, resolved);
+  }, [enhancedUser?.profileImage, enhancedUser?.uid]);
 
   // TODO: Replace with actual data when backend is implemented
   const mockPhoneNumber = enhancedUser?.phoneNumber || '+972-50-123-4567';
@@ -101,6 +111,7 @@ export default function SettingsPage() {
   // Handle profile image update
   const handleImageUpdate = (newImageUrl: string) => {
     setProfileImageUrl(newImageUrl);
+    writeProfileImageCache(enhancedUser?.uid, newImageUrl);
     // TODO: Update image in Firestore
     console.log('Profile image updated in settings:', newImageUrl);
   };

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -8,6 +8,7 @@ import { ADMIN_CONFIG, ADMIN_MESSAGES } from '@/constants/admin';
 import { UserDataService } from '@/lib/userDataService';
 import { EnhancedAuthUser, UserType } from '@/types/user';
 import { isRegistrationInProgress } from '@/lib/registrationFlowFlag';
+import { clearProfileImageCache } from '@/lib/profileImageCache';
 
 // Types
 export interface AuthUser {
@@ -244,6 +245,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const logout = async (): Promise<void> => {
     try {
       setIsLoading(true);
+      clearProfileImageCache(auth.currentUser?.uid);
       await signOut(auth);
       setUser(null);
       setShowAuthModal(false);

--- a/src/lib/__tests__/profileImageCache.test.ts
+++ b/src/lib/__tests__/profileImageCache.test.ts
@@ -1,0 +1,77 @@
+import {
+  readProfileImageCache,
+  writeProfileImageCache,
+  clearProfileImageCache,
+} from '../profileImageCache';
+
+const UID = 'user-123';
+const URL_HTTPS = 'https://firebasestorage.googleapis.com/v0/b/x/o/y.jpg';
+const URL_HTTP = 'http://example.test/x.jpg';
+
+describe('profileImageCache', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('returns undefined when nothing cached', () => {
+    expect(readProfileImageCache(UID)).toBeUndefined();
+  });
+
+  it('round-trips an https URL', () => {
+    writeProfileImageCache(UID, URL_HTTPS);
+    expect(readProfileImageCache(UID)).toBe(URL_HTTPS);
+  });
+
+  it('round-trips an http URL', () => {
+    writeProfileImageCache(UID, URL_HTTP);
+    expect(readProfileImageCache(UID)).toBe(URL_HTTP);
+  });
+
+  it('rejects non-http(s) URLs on read (legacy blob:)', () => {
+    window.localStorage.setItem('profileImageCache:v1:' + UID, 'blob:http://localhost/abc');
+    expect(readProfileImageCache(UID)).toBeUndefined();
+  });
+
+  it('writing an invalid URL clears the entry', () => {
+    writeProfileImageCache(UID, URL_HTTPS);
+    writeProfileImageCache(UID, undefined);
+    expect(readProfileImageCache(UID)).toBeUndefined();
+  });
+
+  it('writing a non-http(s) URL clears the entry', () => {
+    writeProfileImageCache(UID, URL_HTTPS);
+    writeProfileImageCache(UID, 'blob:http://localhost/abc');
+    expect(readProfileImageCache(UID)).toBeUndefined();
+  });
+
+  it('clearProfileImageCache removes the entry', () => {
+    writeProfileImageCache(UID, URL_HTTPS);
+    clearProfileImageCache(UID);
+    expect(readProfileImageCache(UID)).toBeUndefined();
+  });
+
+  it('namespaces entries per uid', () => {
+    writeProfileImageCache('a', URL_HTTPS);
+    writeProfileImageCache('b', URL_HTTP);
+    expect(readProfileImageCache('a')).toBe(URL_HTTPS);
+    expect(readProfileImageCache('b')).toBe(URL_HTTP);
+    clearProfileImageCache('a');
+    expect(readProfileImageCache('a')).toBeUndefined();
+    expect(readProfileImageCache('b')).toBe(URL_HTTP);
+  });
+
+  it('no-ops when uid is missing', () => {
+    writeProfileImageCache(undefined, URL_HTTPS);
+    expect(readProfileImageCache(undefined)).toBeUndefined();
+    expect(window.localStorage.length).toBe(0);
+  });
+
+  it('swallows storage failures (quota / disabled)', () => {
+    const original = Storage.prototype.setItem;
+    Storage.prototype.setItem = () => {
+      throw new Error('QuotaExceeded');
+    };
+    expect(() => writeProfileImageCache(UID, URL_HTTPS)).not.toThrow();
+    Storage.prototype.setItem = original;
+  });
+});

--- a/src/lib/profileImageCache.ts
+++ b/src/lib/profileImageCache.ts
@@ -1,0 +1,54 @@
+/**
+ * Profile image localStorage cache.
+ *
+ * Lets pages paint the user's avatar on first render before Firestore returns,
+ * eliminating the icon → image flicker on reload. The Firestore profileImage
+ * field acts as the authoritative source; this cache is stale-while-revalidate.
+ *
+ * Key shape: `profileImageCache:v1:{uid}` → resolved download URL.
+ * Invalidation: any time enhancedUser.profileImage differs from the cached
+ * value, overwrite. The download URL itself changes on every upload (path
+ * includes `Date.now()`), so equality of the URL string is the hash.
+ */
+
+const STORAGE_PREFIX = 'profileImageCache:v1:';
+
+function isUsable(url: string | undefined | null): url is string {
+  return typeof url === 'string' && /^https?:\/\//i.test(url);
+}
+
+function storageAvailable(): boolean {
+  return typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+}
+
+export function readProfileImageCache(uid: string | undefined): string | undefined {
+  if (!uid || !storageAvailable()) return undefined;
+  try {
+    const cached = window.localStorage.getItem(STORAGE_PREFIX + uid);
+    return isUsable(cached) ? cached : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function writeProfileImageCache(uid: string | undefined, url: string | undefined): void {
+  if (!uid || !storageAvailable()) return;
+  try {
+    if (isUsable(url)) {
+      window.localStorage.setItem(STORAGE_PREFIX + uid, url);
+    } else {
+      window.localStorage.removeItem(STORAGE_PREFIX + uid);
+    }
+  } catch {
+    // Quota exceeded or storage disabled — cache is best-effort.
+  }
+}
+
+export function clearProfileImageCache(uid: string | undefined): void {
+  if (!uid || !storageAvailable()) return;
+  try {
+    window.localStorage.removeItem(STORAGE_PREFIX + uid);
+  } catch {
+    // best-effort
+  }
+}


### PR DESCRIPTION
Adds src/lib/profileImageCache.ts (read/write/clear, http(s) URL filter, SSR-safe, swallows quota errors). Profile + Settings pages seed their profileImageUrl state from the cache so the avatar paints on first render, before Firestore returns enhancedUser.profileImage. The existing useEffect on enhancedUser.profileImage then revalidates and overwrites the cache (stale-while-revalidate). AuthContext.logout clears the entry so the next signer-in on the same device doesn't see the previous user's avatar. URL itself is the invalidation hash — upload paths include Date.now(), so any Firestore change is a different string.

10 jest tests on the cache util. Lint + full suite pass.

Closes the queued "Profile image localStorage cache" item from project_future_features.md (was deferred 2026-05-12).