### PR TITLE
feat(settings): account activity view

### DIFF
--- a/docs/codebase/src/app/api/auth/audit/route.md
+++ b/docs/codebase/src/app/api/auth/audit/route.md
@@ -1,11 +1,15 @@
-# POST /api/auth/audit
+# /api/auth/audit
 
 **File:** `src/app/api/auth/audit/route.ts`
-**Status:** Active (Settings PR-D)
+**Status:** Active (Settings PR-D + Account Activity follow-up)
 
 ## Purpose
 
-Single entry point for clients to log a credential-change event to `credentialAuditLog`. Backed by `writeCredentialAuditEvent` in `credentialAuditService.ts`.
+Entry point for the credential audit log. POST appends an event; GET reads recent events. Both are backed by `credentialAuditService.ts` (admin SDK; client reads are denied at the Firestore rules layer).
+
+# POST /api/auth/audit
+
+Logs a credential-change event to `credentialAuditLog`. Backed by `writeCredentialAuditEvent` in `credentialAuditService.ts`.
 
 ## Request
 
@@ -35,8 +39,42 @@ The route captures IP + User-Agent from the request headers — the client canno
 - 403 — caller is not the target and not elevated.
 - 500 — write failure.
 
+# GET /api/auth/audit
+
+Returns recent audit entries for the caller (default) or any user (when elevated). Backed by `listCredentialAuditForUser`.
+
+## Request
+
+```
+GET /api/auth/audit?uid=<uid>&limit=<n>
+Authorization: Bearer <idToken>
+```
+
+Both query params are optional. `uid` defaults to the actor; `limit` defaults to 25 and is clamped server-side to a max of 100. Response shape:
+
+```
+{ success: true, entries: Array<CredentialAuditEntry & { id: string }> }
+```
+
+Entries include `ip` and `userAgent` so the user can recognise unfamiliar devices in the Account Activity section. Plaintext old/new phone numbers are never returned — only SHA-256 hashes via `metadata`.
+
+## Authorization
+
+- Bearer token required via `getActorOrError`.
+- Caller reads their OWN audit log by default.
+- ADMIN / SYSTEM_MANAGER may pass `?uid=<other>` to read another user's log.
+- Non-elevated cross-uid → 403.
+
+## Failure modes
+
+- 400 — `limit` is not a positive integer.
+- 401 — missing or invalid bearer token.
+- 403 — caller is not the target and not elevated.
+- 500 — read failure.
+
 ## Related
 
 - Service: `src/lib/db/server/credentialAuditService.ts`
-- Client wrapper: `src/lib/credentialAuditClient.ts`
+- Client wrapper: `src/lib/credentialAuditClient.ts` (`logCredentialAuditEvent` + `fetchCredentialAuditLog`)
+- UI surface: `src/components/settings/AccountActivitySection.tsx`
 - Settings PR plan: `project_settings_page.md` PR-D.

--- a/docs/codebase/src/app/settings/page.md
+++ b/docs/codebase/src/app/settings/page.md
@@ -23,6 +23,7 @@ Settings page (`/settings`). Provides a comprehensive settings UI covering profi
 ## Wired actions (real backend)
 
 - **Change password** — opens `<ChangePasswordModal>` (`src/components/settings/ChangePasswordModal.tsx`). Re-authenticates via Firebase, then `updatePassword`. Success → toast via `useToast`. Errors mapped through `mapFirebaseAuthError`. See PR-B in `project_settings_page.md`.
+- **Account activity** — `<AccountActivitySection>` renders a collapsible read of the user's `credentialAuditLog` via `GET /api/auth/audit`. Shows event kind, timestamp, actor (self / admin), IP, and User-Agent. See `docs/codebase/src/components/settings/AccountActivitySection.md`.
 
 ## Known Issues / TODO
 

--- a/docs/codebase/src/components/settings/AccountActivitySection.md
+++ b/docs/codebase/src/components/settings/AccountActivitySection.md
@@ -1,0 +1,41 @@
+# AccountActivitySection.tsx
+
+**File:** `src/components/settings/AccountActivitySection.tsx`
+**Status:** Active (Settings — Account Activity follow-up to PR-D)
+
+## Purpose
+
+Surfaces the signed-in user's `credentialAuditLog` inside the Settings page as a collapsible Headless UI `Disclosure`. The credential audit log is otherwise invisible to the user — this section is the user-facing read path for entries written by PR-B (`PASSWORD_CHANGED`), PR-C (`PHONE_CHANGED`), and PR-G (`ACCOUNT_DELETION_*`).
+
+## Data flow
+
+1. On mount (once `enhancedUser.uid` is known) calls `fetchCredentialAuditLog({ limit: 25 })` from `src/lib/credentialAuditClient.ts`.
+2. The client wrapper calls `GET /api/auth/audit` (bearer-authed via `apiFetch`).
+3. Server scopes the read to `actor.uid` and returns newest-first entries from `listCredentialAuditForUser`.
+4. Component renders one row per entry with: event icon (lucide-react, per `EVENT_ICON` map), Hebrew label (per `EVENT_LABEL` map → `TEXT_CONSTANTS.SETTINGS.ACCOUNT_EVENT_*`), actor label (self vs. admin), formatted `he-IL` timestamp, and the `ip` + `userAgent` fields verbatim.
+
+## States
+
+| Branch | Trigger | Renders |
+|--------|---------|---------|
+| Loading (cold) | `loading && entries === null` | `ACCOUNT_ACTIVITY_LOADING` |
+| Error | `error !== null` | error banner + retry button (`ACCOUNT_ACTIVITY_ERROR`/`RETRY`) |
+| Empty | `entries.length === 0` | `ACCOUNT_ACTIVITY_EMPTY` |
+| Populated | otherwise | divided `<ul>` of `<ActivityRow>` |
+
+A spinning `RefreshCwIcon` button in the header allows manual reload regardless of state (disabled while in-flight). The disclosure header carries the entry count when known.
+
+## Why ip + UA are surfaced to the user
+
+This is intentional. The point of the section is to let the user spot foreign devices / sessions on their own account. Plaintext phone numbers are never returned (PR-C stores only SHA-256 hashes in `metadata`), so `metadata` is currently elided from the UI.
+
+## Bilingual
+
+Every visible string is keyed under `TEXT_CONSTANTS.SETTINGS.ACCOUNT_ACTIVITY_*` / `ACCOUNT_EVENT_*` (Hebrew) with mirrored entries in `TEXT_EN.SETTINGS.*` per `feedback_bilingual_text`.
+
+## Related
+
+- API: `docs/codebase/src/app/api/auth/audit/route.md` (GET section).
+- Client wrapper: `src/lib/credentialAuditClient.ts` (`fetchCredentialAuditLog`).
+- Service: `src/lib/db/server/credentialAuditService.ts` (`listCredentialAuditForUser`).
+- Settings rollout: `project_settings_page.md`.

--- a/docs/codebase/src/lib/credentialAuditClient.md
+++ b/docs/codebase/src/lib/credentialAuditClient.md
@@ -1,0 +1,32 @@
+# credentialAuditClient.ts
+
+**File:** `src/lib/credentialAuditClient.ts`
+**Status:** Active (Settings PR-D + Account Activity follow-up)
+
+## Purpose
+
+Browser-side wrapper for the credential audit API. Two exports:
+
+| Export | Direction | Error policy |
+|--------|-----------|--------------|
+| `logCredentialAuditEvent(args)` | POST `/api/auth/audit` | Fire-and-forget; logs failures via `console.warn` so audit never blocks the primary action. |
+| `fetchCredentialAuditLog({ uid?, limit? })` | GET `/api/auth/audit` | Throws on failure; the UI surfaces a retry. |
+
+Both go through `apiFetch` so the bearer token is attached automatically.
+
+## fetchCredentialAuditLog
+
+Returns `CredentialAuditEntryWithId[]` (newest-first). With no args, scopes to the caller. Elevated callers (ADMIN / SYSTEM_MANAGER) may pass `uid` to read another user's log. `limit` defaults to the server's value (25) and is clamped server-side to 100.
+
+## Consumers
+
+- `src/components/settings/AccountActivitySection.tsx` — drives the Account Activity disclosure on the Settings page.
+- `src/components/settings/ChangePasswordModal.tsx` → `logCredentialAuditEvent({ eventType: 'PASSWORD_CHANGED' })` on success.
+- PR-C phone-change confirm route writes `PHONE_CHANGED` server-side directly (no client log).
+- PR-G account deletion writes `ACCOUNT_DELETION_*` server-side directly.
+
+## Related
+
+- Route: `docs/codebase/src/app/api/auth/audit/route.md`
+- Service: `src/lib/db/server/credentialAuditService.ts`
+- Type: `src/types/credentialAudit.ts`

--- a/src/app/api/auth/audit/__tests__/route.test.ts
+++ b/src/app/api/auth/audit/__tests__/route.test.ts
@@ -1,0 +1,114 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for GET /api/auth/audit — the credential-audit read endpoint.
+ *
+ * Verifies bearer-auth requirement, self-scope default, elevation check
+ * for cross-uid reads, and limit param parsing/clamping.
+ *
+ * Node env is required because the route imports `next/server`, which
+ * touches the global `Request` constructor (jsdom omits it).
+ */
+
+import { UserType } from '@/types/user';
+
+jest.mock('firebase-admin/firestore', () => ({
+  FieldValue: { serverTimestamp: () => 'SERVER_TIMESTAMP' },
+}));
+
+jest.mock('firebase-admin/app', () => ({
+  initializeApp: () => ({}),
+  getApps: () => [],
+  cert: () => ({}),
+  applicationDefault: () => ({}),
+}));
+
+jest.mock('@/lib/db/admin', () => ({
+  getAdminAuth: jest.fn(),
+  getAdminDb: jest.fn(),
+}));
+
+const listMock = jest.fn();
+jest.mock('@/lib/db/server/credentialAuditService', () => ({
+  writeCredentialAuditEvent: jest.fn(),
+  listCredentialAuditForUser: (uid: string, limit?: number) => listMock(uid, limit),
+}));
+
+let actorOverride: { uid: string; userType: UserType } | null = null;
+jest.mock('@/lib/db/server/auth', () => {
+  const { NextResponse } = jest.requireActual('next/server');
+  return {
+    getActorOrError: jest.fn(async () => {
+      if (!actorOverride) {
+        return NextResponse.json({ success: false, error: 'unauth' }, { status: 401 });
+      }
+      return { ...actorOverride, grants: [] };
+    }),
+  };
+});
+
+import { GET } from '../route';
+
+function makeRequest(url: string): Request {
+  return new Request(url, { headers: { Authorization: 'Bearer fake' } });
+}
+
+beforeEach(() => {
+  listMock.mockReset();
+  listMock.mockResolvedValue([
+    { id: 'a1', uid: 'self-uid', eventType: 'PASSWORD_CHANGED' },
+  ]);
+  actorOverride = null;
+});
+
+describe('GET /api/auth/audit', () => {
+  it('returns 401 when actor unauthenticated', async () => {
+    const res = await GET(makeRequest('http://x/api/auth/audit'));
+    expect(res.status).toBe(401);
+  });
+
+  it('defaults to actor.uid + default limit', async () => {
+    actorOverride = { uid: 'self-uid', userType: UserType.USER };
+    const res = await GET(makeRequest('http://x/api/auth/audit'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.entries).toHaveLength(1);
+    expect(listMock).toHaveBeenCalledWith('self-uid', 25);
+  });
+
+  it('honours an explicit limit, clamped to 100', async () => {
+    actorOverride = { uid: 'self-uid', userType: UserType.USER };
+    await GET(makeRequest('http://x/api/auth/audit?limit=5'));
+    expect(listMock).toHaveBeenLastCalledWith('self-uid', 5);
+    await GET(makeRequest('http://x/api/auth/audit?limit=99999'));
+    expect(listMock).toHaveBeenLastCalledWith('self-uid', 100);
+  });
+
+  it('rejects non-positive limit', async () => {
+    actorOverride = { uid: 'self-uid', userType: UserType.USER };
+    const res = await GET(makeRequest('http://x/api/auth/audit?limit=0'));
+    expect(res.status).toBe(400);
+  });
+
+  it('blocks reads of another uid for non-elevated actor', async () => {
+    actorOverride = { uid: 'self-uid', userType: UserType.USER };
+    const res = await GET(makeRequest('http://x/api/auth/audit?uid=other-uid'));
+    expect(res.status).toBe(403);
+    expect(listMock).not.toHaveBeenCalled();
+  });
+
+  it('permits elevated actor to read another uid', async () => {
+    actorOverride = { uid: 'admin-uid', userType: UserType.ADMIN };
+    const res = await GET(makeRequest('http://x/api/auth/audit?uid=target-uid'));
+    expect(res.status).toBe(200);
+    expect(listMock).toHaveBeenCalledWith('target-uid', 25);
+  });
+
+  it('permits SYSTEM_MANAGER cross-uid read', async () => {
+    actorOverride = { uid: 'sys-uid', userType: UserType.SYSTEM_MANAGER };
+    const res = await GET(makeRequest('http://x/api/auth/audit?uid=target-uid'));
+    expect(res.status).toBe(200);
+    expect(listMock).toHaveBeenCalledWith('target-uid', 25);
+  });
+});

--- a/src/app/api/auth/audit/route.ts
+++ b/src/app/api/auth/audit/route.ts
@@ -1,6 +1,9 @@
 import { NextResponse } from 'next/server';
 import { getActorOrError } from '@/lib/db/server/auth';
-import { writeCredentialAuditEvent } from '@/lib/db/server/credentialAuditService';
+import {
+  writeCredentialAuditEvent,
+  listCredentialAuditForUser,
+} from '@/lib/db/server/credentialAuditService';
 import { UserType } from '@/types/user';
 import type { CredentialAuditEventType } from '@/types/credentialAudit';
 
@@ -80,6 +83,61 @@ export async function POST(request: Request) {
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error('[API] auth/audit POST failed:', message);
+    return NextResponse.json({ success: false, error: message }, { status: 500 });
+  }
+}
+
+const MAX_LIMIT = 100;
+const DEFAULT_LIMIT = 25;
+
+/**
+ * GET /api/auth/audit?uid=<uid>&limit=<n>
+ *
+ * Returns the credential audit entries for the actor (default) or for a
+ * different uid when the actor is ADMIN / SYSTEM_MANAGER. Bearer-token
+ * authenticated. Newest first. `limit` clamped to [1, 100], defaults to 25.
+ *
+ * Response shape: `{ success: true, entries: CredentialAuditEntry[] }`.
+ * `ip` and `userAgent` are intentionally surfaced to the user themselves —
+ * the point of the "your account activity" view is to make those visible
+ * so the user can spot foreign logins / device anomalies.
+ */
+export async function GET(request: Request) {
+  try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
+    const actor = actorOrError;
+
+    const url = new URL(request.url);
+    const targetUid = url.searchParams.get('uid') || actor.uid;
+
+    const isElevated =
+      actor.userType === UserType.ADMIN || actor.userType === UserType.SYSTEM_MANAGER;
+    if (targetUid !== actor.uid && !isElevated) {
+      return NextResponse.json(
+        { success: false, error: 'Forbidden: cannot read audit for another user' },
+        { status: 403 },
+      );
+    }
+
+    const rawLimit = url.searchParams.get('limit');
+    let limit = DEFAULT_LIMIT;
+    if (rawLimit !== null) {
+      const parsed = Number.parseInt(rawLimit, 10);
+      if (!Number.isFinite(parsed) || parsed < 1) {
+        return NextResponse.json(
+          { success: false, error: 'limit must be a positive integer' },
+          { status: 400 },
+        );
+      }
+      limit = Math.min(parsed, MAX_LIMIT);
+    }
+
+    const entries = await listCredentialAuditForUser(targetUid, limit);
+    return NextResponse.json({ success: true, entries });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('[API] auth/audit GET failed:', message);
     return NextResponse.json({ success: false, error: message }, { status: 500 });
   }
 }

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -9,6 +9,7 @@ import ProfileImageUpload from '@/components/profile/ProfileImageUpload';
 import ChangePasswordModal from '@/components/settings/ChangePasswordModal';
 import ChangePhoneModal from '@/components/settings/ChangePhoneModal';
 import DeleteAccountModal from '@/components/settings/DeleteAccountModal';
+import AccountActivitySection from '@/components/settings/AccountActivitySection';
 import { cancelAccountDeletion } from '@/lib/accountDeletionClient';
 import { readProfileImageCache, writeProfileImageCache } from '@/lib/profileImageCache';
 import { computeDaysLeft } from '@/components/settings/PendingDeletionBanner';
@@ -231,6 +232,9 @@ export default function SettingsPage() {
               </div>
             </div>
           </div>
+
+          {/* Account Activity (credential audit log) */}
+          <AccountActivitySection />
 
           {/* Notifications Section */}
           <div className="bg-white rounded-2xl shadow-lg p-6 mb-8">

--- a/src/components/settings/AccountActivitySection.tsx
+++ b/src/components/settings/AccountActivitySection.tsx
@@ -1,0 +1,248 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import {
+  Disclosure,
+  DisclosureButton,
+  DisclosurePanel,
+} from '@headlessui/react';
+import {
+  AlertCircleIcon,
+  ChevronDownIcon,
+  KeyIcon,
+  MailIcon,
+  PhoneIcon,
+  RefreshCwIcon,
+  ShieldOffIcon,
+  TrashIcon,
+  UndoIcon,
+  UserXIcon,
+  ActivityIcon,
+} from 'lucide-react';
+import type { Timestamp } from 'firebase/firestore';
+import { useAuth } from '@/contexts/AuthContext';
+import { TEXT_CONSTANTS } from '@/constants/text';
+import { fetchCredentialAuditLog } from '@/lib/credentialAuditClient';
+import type { CredentialAuditEntryWithId } from '@/lib/credentialAuditClient';
+import type { CredentialAuditEventType } from '@/types/credentialAudit';
+import { cn } from '@/lib/cn';
+
+const EVENT_ICON: Record<CredentialAuditEventType, React.ComponentType<{ className?: string }>> = {
+  PASSWORD_CHANGED: KeyIcon,
+  PHONE_CHANGED: PhoneIcon,
+  EMAIL_CHANGED: MailIcon,
+  PHONE_FORCE_RESET: ShieldOffIcon,
+  SESSIONS_REVOKED: UserXIcon,
+  ACCOUNT_DELETION_REQUESTED: TrashIcon,
+  ACCOUNT_DELETION_CANCELLED: UndoIcon,
+  ACCOUNT_DELETED: TrashIcon,
+};
+
+const EVENT_LABEL: Record<CredentialAuditEventType, string> = {
+  PASSWORD_CHANGED: TEXT_CONSTANTS.SETTINGS.ACCOUNT_EVENT_PASSWORD_CHANGED,
+  PHONE_CHANGED: TEXT_CONSTANTS.SETTINGS.ACCOUNT_EVENT_PHONE_CHANGED,
+  EMAIL_CHANGED: TEXT_CONSTANTS.SETTINGS.ACCOUNT_EVENT_EMAIL_CHANGED,
+  PHONE_FORCE_RESET: TEXT_CONSTANTS.SETTINGS.ACCOUNT_EVENT_PHONE_FORCE_RESET,
+  SESSIONS_REVOKED: TEXT_CONSTANTS.SETTINGS.ACCOUNT_EVENT_SESSIONS_REVOKED,
+  ACCOUNT_DELETION_REQUESTED:
+    TEXT_CONSTANTS.SETTINGS.ACCOUNT_EVENT_ACCOUNT_DELETION_REQUESTED,
+  ACCOUNT_DELETION_CANCELLED:
+    TEXT_CONSTANTS.SETTINGS.ACCOUNT_EVENT_ACCOUNT_DELETION_CANCELLED,
+  ACCOUNT_DELETED: TEXT_CONSTANTS.SETTINGS.ACCOUNT_EVENT_ACCOUNT_DELETED,
+};
+
+function formatTimestamp(ts: Timestamp | undefined): string {
+  if (!ts || typeof ts.toDate !== 'function') return '';
+  try {
+    const d = ts.toDate();
+    return `${d.toLocaleDateString('he-IL')} ${d.toLocaleTimeString('he-IL', {
+      hour: '2-digit',
+      minute: '2-digit',
+    })}`;
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Renders the signed-in user's credential audit log inside a collapsible
+ * disclosure. Reads from `GET /api/auth/audit` which scopes to the actor.
+ *
+ * The user is intentionally shown ip + user-agent for each entry so they
+ * can recognise unfamiliar devices/sessions and escalate. Plaintext old/new
+ * phone numbers are never returned by the API — only hashes — so the
+ * metadata field is currently elided from the UI.
+ */
+export default function AccountActivitySection() {
+  const { enhancedUser } = useAuth();
+  const [entries, setEntries] = useState<CredentialAuditEntryWithId[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await fetchCredentialAuditLog({ limit: 25 });
+      setEntries(data);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!enhancedUser?.uid) return;
+    load();
+  }, [enhancedUser?.uid, load]);
+
+  return (
+    <div className="bg-white rounded-2xl shadow-lg p-6 mb-8">
+      <Disclosure>
+        {({ open }) => (
+          <>
+            <div className="flex items-center gap-3">
+              <div className="p-2 bg-info-100 rounded-lg">
+                <ActivityIcon className="w-5 h-5 text-info-600" />
+              </div>
+              <DisclosureButton className="flex-1 flex items-center gap-2 text-start focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 rounded">
+                <h2 className="text-xl font-bold text-neutral-900">
+                  {TEXT_CONSTANTS.SETTINGS.ACCOUNT_ACTIVITY}
+                </h2>
+                {entries && (
+                  <span className="text-sm text-neutral-500">({entries.length})</span>
+                )}
+                <ChevronDownIcon
+                  className={cn(
+                    'w-5 h-5 text-neutral-500 transition-transform ms-auto',
+                    open && 'rotate-180',
+                  )}
+                />
+              </DisclosureButton>
+              <button
+                type="button"
+                onClick={load}
+                disabled={loading}
+                className="btn-ghost text-sm flex items-center gap-1 disabled:opacity-60"
+                aria-label={TEXT_CONSTANTS.SETTINGS.ACCOUNT_ACTIVITY_REFRESH}
+                title={TEXT_CONSTANTS.SETTINGS.ACCOUNT_ACTIVITY_REFRESH}
+              >
+                <RefreshCwIcon
+                  className={cn('w-4 h-4', loading && 'animate-spin')}
+                  aria-hidden="true"
+                />
+              </button>
+            </div>
+
+            <DisclosurePanel className="mt-4">
+              <p className="text-sm text-neutral-600 mb-4">
+                {TEXT_CONSTANTS.SETTINGS.ACCOUNT_ACTIVITY_DESCRIPTION}
+              </p>
+              <AccountActivityBody
+                entries={entries}
+                loading={loading}
+                error={error}
+                onRetry={load}
+                selfUid={enhancedUser?.uid}
+              />
+            </DisclosurePanel>
+          </>
+        )}
+      </Disclosure>
+    </div>
+  );
+}
+
+interface BodyProps {
+  entries: CredentialAuditEntryWithId[] | null;
+  loading: boolean;
+  error: string | null;
+  onRetry: () => void;
+  selfUid: string | undefined;
+}
+
+function AccountActivityBody({ entries, loading, error, onRetry, selfUid }: BodyProps) {
+  if (loading && entries === null) {
+    return (
+      <div className="text-sm text-neutral-500 py-4 text-center">
+        {TEXT_CONSTANTS.SETTINGS.ACCOUNT_ACTIVITY_LOADING}
+      </div>
+    );
+  }
+  if (error) {
+    return (
+      <div className="flex flex-col items-start gap-2 p-4 border border-danger-200 rounded-xl bg-danger-50">
+        <div className="flex items-center gap-2 text-sm text-danger-700">
+          <AlertCircleIcon className="w-4 h-4" aria-hidden="true" />
+          <span>{TEXT_CONSTANTS.SETTINGS.ACCOUNT_ACTIVITY_ERROR}</span>
+        </div>
+        <button type="button" onClick={onRetry} className="btn-ghost text-sm text-danger-700">
+          {TEXT_CONSTANTS.SETTINGS.ACCOUNT_ACTIVITY_RETRY}
+        </button>
+      </div>
+    );
+  }
+  if (!entries || entries.length === 0) {
+    return (
+      <div className="text-sm text-neutral-500 py-4 text-center">
+        {TEXT_CONSTANTS.SETTINGS.ACCOUNT_ACTIVITY_EMPTY}
+      </div>
+    );
+  }
+  return (
+    <ul className="divide-y divide-neutral-200 border border-neutral-200 rounded-xl overflow-hidden">
+      {entries.map((entry) => (
+        <ActivityRow key={entry.id} entry={entry} selfUid={selfUid} />
+      ))}
+    </ul>
+  );
+}
+
+function ActivityRow({
+  entry,
+  selfUid,
+}: {
+  entry: CredentialAuditEntryWithId;
+  selfUid: string | undefined;
+}) {
+  const Icon = EVENT_ICON[entry.eventType] ?? KeyIcon;
+  const label = EVENT_LABEL[entry.eventType] ?? entry.eventType;
+  const actorIsSelf = entry.actorUid === selfUid;
+  const actorLabel = actorIsSelf
+    ? TEXT_CONSTANTS.SETTINGS.ACCOUNT_ACTIVITY_ACTOR_SELF
+    : TEXT_CONSTANTS.SETTINGS.ACCOUNT_ACTIVITY_ACTOR_ADMIN;
+  const when = formatTimestamp(entry.timestamp);
+  return (
+    <li className="p-4 hover:bg-neutral-50">
+      <div className="flex items-start gap-3">
+        <div className="p-1.5 bg-neutral-100 rounded-lg flex-shrink-0">
+          <Icon className="w-4 h-4 text-neutral-700" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+            <span className="font-medium text-neutral-900 text-sm">{label}</span>
+            <span className="text-xs text-neutral-500">{actorLabel}</span>
+          </div>
+          {when && <div className="text-xs text-neutral-500 mt-0.5">{when}</div>}
+          <div className="flex flex-wrap gap-x-4 gap-y-0.5 text-xs text-neutral-500 mt-1">
+            {entry.ip && (
+              <span>
+                <span className="font-medium">{TEXT_CONSTANTS.SETTINGS.ACCOUNT_ACTIVITY_IP}:</span>{' '}
+                <span className="font-mono">{entry.ip}</span>
+              </span>
+            )}
+            {entry.userAgent && (
+              <span className="truncate max-w-md" title={entry.userAgent}>
+                <span className="font-medium">
+                  {TEXT_CONSTANTS.SETTINGS.ACCOUNT_ACTIVITY_DEVICE}:
+                </span>{' '}
+                {entry.userAgent}
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+    </li>
+  );
+}

--- a/src/constants/text.en.ts
+++ b/src/constants/text.en.ts
@@ -64,6 +64,28 @@ export const TEXT_EN = {
     DELETE_ACCOUNT_OUTSTANDING_EQUIPMENT: 'Equipment signed',
     DELETE_ACCOUNT_OUTSTANDING_AMMUNITION: 'Ammunition signed',
     DELETE_ACCOUNT_OUTSTANDING_TRANSFERS: 'Open transfer requests',
+
+    // Account Activity Section — credential audit log surfaced to the user
+    ACCOUNT_ACTIVITY: 'Account activity',
+    ACCOUNT_ACTIVITY_DESCRIPTION:
+      'Recent security events on your account — password, phone, and account-deletion changes. If anything looks unfamiliar, contact a system administrator.',
+    ACCOUNT_ACTIVITY_EMPTY: 'No security events yet.',
+    ACCOUNT_ACTIVITY_LOADING: 'Loading activity...',
+    ACCOUNT_ACTIVITY_ERROR: 'Failed to load activity.',
+    ACCOUNT_ACTIVITY_RETRY: 'Try again',
+    ACCOUNT_ACTIVITY_REFRESH: 'Refresh',
+    ACCOUNT_ACTIVITY_IP: 'IP address',
+    ACCOUNT_ACTIVITY_DEVICE: 'Device',
+    ACCOUNT_ACTIVITY_ACTOR_SELF: 'by you',
+    ACCOUNT_ACTIVITY_ACTOR_ADMIN: 'by a system administrator',
+    ACCOUNT_EVENT_PASSWORD_CHANGED: 'Password changed',
+    ACCOUNT_EVENT_PHONE_CHANGED: 'Phone number changed',
+    ACCOUNT_EVENT_EMAIL_CHANGED: 'Email address changed',
+    ACCOUNT_EVENT_PHONE_FORCE_RESET: 'Phone number reset by admin',
+    ACCOUNT_EVENT_SESSIONS_REVOKED: 'Sessions revoked',
+    ACCOUNT_EVENT_ACCOUNT_DELETION_REQUESTED: 'Account deletion requested',
+    ACCOUNT_EVENT_ACCOUNT_DELETION_CANCELLED: 'Account deletion cancelled',
+    ACCOUNT_EVENT_ACCOUNT_DELETED: 'Account deleted',
   },
   EQUIPMENT: {
     STATUS_AVAILABLE: 'Available',

--- a/src/constants/text.ts
+++ b/src/constants/text.ts
@@ -1312,6 +1312,28 @@ export const TEXT_CONSTANTS = {
     ACCOUNT_SECURITY: 'אבטחת חשבון',
     LINKED_PHONE: 'טלפון מקושר',
     PHONE_NUMBER: 'מספר טלפון:',
+
+    // Account Activity Section — credential audit log surfaced to the user
+    ACCOUNT_ACTIVITY: 'פעילות חשבון',
+    ACCOUNT_ACTIVITY_DESCRIPTION:
+      'אירועי אבטחה אחרונים בחשבונך — שינויי סיסמה, טלפון, מחיקת חשבון. אם משהו נראה לא מוכר, פנה למנהל מערכת.',
+    ACCOUNT_ACTIVITY_EMPTY: 'אין אירועי אבטחה עדיין.',
+    ACCOUNT_ACTIVITY_LOADING: 'טוען פעילות...',
+    ACCOUNT_ACTIVITY_ERROR: 'טעינת הפעילות נכשלה.',
+    ACCOUNT_ACTIVITY_RETRY: 'נסה שוב',
+    ACCOUNT_ACTIVITY_REFRESH: 'רענן',
+    ACCOUNT_ACTIVITY_IP: 'כתובת IP',
+    ACCOUNT_ACTIVITY_DEVICE: 'מכשיר',
+    ACCOUNT_ACTIVITY_ACTOR_SELF: 'על ידך',
+    ACCOUNT_ACTIVITY_ACTOR_ADMIN: 'על ידי מנהל מערכת',
+    ACCOUNT_EVENT_PASSWORD_CHANGED: 'הסיסמה שונתה',
+    ACCOUNT_EVENT_PHONE_CHANGED: 'מספר הטלפון שונה',
+    ACCOUNT_EVENT_EMAIL_CHANGED: 'כתובת המייל שונתה',
+    ACCOUNT_EVENT_PHONE_FORCE_RESET: 'מספר הטלפון אופס על ידי מנהל',
+    ACCOUNT_EVENT_SESSIONS_REVOKED: 'הסשנים נותקו',
+    ACCOUNT_EVENT_ACCOUNT_DELETION_REQUESTED: 'נשלחה בקשת מחיקת חשבון',
+    ACCOUNT_EVENT_ACCOUNT_DELETION_CANCELLED: 'בקשת מחיקת חשבון בוטלה',
+    ACCOUNT_EVENT_ACCOUNT_DELETED: 'החשבון נמחק',
     
     // Notifications Section
     NOTIFICATIONS: 'התראות',

--- a/src/lib/credentialAuditClient.ts
+++ b/src/lib/credentialAuditClient.ts
@@ -9,7 +9,7 @@
  */
 
 import { apiFetch } from '@/lib/apiFetch';
-import type { CredentialAuditEventType } from '@/types/credentialAudit';
+import type { CredentialAuditEntry, CredentialAuditEventType } from '@/types/credentialAudit';
 
 interface LogArgs {
   uid: string;
@@ -30,4 +30,33 @@ export async function logCredentialAuditEvent(args: LogArgs): Promise<void> {
   } catch (error) {
     console.warn('[credentialAudit] failed to log entry:', error);
   }
+}
+
+export type CredentialAuditEntryWithId = CredentialAuditEntry & { id: string };
+
+interface FetchArgs {
+  /** Defaults to the caller. Elevated actors may pass another uid. */
+  uid?: string;
+  /** Caps at 100 server-side. */
+  limit?: number;
+}
+
+/**
+ * Read the caller's credential audit log (or another uid's, if elevated).
+ * Errors throw so the UI can surface a retry — unlike the write path,
+ * which fires and forgets.
+ */
+export async function fetchCredentialAuditLog(
+  args: FetchArgs = {},
+): Promise<CredentialAuditEntryWithId[]> {
+  const params = new URLSearchParams();
+  if (args.uid) params.set('uid', args.uid);
+  if (args.limit !== undefined) params.set('limit', String(args.limit));
+  const qs = params.toString();
+  const response = await apiFetch(`/api/auth/audit${qs ? `?${qs}` : ''}`);
+  const result = await response.json();
+  if (!result.success) {
+    throw new Error(result.error ?? 'Failed to load account activity');
+  }
+  return (result.entries ?? []) as CredentialAuditEntryWithId[];
 }


### PR DESCRIPTION
## Summary
- Adds `GET /api/auth/audit` self-scoped read (elevated may pass `?uid=`); `limit` clamped to [1,100], default 25.
- New `AccountActivitySection` (Headless UI Disclosure) on Settings — lists user's `credentialAuditLog` events with timestamp, actor (self/admin), IP, User-Agent. Loading/error/empty/populated + refresh.
- `fetchCredentialAuditLog` client wrapper (throws on failure; UI retries).
- Bilingual `SETTINGS.ACCOUNT_ACTIVITY_*` + `ACCOUNT_EVENT_*` (he + en) per `feedback_bilingual_text`.
- 7 route tests (auth, self-scope, elevation, limit, validation). 670 jest pass, lint + build clean.

## Test plan
- [ ] Sign in, open `/settings`, expand "פעילות חשבון".
- [ ] Trigger password change → entry appears (refresh button).
- [ ] Trigger phone change → `PHONE_CHANGED` row appears with timestamp + IP + UA.
- [ ] Sign in as non-elevated, hit `/api/auth/audit?uid=<other>` → 403.
- [ ] Sign in as admin, hit `/api/auth/audit?uid=<other>` → 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)