### PR TITLE
feat(settings): pre-flight explainer step on ChangePhoneModal

### DIFF
--- a/docs/codebase/src/components/settings/ChangePhoneModal.md
+++ b/docs/codebase/src/components/settings/ChangePhoneModal.md
@@ -5,7 +5,7 @@
 
 ## Purpose
 
-Three-step modal that lets a signed-in user change their phone number. Mounted by `/settings` and opened when the user clicks the "עדכן" button next to the phone row.
+Four-step modal that lets a signed-in user change their phone number. Mounted by `/settings` and opened when the user clicks the "עדכן" button next to the phone row.
 
 ## Props
 
@@ -20,6 +20,8 @@ Three-step modal that lets a signed-in user change their phone number. Mounted b
 ```
 idle (modal closed)
   ↓ open
+preflight — explainer card (SMS, reauth, other-devices logout, rate limit)
+  ↓ "התחל שינוי מספר"
 reauth — current password input
   ↓ reauth succeeds
 enterNumber — new phone E.164 input + reset reCAPTCHA + send OTP
@@ -64,6 +66,6 @@ Hebrew strings live in `TEXT_CONSTANTS.SETTINGS.CHANGE_PHONE_*`. English mirrors
 
 ## Deferred polish (out of PR-C)
 
-- Pre-flight explainer card listing the three prerequisites before step 1.
+- ~~Pre-flight explainer card listing the prerequisites before step 1.~~ ✅ Shipped 2026-05-14 on `feat/phone-change-preflight` — new `preflight` step lists SMS, password reauth, other-device logout, and rate limit before the reauth step. Bullets keyed under `CHANGE_PHONE_PREFLIGHT_*`.
 - "Sign out other devices now" explicit CTA in the success state. (sessionEpoch fence already cuts them on next API call — the CTA would just confirm it visually.)
 - Old-phone notification (email + SMS) — blocked on PR-E channel pick.

--- a/src/components/settings/ChangePhoneModal.tsx
+++ b/src/components/settings/ChangePhoneModal.tsx
@@ -7,7 +7,7 @@ import {
   DialogPanel,
   DialogTitle,
 } from '@headlessui/react';
-import { Eye, EyeOff, X, ArrowRight } from 'lucide-react';
+import { Eye, EyeOff, X, ArrowRight, ShieldAlert } from 'lucide-react';
 import {
   reauthEmailPassword,
   verifyNewPhone,
@@ -33,10 +33,10 @@ interface Props {
   onSuccess: () => void;
 }
 
-type Step = 'reauth' | 'enterNumber' | 'enterOtp';
+type Step = 'preflight' | 'reauth' | 'enterNumber' | 'enterOtp';
 
 export default function ChangePhoneModal({ open, onClose, onSuccess }: Props) {
-  const [step, setStep] = useState<Step>('reauth');
+  const [step, setStep] = useState<Step>('preflight');
   const [password, setPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
   const [newPhone, setNewPhone] = useState('');
@@ -50,7 +50,7 @@ export default function ChangePhoneModal({ open, onClose, onSuccess }: Props) {
 
   useEffect(() => {
     if (open) {
-      setStep('reauth');
+      setStep('preflight');
       setPassword('');
       setShowPassword(false);
       setNewPhone('');
@@ -206,6 +206,44 @@ export default function ChangePhoneModal({ open, onClose, onSuccess }: Props) {
           <p className="text-sm text-neutral-600 mb-5">
             {TEXT_CONSTANTS.SETTINGS.CHANGE_PHONE_DESCRIPTION}
           </p>
+
+          {step === 'preflight' && (
+            <div className="space-y-4">
+              <h3 className="text-sm font-medium text-neutral-700">
+                {TEXT_CONSTANTS.SETTINGS.CHANGE_PHONE_STEP_PREFLIGHT_TITLE}
+              </h3>
+              <div className="flex items-start gap-3 p-3 bg-warning-50 border border-warning-200 rounded-lg">
+                <ShieldAlert className="w-5 h-5 text-warning-700 flex-shrink-0 mt-0.5" aria-hidden="true" />
+                <div className="text-sm text-warning-900">
+                  <p className="mb-2 font-medium">
+                    {TEXT_CONSTANTS.SETTINGS.CHANGE_PHONE_PREFLIGHT_INTRO}
+                  </p>
+                  <ul className="list-disc list-inside space-y-1 text-warning-800">
+                    <li>{TEXT_CONSTANTS.SETTINGS.CHANGE_PHONE_PREFLIGHT_BULLET_SMS}</li>
+                    <li>{TEXT_CONSTANTS.SETTINGS.CHANGE_PHONE_PREFLIGHT_BULLET_REAUTH}</li>
+                    <li>{TEXT_CONSTANTS.SETTINGS.CHANGE_PHONE_PREFLIGHT_BULLET_SESSIONS}</li>
+                    <li>{TEXT_CONSTANTS.SETTINGS.CHANGE_PHONE_PREFLIGHT_BULLET_RATE_LIMIT}</li>
+                  </ul>
+                </div>
+              </div>
+              <div className="flex items-center justify-end gap-3 pt-2">
+                <button
+                  type="button"
+                  onClick={closeAndCleanup}
+                  className="btn-ghost"
+                >
+                  {TEXT_CONSTANTS.SETTINGS.CANCEL}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setStep('reauth')}
+                  className="btn-primary"
+                >
+                  {TEXT_CONSTANTS.SETTINGS.CHANGE_PHONE_PREFLIGHT_START}
+                </button>
+              </div>
+            </div>
+          )}
 
           {step === 'reauth' && (
             <form onSubmit={onReauthSubmit} className="space-y-4">

--- a/src/constants/text.en.ts
+++ b/src/constants/text.en.ts
@@ -33,6 +33,13 @@ export const TEXT_EN = {
     // Change-phone modal (PR-C)
     CHANGE_PHONE_TITLE: 'Change phone number',
     CHANGE_PHONE_DESCRIPTION: 'Re-enter your password, type the new number, then confirm with the SMS code.',
+    CHANGE_PHONE_STEP_PREFLIGHT_TITLE: 'Before you start',
+    CHANGE_PHONE_PREFLIGHT_INTRO: 'Changing your phone number affects your account security. Please note:',
+    CHANGE_PHONE_PREFLIGHT_BULLET_SMS: 'An SMS verification code will be sent to the new number.',
+    CHANGE_PHONE_PREFLIGHT_BULLET_REAUTH: 'Your current account password will be required.',
+    CHANGE_PHONE_PREFLIGHT_BULLET_SESSIONS: 'Your other devices will be signed out and need to log in again.',
+    CHANGE_PHONE_PREFLIGHT_BULLET_RATE_LIMIT: 'You can request one change per minute.',
+    CHANGE_PHONE_PREFLIGHT_START: 'Start phone change',
     CHANGE_PHONE_STEP_REAUTH_TITLE: 'Confirm password',
     CHANGE_PHONE_STEP_NEW_NUMBER_TITLE: 'New phone number',
     CHANGE_PHONE_STEP_OTP_TITLE: 'Enter SMS code',

--- a/src/constants/text.ts
+++ b/src/constants/text.ts
@@ -1292,6 +1292,13 @@ export const TEXT_CONSTANTS = {
     // Change-phone modal (PR-C)
     CHANGE_PHONE_TITLE: 'שינוי מספר טלפון',
     CHANGE_PHONE_DESCRIPTION: 'אמת את הסיסמה הנוכחית, הזן את המספר החדש ואשר באמצעות קוד SMS.',
+    CHANGE_PHONE_STEP_PREFLIGHT_TITLE: 'לפני שמתחילים',
+    CHANGE_PHONE_PREFLIGHT_INTRO: 'שינוי מספר הטלפון משפיע על האבטחה של החשבון. שים לב:',
+    CHANGE_PHONE_PREFLIGHT_BULLET_SMS: 'יישלח קוד אימות במסרון למספר החדש.',
+    CHANGE_PHONE_PREFLIGHT_BULLET_REAUTH: 'תידרש סיסמת החשבון הנוכחית.',
+    CHANGE_PHONE_PREFLIGHT_BULLET_SESSIONS: 'מכשירים אחרים שלך יתנתקו ויידרשו להתחבר מחדש.',
+    CHANGE_PHONE_PREFLIGHT_BULLET_RATE_LIMIT: 'ניתן לבקש שינוי פעם בדקה.',
+    CHANGE_PHONE_PREFLIGHT_START: 'התחל שינוי מספר',
     CHANGE_PHONE_STEP_REAUTH_TITLE: 'אימות סיסמה',
     CHANGE_PHONE_STEP_NEW_NUMBER_TITLE: 'מספר טלפון חדש',
     CHANGE_PHONE_STEP_OTP_TITLE: 'הזן קוד SMS',


### PR DESCRIPTION
## Summary
- Adds a new `preflight` step at the start of ChangePhoneModal listing the four side-effects: SMS to new number, password reauth, other-device logout, 60s rate limit.
- Modal opens on preflight; "התחל שינוי מספר" advances to existing reauth step.
- Bilingual `CHANGE_PHONE_PREFLIGHT_*` (he + en).
- 676 jest pass, lint + build clean.

## Test plan
- [ ] Open Settings → "עדכן" next to phone → preflight card renders with 4 bullets.
- [ ] Cancel → modal closes cleanly (no orphan pending — /initiate hasn't run yet).
- [ ] "התחל שינוי מספר" → existing reauth step renders.
- [ ] Re-open modal → preflight state again (no leaked state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)