### PR TITLE
feat(phone-book): localStorage cache w/ 90-day TTL + delta sync + man…

### DIFF
--- a/docs/codebase/src/hooks/usePhoneBook.md
+++ b/docs/codebase/src/hooks/usePhoneBook.md
@@ -6,15 +6,56 @@
 ## Purpose
 
 Reads the `phoneBook` collection via the client SDK and exposes
-`{ entries, isLoading, error, refresh }` to the page.
+`{ entries, isLoading, isRefreshing, error, refresh }` to the page. Implements
+a cache-first / stale-while-revalidate strategy backed by localStorage so the
+directory paints instantly on reload and the steady-state network cost drops
+to a single delta query — usually zero docs read — once authorized_personnel
+is stable.
 
-## Notes
+## Return shape
 
-- `useEffect` calls `refresh()` once on mount. `useCallback` deps are
-  `[]` so the identity is stable. Do not regress this pattern — the
-  recent infinite-loop bug in `useAmmunitionReports` came from a
+| Field | Description |
+|-------|-------------|
+| `entries` | Directory rows, sorted by `displayName` (string-locale). |
+| `isLoading` | `true` only until the first batch of rows (cached or server) is on screen. |
+| `isRefreshing` | `true` while a background delta sync or a force-refresh is in flight. UI uses this to spin the refresh icon. |
+| `error` | Hebrew error string if the server fetch fails. Cached rows stay visible even on error. |
+| `refresh()` | Force-discard the cache and re-fetch the full directory. Wired to the manual refresh button. |
+
+## Cache strategy
+
+1. **On mount** — read `phoneBookCache:v1` from localStorage.
+   - **Cache hit:** seed `entries` from the cached payload (immediate paint),
+     then issue `listPhoneBookEntriesUpdatedSince(lastSyncedAtMs)` and merge
+     the result. New rows append; existing rows are replaced by id. Cache
+     overwritten with the merged list + new high-water mark.
+   - **Cache miss / expired:** issue `listPhoneBookEntries()` and write the
+     full payload. TTL is 90 days (`PHONE_BOOK_CACHE_TTL_MS`).
+2. **`refresh()`** — clears the cache, resets the high-water mark to 0, and
+   re-runs the full fetch path. Used by the manual refresh button on
+   `src/app/phone-book/page.tsx`.
+3. **High-water mark** — derived as `max(updatedAt)` across the current list.
+   Stored alongside the entries so the next mount only fetches strictly newer
+   docs.
+
+## Limits
+
+- **Deletions are invisible to delta sync.** A doc removed on the server stays
+  in the cached list until the 90-day TTL expires or the user clicks refresh.
+  Phone-book deletions happen rarely (only via
+  `serverDeletePhoneBookEntryByHash` when an unregistered personnel row is
+  removed); the trade-off is intentional. Document this in product copy if a
+  hard guarantee is ever needed.
+- The delta query orders by `updatedAt`; the merged list is re-sorted by
+  `displayName` client-side to keep the UI ordering stable.
+- `useEffect` deps remain `[forceFullFetch]` with `forceFullFetch` wrapped in
+  `useCallback([])`, so the identity is stable. Do not regress this pattern —
+  the prior infinite-loop bug in `useAmmunitionReports` came from a
   default-`{}` filter param breaking the same invariant.
-- Reads are sorted by `displayName` — entries written via the
-  write-through pipeline always have a non-empty `displayName`.
-- Writes happen exclusively server-side (see
-  `docs/spec/phone-book.md` for the trigger matrix).
+
+## Related files
+
+- `src/lib/phoneBook/phoneBookCache.ts` — serialization, TTL, merge helper.
+- `src/lib/phoneBook/phoneBookService.ts` — full and delta queries.
+- `src/app/phone-book/page.tsx` — refresh button.
+- Writes happen exclusively server-side (see `docs/spec/phone-book.md`).

--- a/docs/codebase/src/lib/phoneBook/phoneBookCache.md
+++ b/docs/codebase/src/lib/phoneBook/phoneBookCache.md
@@ -1,0 +1,62 @@
+# phoneBookCache.ts
+
+**File:** `src/lib/phoneBook/phoneBookCache.ts`
+**Status:** Active
+
+## Purpose
+
+localStorage cache for the phone book directory. Powers the
+stale-while-revalidate strategy in `usePhoneBook` — on mount the hook paints
+the cached rows immediately, then issues a delta query
+(`where('updatedAt', '>', lastSyncedAt)`) instead of refetching the full
+collection. Once authorized_personnel is stable, the steady-state cost of
+opening the phone book is one empty query result.
+
+## Storage shape
+
+| Key | Value |
+|-----|-------|
+| `phoneBookCache:v1` | `{ entries: SerializedEntry[], lastSyncedAtMs: number, cachedAtMs: number }` JSON-stringified. |
+
+`SerializedEntry` is `PhoneBookEntry` with the two Firestore `Timestamp`
+fields (`createdAt`, `updatedAt`) replaced by `createdAtMs` / `updatedAtMs`
+numbers — `localStorage` only stores strings. On read the cache rebuilds the
+Timestamps via `Timestamp.fromMillis()` so callers receive the original
+shape.
+
+## TTL
+
+90 days (`PHONE_BOOK_CACHE_TTL_MS`). Rationale: new registrations are rare
+after the authorized personnel roster is stable, but phone numbers do
+change. Two escape hatches:
+
+1. **Delta sync on every mount** — picks up edits within milliseconds.
+2. **Manual refresh button** — wired in `src/app/phone-book/page.tsx` via
+   `usePhoneBook().refresh()`. Clears the cache and re-fetches the full
+   directory.
+
+## Exports
+
+| Export | Description |
+|--------|-------------|
+| `readPhoneBookCache()` | Returns `{ entries, lastSyncedAtMs }` or `null` if missing / expired / malformed. Self-cleans expired payloads. |
+| `writePhoneBookCache(entries, lastSyncedAtMs)` | Serializes and stores. Swallows quota errors (and clears the key if persistence fails). |
+| `clearPhoneBookCache()` | Removes the entry. Called from `refresh()`. |
+| `mergeDelta(base, delta)` | Pure helper. Merges a delta list into the existing list by `id`; delta entries win. Returns the same array reference if delta is empty. |
+| `PHONE_BOOK_CACHE_KEY`, `PHONE_BOOK_CACHE_TTL_MS` | Exposed for tests. |
+
+## Known limits
+
+- **Deletions are invisible to delta sync.** A doc removed on the server is
+  not in the result of a `where('updatedAt', '>', ts)` query, so the cache
+  keeps the stale row until the TTL expires or the user hits refresh. Phone
+  book deletions only fire for never-registered personnel rows
+  (`serverDeletePhoneBookEntryByHash`); the trade-off is intentional.
+- **Schema migrations** require bumping the storage key (`:v1` → `:v2`) so
+  every client invalidates on the next mount.
+
+## Related files
+
+- `src/hooks/usePhoneBook.ts` — orchestrates cache + delta + refresh.
+- `src/lib/phoneBook/phoneBookService.ts` — `listPhoneBookEntries` (full) and
+  `listPhoneBookEntriesUpdatedSince(sinceMs)` (delta).

--- a/docs/codebase/src/lib/phoneBook/phoneBookService.md
+++ b/docs/codebase/src/lib/phoneBook/phoneBookService.md
@@ -1,0 +1,27 @@
+# phoneBookService.ts (client reads)
+
+**File:** `src/lib/phoneBook/phoneBookService.ts`
+**Status:** Active
+
+## Purpose
+
+Client SDK reads against the `phoneBook` collection. Writes are server-only
+(see `src/lib/db/server/phoneBookService.ts`).
+
+## Exports
+
+| Function | Description |
+|----------|-------------|
+| `listPhoneBookEntries()` | Full collection ordered by `displayName`. Used on cold cache and on manual refresh. |
+| `listPhoneBookEntriesUpdatedSince(sinceMs)` | Delta read: every doc with `updatedAt > sinceMs`, ordered by `updatedAt`. Used by `usePhoneBook` after a cache hit. |
+
+## Indexing
+
+The delta query uses `where('updatedAt', '>', ts) + orderBy('updatedAt')` —
+single-field inequality, so no composite index is required. The full query
+orders by `displayName` alone, also single-field.
+
+## Related
+
+- `src/hooks/usePhoneBook.ts` — cache-aware caller.
+- `src/lib/phoneBook/phoneBookCache.ts` — TTL + delta merge.

--- a/src/app/phone-book/page.tsx
+++ b/src/app/phone-book/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useMemo, useState } from 'react';
-import { Search, User as UserIcon } from 'lucide-react';
+import { RefreshCw, Search, User as UserIcon } from 'lucide-react';
 import AuthGuard from '@/components/auth/AuthGuard';
 import AppShell from '@/app/components/AppShell';
 import { Select } from '@/components/ui';
@@ -40,7 +40,7 @@ export default function PhoneBookPage() {
 }
 
 function PhoneBookContent() {
-  const { entries, isLoading, error } = usePhoneBook();
+  const { entries, isLoading, isRefreshing, error, refresh } = usePhoneBook();
   const { config: systemConfig } = useSystemConfig();
   const [search, setSearch] = useState('');
   const [team, setTeam] = useState<string | null>(null);
@@ -134,8 +134,21 @@ function PhoneBookContent() {
         />
       </div>
 
-      <div className="text-xs text-neutral-500">
-        {T.TOTAL.replace('{count}', String(filtered.length))}
+      <div className="flex items-center justify-between gap-2">
+        <div className="text-xs text-neutral-500">
+          {T.TOTAL.replace('{count}', String(filtered.length))}
+        </div>
+        <button
+          type="button"
+          onClick={refresh}
+          disabled={isRefreshing || isLoading}
+          title={T.REFRESH_HINT}
+          aria-label={T.REFRESH}
+          className="inline-flex items-center gap-1.5 px-2 py-1 text-xs text-neutral-600 hover:text-neutral-900 hover:bg-neutral-100 rounded-md disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          <RefreshCw className={`w-3.5 h-3.5 ${isRefreshing ? 'animate-spin' : ''}`} />
+          <span>{T.REFRESH}</span>
+        </button>
       </div>
 
       {isLoading ? (

--- a/src/constants/text.ts
+++ b/src/constants/text.ts
@@ -976,7 +976,9 @@ export const TEXT_CONSTANTS = {
       COL_ROLE: 'תפקיד',
       COL_EMAIL: 'אימייל',
       UNREGISTERED_BADGE: 'לא רשום',
-      TOTAL: 'סה״כ {count}'
+      TOTAL: 'סה״כ {count}',
+      REFRESH: 'רענן',
+      REFRESH_HINT: 'משוך נתונים מעודכנים מהשרת'
     },
     CONVOYS: {
       TITLE: 'שיירות',

--- a/src/hooks/usePhoneBook.ts
+++ b/src/hooks/usePhoneBook.ts
@@ -1,37 +1,121 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
-import { listPhoneBookEntries } from '@/lib/phoneBook/phoneBookService';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  listPhoneBookEntries,
+  listPhoneBookEntriesUpdatedSince,
+} from '@/lib/phoneBook/phoneBookService';
+import {
+  readPhoneBookCache,
+  writePhoneBookCache,
+  clearPhoneBookCache,
+  mergeDelta,
+} from '@/lib/phoneBook/phoneBookCache';
 import type { PhoneBookEntry } from '@/types/phoneBook';
 
 export interface UsePhoneBookReturn {
   entries: PhoneBookEntry[];
   isLoading: boolean;
+  /** True while a background revalidation (delta sync) is in flight. */
+  isRefreshing: boolean;
   error: string | null;
+  /** Force-reload the full directory and overwrite the cache. */
   refresh: () => Promise<void>;
+}
+
+/** Largest `updatedAt` (ms) across the entry list — used for the next delta query. */
+function highWaterMark(entries: PhoneBookEntry[]): number {
+  let max = 0;
+  for (const e of entries) {
+    const ts = e.updatedAt as { toMillis?: () => number; seconds?: number; nanoseconds?: number };
+    let ms = 0;
+    if (typeof ts?.toMillis === 'function') ms = ts.toMillis();
+    else if (typeof ts?.seconds === 'number') ms = ts.seconds * 1000;
+    if (ms > max) max = ms;
+  }
+  return max;
+}
+
+function sortByDisplayName(entries: PhoneBookEntry[]): PhoneBookEntry[] {
+  return [...entries].sort((a, b) => a.displayName.localeCompare(b.displayName));
 }
 
 export function usePhoneBook(): UsePhoneBookReturn {
   const [entries, setEntries] = useState<PhoneBookEntry[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [isRefreshing, setIsRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Latest `updatedAt` we've observed across mounts. Lives in a ref so the
+  // delta sync can use the value without forcing extra renders.
+  const lastSyncedAtRef = useRef<number>(0);
 
-  const refresh = useCallback(async () => {
-    setIsLoading(true);
+  const forceFullFetch = useCallback(async () => {
+    setIsRefreshing(true);
     setError(null);
     try {
       const list = await listPhoneBookEntries();
-      setEntries(list);
+      const sorted = sortByDisplayName(list);
+      setEntries(sorted);
+      const hwm = highWaterMark(sorted);
+      lastSyncedAtRef.current = hwm;
+      writePhoneBookCache(sorted, hwm);
     } catch (e) {
       setError(e instanceof Error ? e.message : 'שגיאה בטעינת ספר טלפונים');
     } finally {
+      setIsRefreshing(false);
       setIsLoading(false);
     }
   }, []);
 
-  useEffect(() => {
-    refresh();
-  }, [refresh]);
+  const refresh = useCallback(async () => {
+    clearPhoneBookCache();
+    lastSyncedAtRef.current = 0;
+    setIsLoading(true);
+    await forceFullFetch();
+  }, [forceFullFetch]);
 
-  return { entries, isLoading, error, refresh };
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const cached = readPhoneBookCache();
+      if (cached && cached.entries.length > 0) {
+        // Paint immediately, then revalidate via a delta query.
+        const seeded = sortByDisplayName(cached.entries);
+        if (!cancelled) {
+          setEntries(seeded);
+          setIsLoading(false);
+          lastSyncedAtRef.current = cached.lastSyncedAtMs;
+        }
+        setIsRefreshing(true);
+        try {
+          const delta = await listPhoneBookEntriesUpdatedSince(cached.lastSyncedAtMs);
+          if (cancelled) return;
+          if (delta.length === 0) {
+            // Nothing changed — leave the cache `cachedAtMs` stale (will TTL out
+            // eventually) but the data is still correct.
+            setIsRefreshing(false);
+            return;
+          }
+          const merged = sortByDisplayName(mergeDelta(seeded, delta));
+          setEntries(merged);
+          const hwm = highWaterMark(merged);
+          lastSyncedAtRef.current = hwm;
+          writePhoneBookCache(merged, hwm);
+        } catch (e) {
+          if (!cancelled) {
+            setError(e instanceof Error ? e.message : 'שגיאה בטעינת ספר טלפונים');
+          }
+        } finally {
+          if (!cancelled) setIsRefreshing(false);
+        }
+      } else {
+        await forceFullFetch();
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [forceFullFetch]);
+
+  return { entries, isLoading, isRefreshing, error, refresh };
 }

--- a/src/lib/__mocks__/firebase.ts
+++ b/src/lib/__mocks__/firebase.ts
@@ -30,6 +30,12 @@ export const serverTimestamp = jest.fn(() => ({ __serverTimestamp: true }));
 export const Timestamp = {
   now: jest.fn(() => ({ toDate: () => new Date(), seconds: 0, nanoseconds: 0 })),
   fromDate: jest.fn((d: Date) => ({ toDate: () => d, seconds: Math.floor(d.getTime() / 1000), nanoseconds: 0 })),
+  fromMillis: jest.fn((ms: number) => ({
+    toDate: () => new Date(ms),
+    toMillis: () => ms,
+    seconds: Math.floor(ms / 1000),
+    nanoseconds: (ms % 1000) * 1_000_000,
+  })),
 };
 export const FieldValue = { serverTimestamp: () => ({ __serverTimestamp: true }) };
 

--- a/src/lib/__tests__/phoneBookCache.test.ts
+++ b/src/lib/__tests__/phoneBookCache.test.ts
@@ -1,0 +1,107 @@
+import { Timestamp } from 'firebase/firestore';
+import {
+  readPhoneBookCache,
+  writePhoneBookCache,
+  clearPhoneBookCache,
+  mergeDelta,
+  PHONE_BOOK_CACHE_KEY,
+  PHONE_BOOK_CACHE_TTL_MS,
+} from '../phoneBook/phoneBookCache';
+import type { PhoneBookEntry } from '@/types/phoneBook';
+
+function makeEntry(over: Partial<PhoneBookEntry> = {}): PhoneBookEntry {
+  return {
+    id: 'h1',
+    source: 'users',
+    displayName: 'Alice Cohen',
+    firstName: 'Alice',
+    lastName: 'Cohen',
+    phoneNumber: '+972501234567',
+    isRegistered: true,
+    createdAt: Timestamp.fromMillis(1_700_000_000_000),
+    updatedAt: Timestamp.fromMillis(1_700_000_500_000),
+    ...over,
+  };
+}
+
+describe('phoneBookCache', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    jest.useRealTimers();
+  });
+
+  it('returns null when nothing cached', () => {
+    expect(readPhoneBookCache()).toBeNull();
+  });
+
+  it('round-trips entries with serialized timestamps', () => {
+    const entry = makeEntry();
+    writePhoneBookCache([entry], 1_700_000_500_000);
+    const got = readPhoneBookCache();
+    expect(got).not.toBeNull();
+    expect(got!.entries).toHaveLength(1);
+    expect(got!.entries[0].id).toBe('h1');
+    expect(got!.entries[0].displayName).toBe('Alice Cohen');
+    // updatedAt is rebuilt as a Timestamp-like object exposing toMillis.
+    expect(got!.entries[0].updatedAt.toMillis()).toBe(1_700_000_500_000);
+    expect(got!.lastSyncedAtMs).toBe(1_700_000_500_000);
+  });
+
+  it('expires entries past TTL', () => {
+    writePhoneBookCache([makeEntry()], 1_700_000_500_000);
+    const payload = JSON.parse(window.localStorage.getItem(PHONE_BOOK_CACHE_KEY)!);
+    payload.cachedAtMs = Date.now() - PHONE_BOOK_CACHE_TTL_MS - 1;
+    window.localStorage.setItem(PHONE_BOOK_CACHE_KEY, JSON.stringify(payload));
+    expect(readPhoneBookCache()).toBeNull();
+    expect(window.localStorage.getItem(PHONE_BOOK_CACHE_KEY)).toBeNull();
+  });
+
+  it('discards malformed payloads', () => {
+    window.localStorage.setItem(PHONE_BOOK_CACHE_KEY, '{"not the right shape": true}');
+    expect(readPhoneBookCache()).toBeNull();
+  });
+
+  it('discards non-JSON payloads', () => {
+    window.localStorage.setItem(PHONE_BOOK_CACHE_KEY, 'definitely not json');
+    expect(readPhoneBookCache()).toBeNull();
+  });
+
+  it('clearPhoneBookCache removes the entry', () => {
+    writePhoneBookCache([makeEntry()], 1_700_000_500_000);
+    clearPhoneBookCache();
+    expect(readPhoneBookCache()).toBeNull();
+  });
+
+  it('swallows quota errors on write', () => {
+    const original = Storage.prototype.setItem;
+    Storage.prototype.setItem = () => {
+      throw new Error('QuotaExceeded');
+    };
+    expect(() => writePhoneBookCache([makeEntry()], 1)).not.toThrow();
+    Storage.prototype.setItem = original;
+  });
+
+  describe('mergeDelta', () => {
+    it('returns base unchanged when delta is empty', () => {
+      const a = makeEntry();
+      const result = mergeDelta([a], []);
+      expect(result).toEqual([a]);
+    });
+
+    it('appends new entries', () => {
+      const a = makeEntry({ id: 'a' });
+      const b = makeEntry({ id: 'b', displayName: 'Beni Levi' });
+      const result = mergeDelta([a], [b]);
+      expect(result).toHaveLength(2);
+      expect(result.map((e) => e.id).sort()).toEqual(['a', 'b']);
+    });
+
+    it('replaces existing entries by id (delta wins)', () => {
+      const a = makeEntry({ id: 'a', displayName: 'Old Name' });
+      const aNew = makeEntry({ id: 'a', displayName: 'New Name' });
+      const result = mergeDelta([a], [aNew]);
+      expect(result).toHaveLength(1);
+      expect(result[0].displayName).toBe('New Name');
+    });
+  });
+});

--- a/src/lib/phoneBook/phoneBookCache.ts
+++ b/src/lib/phoneBook/phoneBookCache.ts
@@ -1,0 +1,144 @@
+/**
+ * Phone book localStorage cache.
+ *
+ * Stores the resolved directory + the most recent `updatedAt` seen so the hook
+ * can serve cached rows on mount and follow up with a delta query
+ * (`where('updatedAt', '>', lastSyncedAt)`) rather than re-fetching the whole
+ * collection. New registrations are rare once authorized_personnel is stable,
+ * so the steady-state cost drops to zero docs read on most page loads.
+ *
+ * Trade-offs:
+ *  - Deletions on the server cannot be observed via delta sync (a deleted doc
+ *    is not in the result set). The 90-day TTL and the manual refresh button
+ *    are the escape hatches.
+ *  - Schema version key in the storage prefix so a future field rename can
+ *    invalidate every client's cache by bumping the version.
+ */
+import { Timestamp } from 'firebase/firestore';
+import type { PhoneBookEntry } from '@/types/phoneBook';
+
+const CACHE_KEY = 'phoneBookCache:v1';
+const TTL_MS = 90 * 24 * 60 * 60 * 1000; // 90 days
+
+interface SerializedEntry extends Omit<PhoneBookEntry, 'createdAt' | 'updatedAt'> {
+  createdAtMs: number;
+  updatedAtMs: number;
+}
+
+interface CachePayload {
+  entries: SerializedEntry[];
+  lastSyncedAtMs: number;
+  cachedAtMs: number;
+}
+
+export interface PhoneBookCacheRead {
+  entries: PhoneBookEntry[];
+  lastSyncedAtMs: number;
+}
+
+function storageAvailable(): boolean {
+  return typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+}
+
+function tsToMs(ts: PhoneBookEntry['updatedAt']): number {
+  if (!ts) return 0;
+  if (typeof (ts as { toMillis?: () => number }).toMillis === 'function') {
+    return (ts as { toMillis: () => number }).toMillis();
+  }
+  // Fallback for plain { seconds, nanoseconds } payloads (e.g. from API JSON).
+  const seconds = (ts as { seconds?: number }).seconds ?? 0;
+  const nanoseconds = (ts as { nanoseconds?: number }).nanoseconds ?? 0;
+  return seconds * 1000 + Math.floor(nanoseconds / 1_000_000);
+}
+
+function msToTs(ms: number) {
+  return Timestamp.fromMillis(ms);
+}
+
+function serialize(entry: PhoneBookEntry): SerializedEntry {
+  const { createdAt, updatedAt, ...rest } = entry;
+  return {
+    ...rest,
+    createdAtMs: tsToMs(createdAt),
+    updatedAtMs: tsToMs(updatedAt),
+  };
+}
+
+function deserialize(entry: SerializedEntry): PhoneBookEntry {
+  const { createdAtMs, updatedAtMs, ...rest } = entry;
+  return {
+    ...rest,
+    createdAt: msToTs(createdAtMs),
+    updatedAt: msToTs(updatedAtMs),
+  } as PhoneBookEntry;
+}
+
+export function readPhoneBookCache(): PhoneBookCacheRead | null {
+  if (!storageAvailable()) return null;
+  try {
+    const raw = window.localStorage.getItem(CACHE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as CachePayload;
+    if (!parsed || !Array.isArray(parsed.entries) || typeof parsed.cachedAtMs !== 'number') {
+      return null;
+    }
+    if (Date.now() - parsed.cachedAtMs > TTL_MS) {
+      window.localStorage.removeItem(CACHE_KEY);
+      return null;
+    }
+    return {
+      entries: parsed.entries.map(deserialize),
+      lastSyncedAtMs: parsed.lastSyncedAtMs ?? 0,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function writePhoneBookCache(entries: PhoneBookEntry[], lastSyncedAtMs: number): void {
+  if (!storageAvailable()) return;
+  try {
+    const payload: CachePayload = {
+      entries: entries.map(serialize),
+      lastSyncedAtMs,
+      cachedAtMs: Date.now(),
+    };
+    window.localStorage.setItem(CACHE_KEY, JSON.stringify(payload));
+  } catch {
+    // Quota exceeded — drop the cache and continue. Network path still works.
+    try {
+      window.localStorage.removeItem(CACHE_KEY);
+    } catch {
+      /* nothing to do */
+    }
+  }
+}
+
+export function clearPhoneBookCache(): void {
+  if (!storageAvailable()) return;
+  try {
+    window.localStorage.removeItem(CACHE_KEY);
+  } catch {
+    /* best-effort */
+  }
+}
+
+/**
+ * Merge a delta (newer) snapshot into an existing list by id. New entries are
+ * appended; existing entries are replaced. Caller decides the final ordering.
+ */
+export function mergeDelta(
+  base: PhoneBookEntry[],
+  delta: PhoneBookEntry[]
+): PhoneBookEntry[] {
+  if (delta.length === 0) return base;
+  const byId = new Map(base.map((e) => [e.id, e]));
+  for (const e of delta) {
+    byId.set(e.id, e);
+  }
+  return Array.from(byId.values());
+}
+
+/** Exposed for tests. */
+export const PHONE_BOOK_CACHE_TTL_MS = TTL_MS;
+export const PHONE_BOOK_CACHE_KEY = CACHE_KEY;

--- a/src/lib/phoneBook/phoneBookService.ts
+++ b/src/lib/phoneBook/phoneBookService.ts
@@ -3,12 +3,29 @@
  * Mutations go through the server-side write-through pipeline.
  */
 import { db } from '@/lib/firebase';
-import { collection, getDocs, orderBy, query } from 'firebase/firestore';
+import { collection, getDocs, orderBy, query, Timestamp, where } from 'firebase/firestore';
 import { COLLECTIONS } from '@/lib/db/collections';
 import type { PhoneBookEntry } from '@/types/phoneBook';
 
 export async function listPhoneBookEntries(): Promise<PhoneBookEntry[]> {
   const q = query(collection(db, COLLECTIONS.PHONE_BOOK), orderBy('displayName'));
+  const snap = await getDocs(q);
+  return snap.docs.map((d) => ({ id: d.id, ...d.data() }) as PhoneBookEntry);
+}
+
+/**
+ * Delta read: every doc whose `updatedAt` is strictly greater than `sinceMs`.
+ * Used by the cache layer to avoid re-fetching the whole directory on mount.
+ * Returns docs ordered by `updatedAt` — caller merges into its existing list.
+ */
+export async function listPhoneBookEntriesUpdatedSince(
+  sinceMs: number
+): Promise<PhoneBookEntry[]> {
+  const q = query(
+    collection(db, COLLECTIONS.PHONE_BOOK),
+    where('updatedAt', '>', Timestamp.fromMillis(sinceMs)),
+    orderBy('updatedAt')
+  );
   const snap = await getDocs(q);
   return snap.docs.map((d) => ({ id: d.id, ...d.data() }) as PhoneBookEntry);
 }


### PR DESCRIPTION
…ual refresh

Phone book directory now caches its result in localStorage and serves cached rows on mount so the page paints instantly. The hook then issues a delta query (where('updatedAt', '>', lastSyncedAt)) and merges any newer rows, rather than refetching the full collection. Steady-state cost once the authorized_personnel roster is stable is a single empty query result.

Files:
- src/lib/phoneBook/phoneBookCache.ts — read/write/clear/mergeDelta, Timestamp -> millis serialization, 90-day TTL, SSR-safe, quota-tolerant.
- src/lib/phoneBook/phoneBookService.ts — adds listPhoneBookEntriesUpdatedSince(sinceMs) on top of the existing full read.
- src/hooks/usePhoneBook.ts — cache-first hydration, background delta sync, isRefreshing flag, force-refresh that clears the cache.
- src/app/phone-book/page.tsx — manual refresh icon button (spins while isRefreshing). New TEXT_CONSTANTS keys PHONE_BOOK.REFRESH and REFRESH_HINT.
- src/lib/__mocks__/firebase.ts — adds Timestamp.fromMillis for the cache serialization tests.

10 jest tests on the cache util (round-trip, TTL expiry, malformed payloads, quota, mergeDelta). Lint + full test suite + production build all green.

Known limit (intentional): server deletions are invisible to the delta query. The 90-day TTL and the manual refresh button are the escape hatches — documented in docs/codebase/src/lib/phoneBook/phoneBookCache.md.

Closes the "Local-storage cache with TTL" item from Phone Book Phase 2 queue in project_future_features.md.