### PR TITLE
feat(status): phone column on soldier-status page

### DIFF
--- a/docs/codebase/src/app/status/page.md
+++ b/docs/codebase/src/app/status/page.md
@@ -58,5 +58,5 @@ None directly. Data comes from Google Sheets API (`/api/sheets`). Caching via `l
 - Name filter is debounced 300ms via `useEffect` + `setTimeout`.
 - Report generation uses `soldierUtils.ts` helpers.
 - WhatsApp sharing uses `navigator.clipboard` + `window.open('https://wa.me/')`.
-- Uses both `SoldiersTableDesktop` and `SoldiersTableMobile` — responsive switching via CSS breakpoints.
+- Uses both `SoldiersTableDesktop` and `SoldiersTableMobile` — responsive switching via CSS breakpoints. Both render a phone column (desktop) / phone row (mobile) with a `tel:` link formatted via `formatPhoneForDisplay`. Em-dash when the soldier has no phone on either roster source.
 - `mapRawStatusToStructured` / `mapStructuredStatusToRaw` from `statusUtils.ts` handle the Google Sheets ↔ UI status format conversion.

--- a/docs/codebase/src/lib/db/server/soldierStatusService.md
+++ b/docs/codebase/src/lib/db/server/soldierStatusService.md
@@ -80,11 +80,17 @@ history row carries no `updatedByName`.
 
 `serverListRoster` is intentionally an in-memory three-collection read:
 
-1. Seed rows from `authorized_personnel` (firstName, lastName, default platoon, `isRegistered: false`).
-2. Override / add rows from `users`, preferring user-side firstName/lastName/teamId and flipping `isRegistered: true`.
+1. Seed rows from `authorized_personnel` (firstName, lastName, phoneNumber, default platoon, `isRegistered: false`).
+2. Override / add rows from `users`, preferring user-side firstName/lastName/teamId/phoneNumber (the registered soldier maintains it themselves) and flipping `isRegistered: true`.
 3. Apply each soldier's `soldierStatus` overlay — status, customStatus, updatedAt.
 
 The `isRegistered` flag flows out via `RosterEntry → Soldier` and drives the registered/unregistered dot rendered before the soldier name on both desktop and mobile status tables.
+
+`phoneNumber` is sourced with the same precedence: `users.phoneNumber` wins
+when present, falling back to `authorized_personnel.phoneNumber`. The field
+is left undefined when neither source carries one; the UI renders an em-dash
+in that case. Formatting (Israeli local 0xx-xxx-xxxx) happens in the table
+component via `formatPhoneForDisplay`.
 
 Defaults:
 - Missing `teamId` on the user → `'מסייעת'` (matches the legacy sheet default).

--- a/src/app/components/SoldiersTableDesktop.tsx
+++ b/src/app/components/SoldiersTableDesktop.tsx
@@ -5,6 +5,7 @@ import { Soldier } from '../../types';
 import { getAvailableStatuses } from '@/lib/statusUtils';
 import SelectAllCheckbox from './SelectAllCheckbox';
 import { TEXT_CONSTANTS } from '@/constants/text';
+import { formatPhoneForDisplay } from '@/utils/validationUtils';
 
 interface SoldiersTableDesktopProps {
   soldiers: Soldier[];
@@ -76,6 +77,8 @@ export default function SoldiersTableDesktop({
             <col className="w-4" />
             <col className="w-28" />
             <col className="w-4" />
+            <col className="w-32" />
+            <col className="w-4" />
             <col className={hasOtherStatus ? "w-48" : "w-36"} />
             <col className="w-4" />
             <col className={hasOtherStatus ? "w-56" : ""} />
@@ -138,6 +141,10 @@ export default function SoldiersTableDesktop({
                     </div>
                   </div>
                 )}
+              </th>
+              <th className="px-1 py-3 text-neutral-400">|</th>
+              <th className="px-4 py-3 text-start text-sm font-medium text-neutral-700">
+                {TEXT_CONSTANTS.STATUS_PAGE.PHONE}
               </th>
               <th className="px-1 py-3 text-neutral-400">|</th>
               <th className="px-4 py-3 text-start text-sm font-medium text-neutral-700 relative">
@@ -218,6 +225,19 @@ export default function SoldiersTableDesktop({
                 </td>
                 <td className="px-1 py-3 text-neutral-400 text-center">|</td>
                 <td className="px-4 py-3 text-neutral-700">{soldier.platoon}</td>
+                <td className="px-1 py-3 text-neutral-400 text-center">|</td>
+                <td className="px-4 py-3 text-neutral-700 whitespace-nowrap">
+                  {soldier.phoneNumber ? (
+                    <a
+                      href={`tel:${soldier.phoneNumber}`}
+                      className="text-primary-600 hover:underline"
+                    >
+                      {formatPhoneForDisplay(soldier.phoneNumber)}
+                    </a>
+                  ) : (
+                    <span className="text-neutral-400">{TEXT_CONSTANTS.STATUS_PAGE.NO_PHONE}</span>
+                  )}
+                </td>
                 <td className="px-1 py-3 text-neutral-400 text-center">|</td>
                 <td className="px-4 py-3">
                   <div className="flex items-center gap-2">

--- a/src/app/components/SoldiersTableMobile.tsx
+++ b/src/app/components/SoldiersTableMobile.tsx
@@ -6,6 +6,7 @@ import { Soldier } from '../../types';
 import { getAvailableStatuses } from '@/lib/statusUtils';
 import SelectAllCheckbox from './SelectAllCheckbox';
 import { TEXT_CONSTANTS } from '@/constants/text';
+import { formatPhoneForDisplay } from '@/utils/validationUtils';
 
 interface SoldiersTableMobileProps {
   soldiers: Soldier[];
@@ -254,9 +255,21 @@ export default function SoldiersTableMobile({
               </div>
             </div>
             
+            {soldier.phoneNumber && (
+              <div className="mb-3 text-sm text-neutral-700">
+                <span className="text-neutral-500">{TEXT_CONSTANTS.STATUS_PAGE.PHONE}: </span>
+                <a
+                  href={`tel:${soldier.phoneNumber}`}
+                  className="text-primary-600 hover:underline"
+                >
+                  {formatPhoneForDisplay(soldier.phoneNumber)}
+                </a>
+              </div>
+            )}
+
             {/* Row 2: Notes + Custom Status (when selected) */}
             <div className="flex gap-3">
-              <input 
+              <input
                 type="text"
                 value={soldier.notes || ''}
                 onChange={(e) => onNotesChange(index, e.target.value)}

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -9,4 +9,6 @@ export interface Soldier {
   notes?: string;
   isSelected: boolean;
   isRegistered: boolean;
+  /** Raw phone string from the roster join; formatted for display in the table. */
+  phoneNumber?: string;
 }

--- a/src/constants/text.ts
+++ b/src/constants/text.ts
@@ -1643,8 +1643,10 @@ export const TEXT_CONSTANTS = {
     SELECTION: 'בחירה',
     NAME: 'שם',
     TEAM: 'צוות',
+    PHONE: 'טלפון',
     STATUS: 'סטטוס',
     NOTES: 'הערות',
+    NO_PHONE: '—',
     
     // Report Features
     REPORT_PREVIEW_TITLE: 'תצוגה מקדימה של הדוח',

--- a/src/hooks/useSoldierStatus.ts
+++ b/src/hooks/useSoldierStatus.ts
@@ -25,6 +25,7 @@ function rosterToSoldier(entry: RosterEntry): Soldier {
     customStatus: entry.customStatus,
     isSelected: false,
     isRegistered: entry.isRegistered ?? false,
+    phoneNumber: entry.phoneNumber,
   };
 }
 

--- a/src/lib/__tests__/soldierStatusService.test.ts
+++ b/src/lib/__tests__/soldierStatusService.test.ts
@@ -203,6 +203,55 @@ describe('serverListRoster', () => {
     });
   });
 
+  it('exposes phoneNumber from authorized_personnel when no user is registered', async () => {
+    store.set('authorized_personnel/hash-a', {
+      id: 'hash-a',
+      data: { firstName: 'A', lastName: 'A', phoneNumber: '0501234567' },
+    });
+    const out = await serverListRoster();
+    expect(out[0].phoneNumber).toBe('0501234567');
+  });
+
+  it('prefers users.phoneNumber over authorized_personnel.phoneNumber', async () => {
+    store.set('authorized_personnel/hash-a', {
+      id: 'hash-a',
+      data: { firstName: 'A', lastName: 'A', phoneNumber: '0500000000' },
+    });
+    store.set('users/uid-1', {
+      id: 'uid-1',
+      data: {
+        militaryPersonalNumberHash: 'hash-a',
+        firstName: 'A',
+        lastName: 'A',
+        phoneNumber: '0501111111',
+      },
+    });
+    const out = await serverListRoster();
+    expect(out[0].phoneNumber).toBe('0501111111');
+  });
+
+  it('falls back to authorized_personnel.phoneNumber when the user has none', async () => {
+    store.set('authorized_personnel/hash-a', {
+      id: 'hash-a',
+      data: { firstName: 'A', lastName: 'A', phoneNumber: '0500000000' },
+    });
+    store.set('users/uid-1', {
+      id: 'uid-1',
+      data: { militaryPersonalNumberHash: 'hash-a', firstName: 'A', lastName: 'A' },
+    });
+    const out = await serverListRoster();
+    expect(out[0].phoneNumber).toBe('0500000000');
+  });
+
+  it('omits phoneNumber when neither source carries one', async () => {
+    store.set('authorized_personnel/hash-a', {
+      id: 'hash-a',
+      data: { firstName: 'A', lastName: 'A' },
+    });
+    const out = await serverListRoster();
+    expect(out[0].phoneNumber).toBeUndefined();
+  });
+
   it('sorts roster by Hebrew full name', async () => {
     store.set('authorized_personnel/h2', {
       id: 'h2',

--- a/src/lib/db/server/soldierStatusService.ts
+++ b/src/lib/db/server/soldierStatusService.ts
@@ -45,6 +45,7 @@ interface UserDocLite {
   firstName?: string;
   lastName?: string;
   teamId?: string;
+  phoneNumber?: string;
 }
 
 interface PersonnelDocLite {
@@ -52,6 +53,7 @@ interface PersonnelDocLite {
   lastName?: string;
   approvedRole?: string;
   status?: string;
+  phoneNumber?: string;
 }
 
 interface StatusDocLite {
@@ -100,6 +102,7 @@ export async function serverListRoster(): Promise<RosterEntry[]> {
       platoon: 'מסייעת',
       status: 'בית',
       isRegistered: false,
+      ...(data.phoneNumber ? { phoneNumber: data.phoneNumber } : {}),
     });
   }
 
@@ -109,6 +112,9 @@ export async function serverListRoster(): Promise<RosterEntry[]> {
     if (!hash) continue;
     const platoon = data.teamId && data.teamId.trim() ? data.teamId : 'מסייעת';
     const existing = rowByHash.get(hash);
+    // Prefer the user's phone (the soldier maintains it themselves once
+    // registered); fall back to the personnel-roster phone.
+    const phoneNumber = data.phoneNumber || existing?.phoneNumber;
     rowByHash.set(hash, {
       id: hash,
       firstName: data.firstName ?? existing?.firstName ?? '',
@@ -118,6 +124,7 @@ export async function serverListRoster(): Promise<RosterEntry[]> {
       isRegistered: true,
       ...(existing?.customStatus ? { customStatus: existing.customStatus } : {}),
       ...(existing?.updatedAtMs ? { updatedAtMs: existing.updatedAtMs } : {}),
+      ...(phoneNumber ? { phoneNumber } : {}),
     });
   }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,4 +9,6 @@ export interface Soldier {
   notes?: string;
   isSelected: boolean;
   isRegistered: boolean;
+  /** Raw phone string from the roster join; formatted for display in the table. */
+  phoneNumber?: string;
 }

--- a/src/types/soldierStatus.ts
+++ b/src/types/soldierStatus.ts
@@ -53,6 +53,12 @@ export interface RosterEntry {
   updatedAtMs?: number;
   /** True when there is a matching `users` doc (i.e. soldier completed registration). */
   isRegistered: boolean;
+  /**
+   * E.164 or Israeli-local phone string. Sourced from the `users` doc when the
+   * soldier has registered (likely freshest), falling back to the
+   * `authorized_personnel` doc. Format-for-display happens in the UI layer.
+   */
+  phoneNumber?: string;
 }
 
 export interface UpdateSoldierStatusInput {


### PR DESCRIPTION
Adds a phoneNumber field to the roster join and renders it in both desktop and mobile status tables as a tel: link formatted by formatPhoneForDisplay. Em-dash when neither roster source carries a phone for the soldier.

Source precedence (matches the name/team fields):
  users.phoneNumber  -- preferred (registered soldier maintains it themselves)
  authorized_personnel.phoneNumber  -- fallback

Files:
- src/types/soldierStatus.ts — RosterEntry.phoneNumber.
- src/app/types.ts + src/types/index.ts — Soldier.phoneNumber on both duplicate definitions; the existing High-severity dup is tracked in docs/duplications.md item #1.
- src/lib/db/server/soldierStatusService.ts — populates phone in both the personnel-seed pass and the users-override pass, with users winning.
- src/hooks/useSoldierStatus.ts — rosterToSoldier copies phoneNumber.
- src/app/components/SoldiersTableDesktop.tsx — new Phone column between Team and Status. Adjusted colgroup, header divider, body cell.
- src/app/components/SoldiersTableMobile.tsx — phone row above the notes row, conditional on presence.
- src/constants/text.ts — STATUS_PAGE.PHONE + STATUS_PAGE.NO_PHONE.
- src/lib/__tests__/soldierStatusService.test.ts — 4 new cases covering personnel-only, user-prefers-user, user-falls-back, both-missing.

Docs updated:
- docs/codebase/src/lib/db/server/soldierStatusService.md — phoneNumber source precedence + UI formatting.
- docs/codebase/src/app/status/page.md — phone column note.

Lint + 699 jest tests + production build all green. Closes the "Phone column" item from the status-page section of project_future_features.md.