### PR TITLE
feat(settings): sign out other devices

### DIFF
--- a/docs/codebase/src/app/api/users/sessions/revoke/route.md
+++ b/docs/codebase/src/app/api/users/sessions/revoke/route.md
@@ -1,0 +1,48 @@
+# POST /api/users/sessions/revoke
+
+**File:** `src/app/api/users/sessions/revoke/route.ts`
+**Status:** Active (Settings — Sign Out Other Devices)
+
+## Purpose
+
+Lets a signed-in user end every OTHER session on their account while the calling device stays alive. Backed by the existing `users.sessionEpoch` fence — bumping it kills every device whose token was minted earlier.
+
+## Request
+
+```
+POST /api/users/sessions/revoke
+Authorization: Bearer <idToken>
+```
+
+No body.
+
+## Response
+
+```
+{ success: true, sessionEpochMs: number }
+```
+
+`sessionEpochMs` is the millisecond timestamp written to `users.sessionEpoch` — equal to the calling token's `auth_time` claim, in ms. Other devices fail `getActorFromRequest`'s fence on their next API hit.
+
+## Authorization
+
+- Bearer token required via `getActorOrError`.
+- Self-only — the route always operates on `actor.uid`. No admin force-logout path here.
+
+## Failure modes
+
+- 400 — token decoded fine but `auth_time` claim is missing or zero.
+- 401 — missing bearer; invalid / expired token.
+- 500 — Firestore write failure.
+
+## Side effects
+
+- Updates `users/{uid}.sessionEpoch` (existing field, also bumped by `/api/users/phone-change/confirm`).
+- Writes `SESSIONS_REVOKED` row to `credentialAuditLog` (IP + UA captured server-side). Audit write is fire-and-forget — failure is logged but does not fail the route response.
+
+## Related
+
+- Fence enforcement: `src/lib/db/server/auth.ts` (`getActorFromRequest`).
+- UI: `src/components/settings/RevokeSessionsRow.tsx`.
+- Client wrapper: `src/lib/sessionsClient.ts`.
+- Settings rollout: `project_settings_page.md`.

--- a/docs/codebase/src/app/settings/page.md
+++ b/docs/codebase/src/app/settings/page.md
@@ -24,6 +24,7 @@ Settings page (`/settings`). Provides a comprehensive settings UI covering profi
 
 - **Change password** — opens `<ChangePasswordModal>` (`src/components/settings/ChangePasswordModal.tsx`). Re-authenticates via Firebase, then `updatePassword`. Success → toast via `useToast`. Errors mapped through `mapFirebaseAuthError`. See PR-B in `project_settings_page.md`.
 - **Account activity** — `<AccountActivitySection>` renders a collapsible read of the user's `credentialAuditLog` via `GET /api/auth/audit`. Shows event kind, timestamp, actor (self / admin), IP, and User-Agent. See `docs/codebase/src/components/settings/AccountActivitySection.md`.
+- **Sign out other devices** — `<RevokeSessionsRow>` renders inside the Account Security section. Posts to `/api/users/sessions/revoke` which bumps `users.sessionEpoch`, killing every other device on the next API hit. Writes a `SESSIONS_REVOKED` audit row. See `docs/codebase/src/components/settings/RevokeSessionsRow.md`.
 
 ## Known Issues / TODO
 

--- a/docs/codebase/src/components/settings/RevokeSessionsRow.md
+++ b/docs/codebase/src/components/settings/RevokeSessionsRow.md
@@ -1,0 +1,28 @@
+# RevokeSessionsRow.tsx
+
+**File:** `src/components/settings/RevokeSessionsRow.tsx`
+**Status:** Active (Settings — Sign Out Other Devices)
+
+## Purpose
+
+Renders the "Sign out other devices" affordance inside the Account Security section of the Settings page. Calling the action ends every other session on the user's account while keeping the current device signed in.
+
+## Flow
+
+1. User clicks the row's primary button → Headless UI `Dialog` confirm modal opens.
+2. Confirm → `revokeOtherSessions()` (`src/lib/sessionsClient.ts`) hits `POST /api/users/sessions/revoke`.
+3. Server bumps `users.sessionEpoch` to this device's `auth_time` (ms) and writes a `SESSIONS_REVOKED` audit row.
+4. Toast via `useToast` reports success or the server's error.
+
+Other devices die on their next API request when `getActorFromRequest` rejects them with the `Session invalidated by a security event` error.
+
+## Bilingual
+
+All visible strings under `TEXT_CONSTANTS.SETTINGS.REVOKE_SESSIONS_*` (Hebrew) with `TEXT_EN` mirrors. The confirm modal title, body, submit, cancel, success, and error messages are all keyed.
+
+## Related
+
+- API: `docs/codebase/src/app/api/users/sessions/revoke/route.md`
+- Client wrapper: `src/lib/sessionsClient.ts`
+- Audit surface: `docs/codebase/src/components/settings/AccountActivitySection.md` (where the resulting `SESSIONS_REVOKED` row appears)
+- Settings rollout: `project_settings_page.md`

--- a/src/app/api/users/sessions/revoke/__tests__/route.test.ts
+++ b/src/app/api/users/sessions/revoke/__tests__/route.test.ts
@@ -1,0 +1,122 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for POST /api/users/sessions/revoke — the "sign out other devices"
+ * endpoint. Verifies bearer-auth requirement, sessionEpoch write, and
+ * audit-log fire-and-forget behaviour (audit failure must not fail the
+ * route response).
+ */
+
+import { UserType } from '@/types/user';
+
+jest.mock('firebase-admin/firestore', () => ({
+  FieldValue: { serverTimestamp: () => 'SERVER_TIMESTAMP' },
+}));
+
+jest.mock('firebase-admin/app', () => ({
+  initializeApp: () => ({}),
+  getApps: () => [],
+  cert: () => ({}),
+  applicationDefault: () => ({}),
+}));
+
+const updateMock = jest.fn(async () => undefined);
+const verifyIdTokenMock = jest.fn();
+
+jest.mock('@/lib/db/admin', () => ({
+  getAdminAuth: () => ({ verifyIdToken: verifyIdTokenMock }),
+  getAdminDb: () => ({
+    collection: () => ({
+      doc: () => ({ update: updateMock }),
+    }),
+  }),
+}));
+
+const writeAuditMock = jest.fn(async () => 'audit-id');
+jest.mock('@/lib/db/server/credentialAuditService', () => ({
+  writeCredentialAuditEvent: (args: unknown) => writeAuditMock(args),
+}));
+
+let actorOverride: { uid: string; userType: UserType } | null = null;
+jest.mock('@/lib/db/server/auth', () => {
+  const { NextResponse } = jest.requireActual('next/server');
+  return {
+    getActorOrError: jest.fn(async () => {
+      if (!actorOverride) {
+        return NextResponse.json({ success: false, error: 'unauth' }, { status: 401 });
+      }
+      return { ...actorOverride, grants: [] };
+    }),
+  };
+});
+
+import { POST } from '../route';
+
+function makeRequest(token: string | null = 'fake-token'): Request {
+  const headers: Record<string, string> = {};
+  if (token) headers.Authorization = `Bearer ${token}`;
+  return new Request('http://x/api/users/sessions/revoke', { method: 'POST', headers });
+}
+
+beforeEach(() => {
+  updateMock.mockClear();
+  writeAuditMock.mockClear();
+  verifyIdTokenMock.mockReset();
+  actorOverride = null;
+});
+
+describe('POST /api/users/sessions/revoke', () => {
+  it('returns 401 when actor unauthenticated', async () => {
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(401);
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when bearer is missing entirely', async () => {
+    actorOverride = { uid: 'u1', userType: UserType.USER };
+    const res = await POST(makeRequest(null));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 when token verify throws', async () => {
+    actorOverride = { uid: 'u1', userType: UserType.USER };
+    verifyIdTokenMock.mockRejectedValueOnce(new Error('expired'));
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(401);
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when token has no auth_time claim', async () => {
+    actorOverride = { uid: 'u1', userType: UserType.USER };
+    verifyIdTokenMock.mockResolvedValueOnce({ auth_time: 0 });
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(400);
+  });
+
+  it('bumps sessionEpoch and writes audit on success', async () => {
+    actorOverride = { uid: 'u1', userType: UserType.USER };
+    verifyIdTokenMock.mockResolvedValueOnce({ auth_time: 1_700_000_000 });
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.sessionEpochMs).toBe(1_700_000_000 * 1000);
+    expect(updateMock).toHaveBeenCalledWith({ sessionEpoch: 1_700_000_000 * 1000 });
+    expect(writeAuditMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        uid: 'u1',
+        actorUid: 'u1',
+        eventType: 'SESSIONS_REVOKED',
+      }),
+    );
+  });
+
+  it('succeeds even when audit write fails (fire-and-forget)', async () => {
+    actorOverride = { uid: 'u1', userType: UserType.USER };
+    verifyIdTokenMock.mockResolvedValueOnce({ auth_time: 1_700_000_000 });
+    writeAuditMock.mockRejectedValueOnce(new Error('audit down'));
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(200);
+    expect(updateMock).toHaveBeenCalled();
+  });
+});

--- a/src/app/api/users/sessions/revoke/route.ts
+++ b/src/app/api/users/sessions/revoke/route.ts
@@ -1,0 +1,83 @@
+import { NextResponse } from 'next/server';
+import { getActorOrError } from '@/lib/db/server/auth';
+import { getAdminAuth, getAdminDb } from '@/lib/db/admin';
+import { COLLECTIONS } from '@/lib/db/collections';
+import { writeCredentialAuditEvent } from '@/lib/db/server/credentialAuditService';
+
+/**
+ * POST /api/users/sessions/revoke
+ *
+ * Sign out the caller from every OTHER device while keeping the current
+ * one alive. Same mechanism as the phone-change confirm flow: bump
+ * `users.sessionEpoch` to the calling device's `auth_time`, so every
+ * other device whose token was minted earlier fails the fence in
+ * `getActorFromRequest` on its next API hit.
+ *
+ * No admin cross-uid path here. If we add a "force-logout user X" admin
+ * tool it gets its own route so the privileged path is auditable
+ * separately from the self-service one.
+ *
+ * Writes a `SESSIONS_REVOKED` row to `credentialAuditLog` so the user
+ * can see the action surface in the Account Activity section.
+ */
+export async function POST(request: Request) {
+  try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
+    const actor = actorOrError;
+
+    const header =
+      request.headers.get('authorization') ?? request.headers.get('Authorization') ?? '';
+    const idToken = header.startsWith('Bearer ') ? header.slice('Bearer '.length).trim() : '';
+    if (!idToken) {
+      return NextResponse.json(
+        { success: false, error: 'Missing bearer token' },
+        { status: 401 },
+      );
+    }
+
+    let authTimeSeconds: number;
+    try {
+      const decoded = await getAdminAuth().verifyIdToken(idToken, true);
+      authTimeSeconds = decoded.auth_time ?? 0;
+    } catch {
+      return NextResponse.json(
+        { success: false, error: 'Invalid or expired token' },
+        { status: 401 },
+      );
+    }
+    if (!authTimeSeconds) {
+      return NextResponse.json(
+        { success: false, error: 'Token missing auth_time claim' },
+        { status: 400 },
+      );
+    }
+
+    const sessionEpochMs = authTimeSeconds * 1000;
+    await getAdminDb().collection(COLLECTIONS.USERS).doc(actor.uid).update({
+      sessionEpoch: sessionEpochMs,
+    });
+
+    try {
+      const xff = request.headers.get('x-forwarded-for') ?? '';
+      const ip = xff.split(',')[0]?.trim() || request.headers.get('x-real-ip') || undefined;
+      const userAgent = request.headers.get('user-agent') ?? undefined;
+      await writeCredentialAuditEvent({
+        uid: actor.uid,
+        actorUid: actor.uid,
+        actorUserType: String(actor.userType),
+        eventType: 'SESSIONS_REVOKED',
+        ip,
+        userAgent,
+      });
+    } catch (e) {
+      console.warn('[sessions/revoke] audit-log write failed:', e);
+    }
+
+    return NextResponse.json({ success: true, sessionEpochMs });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('[API] users/sessions/revoke POST failed:', message);
+    return NextResponse.json({ success: false, error: message }, { status: 500 });
+  }
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -10,6 +10,7 @@ import ChangePasswordModal from '@/components/settings/ChangePasswordModal';
 import ChangePhoneModal from '@/components/settings/ChangePhoneModal';
 import DeleteAccountModal from '@/components/settings/DeleteAccountModal';
 import AccountActivitySection from '@/components/settings/AccountActivitySection';
+import RevokeSessionsRow from '@/components/settings/RevokeSessionsRow';
 import { cancelAccountDeletion } from '@/lib/accountDeletionClient';
 import { readProfileImageCache, writeProfileImageCache } from '@/lib/profileImageCache';
 import { computeDaysLeft } from '@/components/settings/PendingDeletionBanner';
@@ -218,18 +219,21 @@ export default function SettingsPage() {
               </h2>
             </div>
 
-            <div className="p-4 border border-neutral-200 rounded-xl">
-              <div className="flex items-center gap-4">
-                <PhoneIcon className="w-5 h-5 text-neutral-400" />
-                <div>
-                  <h3 className="font-medium text-neutral-900">
-                    {TEXT_CONSTANTS.SETTINGS.LINKED_PHONE}
-                  </h3>
-                  <p className="text-sm text-neutral-500">
-                    {TEXT_CONSTANTS.SETTINGS.PHONE_NUMBER} {mockPhoneNumber}
-                  </p>
+            <div className="space-y-4">
+              <div className="p-4 border border-neutral-200 rounded-xl">
+                <div className="flex items-center gap-4">
+                  <PhoneIcon className="w-5 h-5 text-neutral-400" />
+                  <div>
+                    <h3 className="font-medium text-neutral-900">
+                      {TEXT_CONSTANTS.SETTINGS.LINKED_PHONE}
+                    </h3>
+                    <p className="text-sm text-neutral-500">
+                      {TEXT_CONSTANTS.SETTINGS.PHONE_NUMBER} {mockPhoneNumber}
+                    </p>
+                  </div>
                 </div>
               </div>
+              <RevokeSessionsRow />
             </div>
           </div>
 

--- a/src/components/settings/RevokeSessionsRow.tsx
+++ b/src/components/settings/RevokeSessionsRow.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  Dialog,
+  DialogBackdrop,
+  DialogPanel,
+  DialogTitle,
+} from '@headlessui/react';
+import { LogOutIcon, X } from 'lucide-react';
+import { TEXT_CONSTANTS } from '@/constants/text';
+import { useToast } from '@/components/ui/Toast';
+import { revokeOtherSessions } from '@/lib/sessionsClient';
+
+/**
+ * Settings row + confirm modal that lets the user end every OTHER session
+ * on their account. The current device stays signed in because
+ * `users.sessionEpoch` is bumped to this device's `auth_time` — other
+ * devices fail the fence in `getActorFromRequest` on their next API hit.
+ *
+ * Renders inside the Account Security section of the Settings page.
+ */
+export default function RevokeSessionsRow() {
+  const { showToast } = useToast();
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  const onConfirm = async () => {
+    if (submitting) return;
+    setSubmitting(true);
+    const result = await revokeOtherSessions();
+    setSubmitting(false);
+    if (result.success) {
+      showToast(TEXT_CONSTANTS.SETTINGS.REVOKE_SESSIONS_SUCCESS, 'success');
+      setConfirmOpen(false);
+    } else {
+      showToast(
+        result.error || TEXT_CONSTANTS.SETTINGS.REVOKE_SESSIONS_ERROR,
+        'danger',
+      );
+    }
+  };
+
+  return (
+    <>
+      <div className="flex items-center justify-between p-4 border border-neutral-200 rounded-xl hover:bg-neutral-50 transition-colors">
+        <div className="flex items-center gap-4">
+          <LogOutIcon className="w-5 h-5 text-neutral-400" />
+          <div>
+            <h3 className="font-medium text-neutral-900">
+              {TEXT_CONSTANTS.SETTINGS.REVOKE_SESSIONS}
+            </h3>
+            <p className="text-sm text-neutral-500">
+              {TEXT_CONSTANTS.SETTINGS.REVOKE_SESSIONS_DESCRIPTION}
+            </p>
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={() => setConfirmOpen(true)}
+          className="btn-primary text-sm"
+        >
+          {TEXT_CONSTANTS.SETTINGS.REVOKE_SESSIONS}
+        </button>
+      </div>
+
+      <Dialog
+        open={confirmOpen}
+        onClose={() => (!submitting ? setConfirmOpen(false) : undefined)}
+        className="relative z-50"
+      >
+        <DialogBackdrop className="fixed inset-0 bg-black/40" />
+        <div className="fixed inset-0 flex items-center justify-center p-4">
+          <DialogPanel className="bg-white rounded-2xl shadow-xl max-w-md w-full p-6">
+            <div className="flex items-start justify-between mb-4">
+              <DialogTitle className="text-lg font-bold text-neutral-900">
+                {TEXT_CONSTANTS.SETTINGS.REVOKE_SESSIONS_CONFIRM_TITLE}
+              </DialogTitle>
+              <button
+                type="button"
+                onClick={() => (!submitting ? setConfirmOpen(false) : undefined)}
+                disabled={submitting}
+                className="text-neutral-400 hover:text-neutral-600 disabled:opacity-60"
+                aria-label={TEXT_CONSTANTS.SETTINGS.REVOKE_SESSIONS_CANCEL}
+              >
+                <X className="w-5 h-5" />
+              </button>
+            </div>
+            <p className="text-sm text-neutral-700 mb-6">
+              {TEXT_CONSTANTS.SETTINGS.REVOKE_SESSIONS_CONFIRM_BODY}
+            </p>
+            <div className="flex gap-3 justify-end">
+              <button
+                type="button"
+                onClick={() => setConfirmOpen(false)}
+                disabled={submitting}
+                className="btn-ghost text-sm"
+              >
+                {TEXT_CONSTANTS.SETTINGS.REVOKE_SESSIONS_CANCEL}
+              </button>
+              <button
+                type="button"
+                onClick={onConfirm}
+                disabled={submitting}
+                className="btn-primary text-sm"
+              >
+                {submitting
+                  ? TEXT_CONSTANTS.SETTINGS.REVOKE_SESSIONS_SUBMITTING
+                  : TEXT_CONSTANTS.SETTINGS.REVOKE_SESSIONS_CONFIRM_SUBMIT}
+              </button>
+            </div>
+          </DialogPanel>
+        </div>
+      </Dialog>
+    </>
+  );
+}

--- a/src/constants/text.en.ts
+++ b/src/constants/text.en.ts
@@ -86,6 +86,19 @@ export const TEXT_EN = {
     ACCOUNT_EVENT_ACCOUNT_DELETION_REQUESTED: 'Account deletion requested',
     ACCOUNT_EVENT_ACCOUNT_DELETION_CANCELLED: 'Account deletion cancelled',
     ACCOUNT_EVENT_ACCOUNT_DELETED: 'Account deleted',
+
+    // Revoke other sessions
+    REVOKE_SESSIONS: 'Sign out other devices',
+    REVOKE_SESSIONS_DESCRIPTION:
+      'Signs out every other session on your account. Other devices will have to log in again. This device stays signed in.',
+    REVOKE_SESSIONS_CONFIRM_TITLE: 'Sign out other devices?',
+    REVOKE_SESSIONS_CONFIRM_BODY:
+      'Other devices signed in to your account will need to log in again. This takes effect immediately.',
+    REVOKE_SESSIONS_CONFIRM_SUBMIT: 'Sign out other devices',
+    REVOKE_SESSIONS_CANCEL: 'Cancel',
+    REVOKE_SESSIONS_SUBMITTING: 'Signing out...',
+    REVOKE_SESSIONS_SUCCESS: 'Other devices signed out. They will be asked to log in again.',
+    REVOKE_SESSIONS_ERROR: 'Sign-out failed. Try again.',
   },
   EQUIPMENT: {
     STATUS_AVAILABLE: 'Available',

--- a/src/constants/text.ts
+++ b/src/constants/text.ts
@@ -1313,6 +1313,19 @@ export const TEXT_CONSTANTS = {
     LINKED_PHONE: 'טלפון מקושר',
     PHONE_NUMBER: 'מספר טלפון:',
 
+    // Revoke other sessions
+    REVOKE_SESSIONS: 'התנתק ממכשירים אחרים',
+    REVOKE_SESSIONS_DESCRIPTION:
+      'מנתק את כל הסשנים האחרים שלך — כל מכשיר אחר יידרש להתחבר מחדש. המכשיר הנוכחי יישאר מחובר.',
+    REVOKE_SESSIONS_CONFIRM_TITLE: 'לנתק מכשירים אחרים?',
+    REVOKE_SESSIONS_CONFIRM_BODY:
+      'מכשירים אחרים שמחוברים עם החשבון שלך יידרשו להתחבר מחדש. פעולה זו נכנסת לתוקף מיידית.',
+    REVOKE_SESSIONS_CONFIRM_SUBMIT: 'נתק מכשירים אחרים',
+    REVOKE_SESSIONS_CANCEL: 'ביטול',
+    REVOKE_SESSIONS_SUBMITTING: 'מנתק...',
+    REVOKE_SESSIONS_SUCCESS: 'המכשירים האחרים נותקו. הם יתבקשו להתחבר מחדש.',
+    REVOKE_SESSIONS_ERROR: 'הניתוק נכשל. נסה שוב.',
+
     // Account Activity Section — credential audit log surfaced to the user
     ACCOUNT_ACTIVITY: 'פעילות חשבון',
     ACCOUNT_ACTIVITY_DESCRIPTION:

--- a/src/lib/sessionsClient.ts
+++ b/src/lib/sessionsClient.ts
@@ -1,0 +1,32 @@
+/**
+ * Client wrapper for session-management endpoints. Single export today:
+ * `revokeOtherSessions` — bumps `users.sessionEpoch` for the caller so
+ * every other device whose token pre-dates the fence is rejected on its
+ * next API hit. The calling device stays alive (its auth_time matches
+ * the new epoch).
+ *
+ * Force the calling-side idToken to refresh after a successful response
+ * via `auth.currentUser.getIdToken(true)` if the caller needs to keep
+ * making authenticated requests immediately. (For the "Sign out other
+ * devices" UI we just close the modal and trust the next request to
+ * mint a fresh token before the fence hits.)
+ */
+
+import { apiFetch } from '@/lib/apiFetch';
+
+interface RevokeResponse {
+  success: boolean;
+  sessionEpochMs?: number;
+  error?: string;
+}
+
+export async function revokeOtherSessions(): Promise<RevokeResponse> {
+  try {
+    const response = await apiFetch('/api/users/sessions/revoke', {
+      method: 'POST',
+    });
+    return (await response.json()) as RevokeResponse;
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `POST /api/users/sessions/revoke` — self-only; bumps `users.sessionEpoch` to the calling token's `auth_time` so every other device dies on its next API hit. Writes `SESSIONS_REVOKED` audit row.
- New `RevokeSessionsRow` in Account Security (Settings): Headless UI Dialog confirm + toast.
- `revokeOtherSessions()` client wrapper.
- Bilingual `SETTINGS.REVOKE_SESSIONS_*` (he + en).
- 6 route tests (auth, missing bearer/auth_time, success, fire-and-forget audit). 676 jest pass, lint + build clean.

## Test plan
- [ ] Sign in on two browsers, hit Settings → "Sign out other devices" on browser A.
- [ ] Browser B's next API call fails with 401 "Session invalidated by a security event".
- [ ] Account Activity section shows the `SESSIONS_REVOKED` entry.
- [ ] Token without `auth_time` claim → 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)