### PR TITLE
feat(settings): sign-out-other-devices toggle in ChangePasswordModal

### DIFF
--- a/docs/codebase/src/components/settings/ChangePasswordModal.md
+++ b/docs/codebase/src/components/settings/ChangePasswordModal.md
@@ -23,7 +23,8 @@ Modal dialog that lets a signed-in user change their account password. Mounted b
 4. Helper performs `reauthenticateWithCredential(EmailAuthProvider.credential(email, current))` then `updatePassword(user, new)`.
 5. On any error, `mapFirebaseAuthError` translates to a Hebrew message rendered inline (`role="alert"`).
 6. On success, fire-and-forget call to `logCredentialAuditEvent({ uid, eventType: 'PASSWORD_CHANGED' })` records the event in `credentialAuditLog`. Audit failure never blocks success — the client wrapper swallows network errors.
-7. Modal calls `onSuccess()` and closes.
+7. If the "Sign out other devices" checkbox is checked (default: on), fire-and-forget `revokeOtherSessions()` (`src/lib/sessionsClient.ts`) bumps `users.sessionEpoch`. Every other device with this user signed in dies on its next API hit. Failure is silent — the password change already succeeded; the user can see the resulting `SESSIONS_REVOKED` row in Account Activity.
+8. Modal calls `onSuccess()` and closes.
 
 ## Error surfaces
 

--- a/src/components/settings/ChangePasswordModal.tsx
+++ b/src/components/settings/ChangePasswordModal.tsx
@@ -10,6 +10,7 @@ import {
 import { Eye, EyeOff, X } from 'lucide-react';
 import { changePassword, mapFirebaseAuthError } from '@/lib/firebasePhoneAuth';
 import { logCredentialAuditEvent } from '@/lib/credentialAuditClient';
+import { revokeOtherSessions } from '@/lib/sessionsClient';
 import { auth } from '@/lib/firebase';
 import { TEXT_CONSTANTS } from '@/constants/text';
 
@@ -30,6 +31,7 @@ export default function ChangePasswordModal({ open, onClose, onSuccess }: Props)
   const [showConfirm, setShowConfirm] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [signOutOthers, setSignOutOthers] = useState(true);
 
   // Reset all form state whenever the modal re-opens. Avoids leaking the
   // previous attempt's inputs back into a fresh open.
@@ -43,6 +45,7 @@ export default function ChangePasswordModal({ open, onClose, onSuccess }: Props)
       setShowConfirm(false);
       setError(null);
       setSubmitting(false);
+      setSignOutOthers(true);
     }
   }, [open]);
 
@@ -69,6 +72,13 @@ export default function ChangePasswordModal({ open, onClose, onSuccess }: Props)
       const uid = auth.currentUser?.uid;
       if (uid) {
         void logCredentialAuditEvent({ uid, eventType: 'PASSWORD_CHANGED' });
+      }
+      if (signOutOthers) {
+        // Fire-and-forget. revokeOtherSessions never throws — it captures
+        // the error in its response. We don't surface the failure here
+        // because the password change already succeeded; the audit
+        // section will reflect whether SESSIONS_REVOKED actually wrote.
+        void revokeOtherSessions();
       }
       onSuccess();
       onClose();
@@ -135,6 +145,19 @@ export default function ChangePasswordModal({ open, onClose, onSuccess }: Props)
               autoComplete="new-password"
               disabled={submitting}
             />
+
+            <label className="flex items-start gap-2 text-sm text-neutral-700 cursor-pointer select-none">
+              <input
+                type="checkbox"
+                checked={signOutOthers}
+                onChange={(e) => setSignOutOthers(e.target.checked)}
+                disabled={submitting}
+                className="mt-0.5 rounded border-neutral-300 text-primary-600 focus:ring-primary-500"
+              />
+              <span>
+                {TEXT_CONSTANTS.SETTINGS.CHANGE_PASSWORD_SIGN_OUT_OTHERS}
+              </span>
+            </label>
 
             {error && (
               <div className="text-sm text-danger-700 bg-danger-50 border border-danger-200 rounded-lg px-3 py-2" role="alert">

--- a/src/constants/text.en.ts
+++ b/src/constants/text.en.ts
@@ -25,6 +25,8 @@ export const TEXT_EN = {
     CHANGE_PASSWORD_SUBMIT: 'Update password',
     CHANGE_PASSWORD_SUBMITTING: 'Updating...',
     CHANGE_PASSWORD_SUCCESS: 'Password updated successfully.',
+    CHANGE_PASSWORD_SIGN_OUT_OTHERS:
+      'Sign out other devices after the password change (recommended).',
     SHOW_PASSWORD: 'Show password',
     HIDE_PASSWORD: 'Hide password',
 

--- a/src/constants/text.ts
+++ b/src/constants/text.ts
@@ -1284,6 +1284,8 @@ export const TEXT_CONSTANTS = {
     CHANGE_PASSWORD_SUBMIT: 'עדכן סיסמה',
     CHANGE_PASSWORD_SUBMITTING: 'מעדכן...',
     CHANGE_PASSWORD_SUCCESS: 'הסיסמה עודכנה בהצלחה.',
+    CHANGE_PASSWORD_SIGN_OUT_OTHERS:
+      'נתק מכשירים אחרים אחרי שינוי הסיסמה (מומלץ).',
     SHOW_PASSWORD: 'הצג סיסמה',
     HIDE_PASSWORD: 'הסתר סיסמה',
 


### PR DESCRIPTION
## Summary
- Adds default-on checkbox to ChangePasswordModal that revokes other sessions after the password change. Reuses POST /api/users/sessions/revoke (PR #89). Fire-and-forget.
- Bilingual SETTINGS.CHANGE_PASSWORD_SIGN_OUT_OTHERS.

## Test plan
- [ ] Sign in on two browsers, change password on browser A with checkbox ON → browser B fails next API call.
- [ ] Uncheck checkbox → browser B continues working.
- [ ] Account Activity shows SESSIONS_REVOKED row only when checkbox was on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)