### PR TITLE
feat(settings): persist notification preferences via profile API

### DIFF
--- a/docs/backlog/2026-q2.md
+++ b/docs/backlog/2026-q2.md
@@ -72,12 +72,12 @@ This document is the source of truth for the Q2 2026 product backlog. Tasks are 
 - **Acceptance:** all uploaded images are square; zoom/pan editable before commit.
 - **Commit:** `feat(profile): add zoom/pan crop step before image upload`
 
-### 2.3 — Notification preferences backend wire-up
-- **Branch:** `feat/settings-notification-preferences`
-- **Files:** `src/lib/db/server/userService.ts:49` (add `'communicationPreferences'` to `PROFILE_WRITABLE_FIELDS`); `src/app/settings/page.tsx` lines 194–248 (wire toggles).
-- **Validation:** server validates `communicationPreferences` matches the `CommunicationPreferences` shape (`src/types/user.ts:21-31`).
-- **UI:** optimistic with rollback on error.
-- **Acceptance:** flipping a toggle persists to Firestore; refresh preserves state.
+### 2.3 — Notification preferences backend wire-up ✅ shipped on `feat/notification-preferences-scaffold`
+- **Branch:** `feat/notification-preferences-scaffold`
+- **Files:** `src/lib/db/server/userService.ts` (dotted-path patch for `communicationPreferences` + boolean-allowlist validation); `src/app/api/users/profile/route.ts` (surface `InvalidProfileUpdateError` as 400); `src/lib/userProfileService.ts` (extend `ProfileUpdates`); `src/app/settings/page.tsx` lines 244–311 (wire toggles); `src/components/settings/NotificationToggleRow.tsx` (shared row with `role="switch"`).
+- **Validation:** server rejects non-boolean values, unknown keys, non-object payloads — all → 400.
+- **UI:** optimistic toggle + rollback on error; saving spinner via `cursor-wait` opacity.
+- **Acceptance:** flipping a toggle persists to Firestore; `AuthContext.refreshEnhancedUser` reflects on next render; refresh preserves state.
 - **Commit:** `feat(settings): persist notification preferences via profile API`
 
 ### 2.4 — Password change flow

--- a/docs/codebase/src/app/api/users/profile/route.md
+++ b/docs/codebase/src/app/api/users/profile/route.md
@@ -12,7 +12,22 @@ Server-side write endpoint for a user's editable profile fields. Backed by `fire
 ```
 PATCH /api/users/profile
 Authorization: Bearer <idToken>
-Body: { uid: string, updates: { teamId?: string, profileImage?: string } }
+Body: {
+  uid: string,
+  updates: {
+    teamId?: string,
+    profileImage?: string,
+    enlistmentCycle?: string,
+    address?: string,
+    communicationPreferences?: {
+      emailNotifications?: boolean,
+      equipmentTransferAlerts?: boolean,
+      systemUpdates?: boolean,
+      schedulingAlerts?: boolean,
+      emergencyNotifications?: boolean
+    }
+  }
+}
 ```
 
 ## Authorization
@@ -23,7 +38,17 @@ Body: { uid: string, updates: { teamId?: string, profileImage?: string } }
 
 ## Field allowlist
 
-`PROFILE_WRITABLE_FIELDS` in `src/lib/db/server/userService.ts` is the single source of truth. Currently: `teamId`, `profileImage`. Unknown keys are silently dropped at the service layer.
+`STRING_FIELDS` + `communicationPreferences` in `src/lib/db/server/userService.ts` is the single source of truth. Currently writable string fields: `teamId`, `profileImage`, `enlistmentCycle`, `address`. Unknown top-level keys are silently dropped at the service layer.
+
+### `communicationPreferences` shape validation
+
+The service rejects (`InvalidProfileUpdateError` → 400) when:
+
+- the payload is not a plain object,
+- it contains a key outside the boolean allowlist (`emailNotifications`, `equipmentTransferAlerts`, `systemUpdates`, `schedulingAlerts`, `emergencyNotifications`),
+- any value is not a boolean.
+
+Writes use **dotted field paths** (`communicationPreferences.emailNotifications: false`) so a partial patch only touches the toggled key — sibling flags on the doc survive. The service also stamps `communicationPreferences.lastUpdated` (server time) and `communicationPreferences.updatedBy` (the actor uid, defaulting to the subject uid).
 
 ## phoneNumber is rejected explicitly (400)
 
@@ -35,7 +60,7 @@ After a successful profile write, the route re-reads `users/{uid}` and calls `se
 
 ## Failure modes
 
-- 400 — missing `uid`, missing `updates` object, or `phoneNumber` present.
+- 400 — missing `uid`, missing `updates` object, `phoneNumber` present, or `communicationPreferences` shape invalid.
 - 403 — caller is not the user and not elevated.
 - 500 — Firestore failure during write or phone-book upsert.
 

--- a/docs/codebase/src/app/settings/page.md
+++ b/docs/codebase/src/app/settings/page.md
@@ -16,23 +16,27 @@ Settings page (`/settings`). Provides a comprehensive settings UI covering profi
 
 | State | Type | Purpose |
 |-------|------|---------|
-| `settings` | `{ emailNotifications, equipmentTransferAlerts, language, theme }` | Local toggle state — not persisted |
+| `notifPrefs` | `Record<NotifPrefKey, boolean>` | Persisted notification toggles, seeded from `enhancedUser.communicationPreferences` (with defaults). Optimistic-updated on click; an effect resyncs whenever `AuthContext` produces fresh prefs. |
+| `savingPref` | `NotifPrefKey \| null` | Which toggle has a network call in flight; disables the row and shows `cursor-wait`. |
+| `settings` | `{ language, theme }` | Local UI-only state — language/theme toggles are still placeholders (PR-F i18n + theming queued). |
 | `profileImageUrl` | `string \| undefined` | Profile image optimistic local state. Seeded from `readProfileImageCache(enhancedUser.uid)` to paint instantly on reload; `useEffect` revalidates against `enhancedUser.profileImage` and writes back. See `docs/codebase/src/lib/profileImageCache.md`. |
-| `changePasswordOpen` | `boolean` | Controls visibility of `<ChangePasswordModal>` |
+| `changePasswordOpen` / `changePhoneOpen` / `deleteAccountOpen` | `boolean` | Modal visibility flags. |
+| `cancellingDeletion` | `boolean` | Tracks the cancel-deletion API call. |
 
 ## Wired actions (real backend)
 
 - **Change password** — opens `<ChangePasswordModal>` (`src/components/settings/ChangePasswordModal.tsx`). Re-authenticates via Firebase, then `updatePassword`. Success → toast via `useToast`. Errors mapped through `mapFirebaseAuthError`. See PR-B in `project_settings_page.md`.
+- **Change phone** — opens `<ChangePhoneModal>` (PR-C). Triggers OTP flow against `/api/users/phone-change/*`.
 - **Account activity** — `<AccountActivitySection>` renders a collapsible read of the user's `credentialAuditLog` via `GET /api/auth/audit`. Shows event kind, timestamp, actor (self / admin), IP, and User-Agent. See `docs/codebase/src/components/settings/AccountActivitySection.md`.
 - **Sign out other devices** — `<RevokeSessionsRow>` renders inside the Account Security section. Posts to `/api/users/sessions/revoke` which bumps `users.sessionEpoch`, killing every other device on the next API hit. Writes a `SESSIONS_REVOKED` audit row. See `docs/codebase/src/components/settings/RevokeSessionsRow.md`.
+- **Notification preferences** — `<NotificationToggleRow>` (per row) calls `handleNotifToggle(key)`, which PATCHes `/api/users/profile` with `{ communicationPreferences: { [key]: nextValue } }`. Optimistic — toggle flips immediately; on error the previous value is restored and a danger toast surfaces. `await refreshEnhancedUser()` reloads the source-of-truth after a successful write.
 
 ## Known Issues / TODO
 
-- Most settings toggles are still UI-only (notifications, language, theme, permission requests, account deletion). Tracked in `project_settings_page.md` PR sequence.
-- `handleToggle` — logs to console, changes local state only.
-- `handleButtonClick` — logs to console, no action.
-- `handleImageUpdate` — does not persist image to Firestore.
+- `handleButtonClick` — logs to console, no action (used by the disabled "request permission" button — PR-H).
+- `handleImageUpdate` — does not yet persist image to Firestore from this page (the `<ProfileImageUpload>` component handles its own Storage upload; the local state here is purely for the immediate preview).
 - `mockPhoneNumber` and `mockPendingTransfers` are hardcoded placeholder values.
+- Language and theme toggles still UI-only — pending i18n PR-F.
 
 ## Notes
 

--- a/docs/codebase/src/components/settings/NotificationToggleRow.md
+++ b/docs/codebase/src/components/settings/NotificationToggleRow.md
@@ -1,0 +1,29 @@
+# NotificationToggleRow.tsx
+
+**File:** `src/components/settings/NotificationToggleRow.tsx`
+**Status:** Active
+
+## Purpose
+
+Single row in Settings → Notifications. Renders an icon, title, description, and an `aria-checked` switch button. Persistence is the parent's responsibility — this component is presentational and stateless aside from rendering the props.
+
+## Props
+
+| Prop | Type | Notes |
+|---|---|---|
+| `icon` | `ReactNode` | Decorative leading icon. |
+| `title` | `string` | Row label (also used as `aria-label` on the switch for screen readers). |
+| `description` | `string` | Secondary text. |
+| `enabled` | `boolean` | Drives both the visual on/off state and `aria-checked`. |
+| `saving` | `boolean` | When true, disables the button and applies `cursor-wait opacity-60`. |
+| `onToggle` | `() => void` | Fired on click. Parent owns optimistic update + rollback. |
+
+## A11y
+
+- `role="switch"` + `aria-checked` so screen readers announce the toggle state.
+- `aria-label={title}` so the switch is named even though the visible label sits in a sibling div.
+- Disabled while `saving` to prevent double-submit.
+
+## Caller
+
+Currently only `src/app/settings/page.tsx` uses it (2 rows: email notifications, equipment transfer alerts). The other three `communicationPreferences` keys (`systemUpdates`, `schedulingAlerts`, `emergencyNotifications`) are defined in the type and validated server-side but have no UI yet — add a row here when product asks for them.

--- a/docs/codebase/src/lib/db/server/userService.md
+++ b/docs/codebase/src/lib/db/server/userService.md
@@ -1,0 +1,44 @@
+# userService.ts (server)
+
+**File:** `src/lib/db/server/userService.ts`
+**Status:** Active
+
+## Purpose
+
+Server-side (firebase-admin) writes against `users/{uid}`. Used by `PATCH /api/users/profile` for self-service profile edits. Identity-anchor fields (phone, email, role/permissions) are intentionally NOT writable here — those flow through dedicated routes with stricter proofs.
+
+## Exports
+
+| Symbol | Shape | Notes |
+|---|---|---|
+| `serverUpdateUserProfile(uid, updates, actorUid?)` | `Promise<void>` | Whitelisted field write. No-ops when the patch yields zero allowed keys. Stamps `updatedAt` (server time). |
+| `InvalidProfileUpdateError` | `Error` subclass | Thrown when `communicationPreferences` fails shape validation. Route maps to HTTP 400. |
+| `ProfileUpdatePayload` | TS type | Shape accepted by `serverUpdateUserProfile`. |
+
+## Writable surface
+
+### String fields (top-level)
+
+`teamId`, `profileImage`, `enlistmentCycle`, `address`. Unknown keys are silently dropped — keeps the route forgiving when newer clients send fields the server doesn't recognise.
+
+### `communicationPreferences` (nested booleans)
+
+Only the keys listed in `COMM_PREF_BOOLEAN_KEYS` are accepted:
+`emailNotifications`, `equipmentTransferAlerts`, `systemUpdates`, `schedulingAlerts`, `emergencyNotifications`.
+
+Validation rejects (`InvalidProfileUpdateError`):
+- non-object payloads (`null`, arrays, primitives),
+- keys outside the allowlist,
+- non-boolean values.
+
+Writes use **dotted field paths** (`communicationPreferences.emailNotifications`) so a partial patch only touches the toggled key — sibling flags persist. The service also writes `communicationPreferences.lastUpdated` (`FieldValue.serverTimestamp()`) and `communicationPreferences.updatedBy` (the `actorUid` arg; defaults to the subject `uid` when omitted).
+
+## Explicit non-writable fields
+
+`phoneNumber` is rejected at the route layer (400) before the service is called — see `src/app/api/users/phone-change/*` for the dedicated OTP-gated flow. The route's pre-service guard is intentionally noisy (loud, not silent) so a client mistakenly sending `phoneNumber` learns immediately instead of seeing a 200 with no persisted change.
+
+`userType`, `permissions`, `role`, `status`, `militaryPersonalNumberHash`, `joinDate`, `createdAt`, `deletionRequestedAt` — none are in the whitelist and would be silently dropped if a client tried to set them.
+
+## Tests
+
+`src/lib/db/server/__tests__/userService.test.ts` locks in: no-op on empty patch, string-field write shape, dotted-path comm-pref write, actor-uid default, validation rejects (unknown key, non-boolean, non-object), and unknown-top-level-key drop.

--- a/docs/firebase-operations.md
+++ b/docs/firebase-operations.md
@@ -131,6 +131,7 @@ Not exposed via the app. Admins seed entries manually from the Firestore console
 | `src/lib/userService.ts` | `registerUser` | `setDoc` | Full user profile on registration |
 | `src/lib/adminUtils.ts` | `deleteUserByMilitaryHash` | `updateDoc` | `isDeleted: true`, `deletedAt` |
 | `src/lib/communicationService.ts` | `updateCommunicationPreferences` | `updateDoc` | `communicationPreferences.*` |
+| `src/lib/db/server/userService.ts` | `serverUpdateUserProfile` | `update` (admin) | Whitelisted: `teamId`, `profileImage`, `enlistmentCycle`, `address`, `communicationPreferences.{emailNotifications,equipmentTransferAlerts,systemUpdates,schedulingAlerts,emergencyNotifications}` (dotted paths + `lastUpdated`/`updatedBy` stamps) |
 | `src/components/SimpleUserTest.tsx` | `handleCreateTestUser` | `setDoc` | Test user profile |
 | `src/components/SimpleUserTest.tsx` | `handleDeleteTestUser` | `deleteDoc` | Removes test user document |
 

--- a/src/app/api/users/profile/route.ts
+++ b/src/app/api/users/profile/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { serverUpdateUserProfile } from '@/lib/db/server/userService';
+import { serverUpdateUserProfile, InvalidProfileUpdateError } from '@/lib/db/server/userService';
 import { getActorOrError } from '@/lib/db/server/auth';
 import { getAdminDb } from '@/lib/db/admin';
 import { COLLECTIONS } from '@/lib/db/collections';
@@ -8,7 +8,7 @@ import { serverUpsertPhoneBookFromUser } from '@/lib/db/server/phoneBookService'
 
 /**
  * PATCH /api/users/profile
- * Body: { uid: string, updates: { teamId?, profileImage? } }
+ * Body: { uid: string, updates: { teamId?, profileImage?, enlistmentCycle?, address?, communicationPreferences? } }
  *
  * Caller must be authenticated (bearer token). Only the user themselves, or
  * an ADMIN / SYSTEM_MANAGER, may update a profile.
@@ -47,7 +47,7 @@ export async function PATCH(request: Request) {
         { status: 403 }
       );
     }
-    await serverUpdateUserProfile(body.uid, body.updates);
+    await serverUpdateUserProfile(body.uid, body.updates, actor.uid);
 
     // Write-through to phone book when phone-book-relevant fields change.
     // phoneNumber is excluded above; the phone-change route will trigger its
@@ -75,6 +75,9 @@ export async function PATCH(request: Request) {
 
     return NextResponse.json({ success: true });
   } catch (error) {
+    if (error instanceof InvalidProfileUpdateError) {
+      return NextResponse.json({ success: false, error: error.message }, { status: 400 });
+    }
     const message = error instanceof Error ? error.message : String(error);
     console.error('[API] users/profile PATCH failed:', message);
     return NextResponse.json({ success: false, error: message }, { status: 500 });

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -11,12 +11,20 @@ import ChangePhoneModal from '@/components/settings/ChangePhoneModal';
 import DeleteAccountModal from '@/components/settings/DeleteAccountModal';
 import AccountActivitySection from '@/components/settings/AccountActivitySection';
 import RevokeSessionsRow from '@/components/settings/RevokeSessionsRow';
+import NotificationToggleRow from '@/components/settings/NotificationToggleRow';
 import { cancelAccountDeletion } from '@/lib/accountDeletionClient';
 import { readProfileImageCache, writeProfileImageCache } from '@/lib/profileImageCache';
 import { computeDaysLeft } from '@/components/settings/PendingDeletionBanner';
 import { Select } from '@/components/ui';
 import { useToast } from '@/components/ui/Toast';
+import { updateUserProfile } from '@/lib/userProfileService';
 import type { Timestamp } from 'firebase/firestore';
+
+type NotifPrefKey = 'emailNotifications' | 'equipmentTransferAlerts';
+const NOTIF_DEFAULTS: Record<NotifPrefKey, boolean> = {
+  emailNotifications: true,
+  equipmentTransferAlerts: true,
+};
 import {
   UserIcon,
   PhoneIcon,
@@ -68,10 +76,18 @@ export default function SettingsPage() {
     setCancellingDeletion(false);
   };
 
-  // TODO: Replace with actual state management when backend is implemented
+  // Notification toggles persist via PATCH /api/users/profile. Language and
+  // theme are still UI-only placeholders (PR-F i18n + theming pending).
+  const [notifPrefs, setNotifPrefs] = useState<Record<NotifPrefKey, boolean>>(() => ({
+    emailNotifications:
+      enhancedUser?.communicationPreferences?.emailNotifications ??
+      NOTIF_DEFAULTS.emailNotifications,
+    equipmentTransferAlerts:
+      enhancedUser?.communicationPreferences?.equipmentTransferAlerts ??
+      NOTIF_DEFAULTS.equipmentTransferAlerts,
+  }));
+  const [savingPref, setSavingPref] = useState<NotifPrefKey | null>(null);
   const [settings, setSettings] = useState({
-    emailNotifications: true,
-    equipmentTransferAlerts: false,
     language: 'hebrew',
     theme: 'light'
   });
@@ -92,17 +108,45 @@ export default function SettingsPage() {
     writeProfileImageCache(enhancedUser?.uid, resolved);
   }, [enhancedUser?.profileImage, enhancedUser?.uid]);
 
+  // Resync notification prefs from server data whenever the auth context
+  // refreshes (e.g. AuthContext finishes its initial Firestore fetch).
+  useEffect(() => {
+    setNotifPrefs({
+      emailNotifications:
+        enhancedUser?.communicationPreferences?.emailNotifications ??
+        NOTIF_DEFAULTS.emailNotifications,
+      equipmentTransferAlerts:
+        enhancedUser?.communicationPreferences?.equipmentTransferAlerts ??
+        NOTIF_DEFAULTS.equipmentTransferAlerts,
+    });
+  }, [
+    enhancedUser?.communicationPreferences?.emailNotifications,
+    enhancedUser?.communicationPreferences?.equipmentTransferAlerts,
+  ]);
+
   // TODO: Replace with actual data when backend is implemented
   const mockPhoneNumber = enhancedUser?.phoneNumber || '+972-50-123-4567';
   const mockPendingTransfers = 3; // Placeholder for notification badge
 
-  const handleToggle = (setting: string) => {
-    // TODO: Implement actual toggle logic when backend is ready
-    setSettings(prev => ({
-      ...prev,
-      [setting]: !prev[setting as keyof typeof prev]
-    }));
-    console.log(`Toggle ${setting} - UI only, no backend action`);
+  const handleNotifToggle = async (key: NotifPrefKey) => {
+    if (savingPref || !enhancedUser?.uid) return;
+    const previous = notifPrefs[key];
+    const next = !previous;
+    setNotifPrefs(prev => ({ ...prev, [key]: next }));
+    setSavingPref(key);
+    try {
+      await updateUserProfile(enhancedUser.uid, {
+        communicationPreferences: { [key]: next },
+      });
+      await refreshEnhancedUser();
+      showToast(TEXT_CONSTANTS.SETTINGS.NOTIFICATION_PREFS_SAVED, 'success');
+    } catch (error) {
+      setNotifPrefs(prev => ({ ...prev, [key]: previous }));
+      console.error('[settings] notification toggle failed:', error);
+      showToast(TEXT_CONSTANTS.SETTINGS.NOTIFICATION_PREFS_ERROR, 'danger');
+    } finally {
+      setSavingPref(null);
+    }
   };
 
   const handleButtonClick = (action: string) => {
@@ -252,61 +296,25 @@ export default function SettingsPage() {
             </div>
 
             <div className="space-y-4">
-              {/* Email Notifications */}
-              <div className="flex items-center justify-between p-4 border border-neutral-200 rounded-xl">
-                <div className="flex items-center gap-4">
-                  <MailIcon className="w-5 h-5 text-neutral-400" />
-                  <div>
-                    <h3 className="font-medium text-neutral-900">
-                      {TEXT_CONSTANTS.SETTINGS.EMAIL_NOTIFICATIONS}
-                    </h3>
-                    <p className="text-sm text-neutral-500">
-                      {TEXT_CONSTANTS.SETTINGS.EMAIL_NOTIFICATIONS_DESC}
-                    </p>
-                  </div>
-                </div>
-                <button
-                  onClick={() => handleToggle('emailNotifications')}
-                  disabled
-                  className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 cursor-not-allowed
-                    ${settings.emailNotifications ? 'bg-neutral-300' : 'bg-neutral-200'}
-                  `}
-                >
-                  <span
-                    className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform
-                      ${settings.emailNotifications ? 'translate-x-6' : 'translate-x-1'}
-                    `}
-                  />
-                </button>
-              </div>
-
-              {/* Equipment Transfer Alerts */}
-              <div className="flex items-center justify-between p-4 border border-neutral-200 rounded-xl">
-                <div className="flex items-center gap-4">
-                  <PackageIcon className="w-5 h-5 text-neutral-400" />
-                  <div>
-                    <h3 className="font-medium text-neutral-900">
-                      {TEXT_CONSTANTS.SETTINGS.EQUIPMENT_TRANSFER_ALERTS}
-                    </h3>
-                    <p className="text-sm text-neutral-500">
-                      {TEXT_CONSTANTS.SETTINGS.EQUIPMENT_TRANSFER_DESC}
-                    </p>
-                  </div>
-                </div>
-                <button
-                  onClick={() => handleToggle('equipmentTransferAlerts')}
-                  disabled
-                  className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 cursor-not-allowed
-                    ${settings.equipmentTransferAlerts ? 'bg-neutral-300' : 'bg-neutral-200'}
-                  `}
-                >
-                  <span
-                    className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform
-                      ${settings.equipmentTransferAlerts ? 'translate-x-6' : 'translate-x-1'}
-                    `}
-                  />
-                </button>
-              </div>
+              <NotificationToggleRow
+                icon={<MailIcon className="w-5 h-5 text-neutral-400" />}
+                title={TEXT_CONSTANTS.SETTINGS.EMAIL_NOTIFICATIONS}
+                description={TEXT_CONSTANTS.SETTINGS.EMAIL_NOTIFICATIONS_DESC}
+                enabled={notifPrefs.emailNotifications}
+                saving={savingPref === 'emailNotifications'}
+                onToggle={() => handleNotifToggle('emailNotifications')}
+              />
+              <NotificationToggleRow
+                icon={<PackageIcon className="w-5 h-5 text-neutral-400" />}
+                title={TEXT_CONSTANTS.SETTINGS.EQUIPMENT_TRANSFER_ALERTS}
+                description={TEXT_CONSTANTS.SETTINGS.EQUIPMENT_TRANSFER_DESC}
+                enabled={notifPrefs.equipmentTransferAlerts}
+                saving={savingPref === 'equipmentTransferAlerts'}
+                onToggle={() => handleNotifToggle('equipmentTransferAlerts')}
+              />
+              <p className="text-xs text-neutral-500 ps-1">
+                {TEXT_CONSTANTS.SETTINGS.NOTIFICATION_PREFS_NOTE}
+              </p>
             </div>
           </div>
 

--- a/src/components/settings/NotificationToggleRow.tsx
+++ b/src/components/settings/NotificationToggleRow.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { ReactNode } from 'react';
+
+interface NotificationToggleRowProps {
+  icon: ReactNode;
+  title: string;
+  description: string;
+  enabled: boolean;
+  saving: boolean;
+  onToggle: () => void;
+}
+
+/**
+ * Single row in the Settings → Notifications section. Optimistic toggle that
+ * the parent persists via PATCH /api/users/profile. `saving` reflects an
+ * in-flight network call so the button visibly waits and ignores re-clicks.
+ *
+ * UI only — the toggled flag controls future delivery; nothing is sent today.
+ */
+export default function NotificationToggleRow({
+  icon,
+  title,
+  description,
+  enabled,
+  saving,
+  onToggle,
+}: NotificationToggleRowProps) {
+  return (
+    <div className="flex items-center justify-between p-4 border border-neutral-200 rounded-xl">
+      <div className="flex items-center gap-4">
+        {icon}
+        <div>
+          <h3 className="font-medium text-neutral-900">{title}</h3>
+          <p className="text-sm text-neutral-500">{description}</p>
+        </div>
+      </div>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={enabled}
+        aria-label={title}
+        onClick={onToggle}
+        disabled={saving}
+        className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 ${
+          saving ? 'cursor-wait opacity-60' : 'cursor-pointer'
+        } ${enabled ? 'bg-primary-600' : 'bg-neutral-300'}`}
+      >
+        <span
+          className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+            enabled ? 'translate-x-6' : 'translate-x-1'
+          }`}
+        />
+      </button>
+    </div>
+  );
+}

--- a/src/constants/text.ts
+++ b/src/constants/text.ts
@@ -1363,6 +1363,10 @@ export const TEXT_CONSTANTS = {
     EMAIL_NOTIFICATIONS_DESC: 'קבל עדכונים חשובים באימייל',
     EQUIPMENT_TRANSFER_ALERTS: 'התראות העברת ציוד',
     EQUIPMENT_TRANSFER_DESC: 'קבל התראות על בקשות והעברות ציוד',
+    NOTIFICATION_PREFS_SAVED: 'העדפות ההתראות נשמרו.',
+    NOTIFICATION_PREFS_ERROR: 'שמירת ההעדפה נכשלה. נסה שוב.',
+    NOTIFICATION_PREFS_NOTE:
+      'ההגדרה נשמרת לחשבונך. שליחת ההתראות בפועל תופעל בעדכון עתידי.',
     TRANSFER_REQUESTS: 'בקשות העברה',
     PENDING_TRANSFERS: 'העברות ממתינות',
     

--- a/src/lib/db/server/__tests__/userService.test.ts
+++ b/src/lib/db/server/__tests__/userService.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Tests for the server-side user profile updater. Locks in:
+ *  - whitelist enforcement (unknown top-level keys dropped silently)
+ *  - communicationPreferences shape validation (unknown keys reject, non-boolean reject)
+ *  - dotted-path writes so partial patches don't clobber sibling pref flags
+ *  - meta fields (updatedAt + comm-pref lastUpdated/updatedBy) populated
+ */
+
+jest.mock('firebase-admin/firestore', () => ({
+  FieldValue: {
+    serverTimestamp: () => 'SERVER_TIMESTAMP',
+  },
+}));
+
+jest.mock('firebase-admin/app', () => ({
+  initializeApp: () => ({}),
+  getApps: () => [],
+  cert: () => ({}),
+  applicationDefault: () => ({}),
+}));
+
+const capturedWrites: Record<string, unknown>[] = [];
+const updateMock = jest.fn(async (data: Record<string, unknown>) => {
+  capturedWrites.push(data);
+});
+const docMock = jest.fn(() => ({ update: updateMock }));
+const collectionMock = jest.fn(() => ({ doc: docMock }));
+
+jest.mock('@/lib/db/admin', () => ({
+  getAdminDb: jest.fn(() => ({ collection: collectionMock })),
+}));
+
+import {
+  serverUpdateUserProfile,
+  InvalidProfileUpdateError,
+} from '../userService';
+
+beforeEach(() => {
+  updateMock.mockClear();
+  docMock.mockClear();
+  collectionMock.mockClear();
+  capturedWrites.length = 0;
+});
+
+describe('serverUpdateUserProfile', () => {
+  it('no-ops when no whitelisted fields are present', async () => {
+    await serverUpdateUserProfile('u1', { phoneNumber: '+972500000000' } as unknown as Parameters<typeof serverUpdateUserProfile>[1]);
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it('writes whitelisted string fields with updatedAt', async () => {
+    await serverUpdateUserProfile('u1', { teamId: 'alpha', address: '5th Ave' });
+    expect(updateMock).toHaveBeenCalledTimes(1);
+    expect(capturedWrites[0]).toEqual({
+      teamId: 'alpha',
+      address: '5th Ave',
+      updatedAt: 'SERVER_TIMESTAMP',
+    });
+  });
+
+  it('writes communicationPreferences via dotted paths so siblings survive', async () => {
+    await serverUpdateUserProfile(
+      'u1',
+      { communicationPreferences: { emailNotifications: false } },
+      'actor-uid',
+    );
+    expect(updateMock).toHaveBeenCalledTimes(1);
+    const payload = capturedWrites[0];
+    expect(payload['communicationPreferences.emailNotifications']).toBe(false);
+    expect(payload['communicationPreferences.lastUpdated']).toBe('SERVER_TIMESTAMP');
+    expect(payload['communicationPreferences.updatedBy']).toBe('actor-uid');
+    expect(payload.updatedAt).toBe('SERVER_TIMESTAMP');
+    // sibling flags must NOT be in the patch
+    expect(payload).not.toHaveProperty('communicationPreferences.equipmentTransferAlerts');
+  });
+
+  it('defaults actorUid to the subject uid when omitted', async () => {
+    await serverUpdateUserProfile('u1', {
+      communicationPreferences: { equipmentTransferAlerts: true },
+    });
+    expect(capturedWrites[0]['communicationPreferences.updatedBy']).toBe('u1');
+  });
+
+  it('rejects unknown communicationPreferences keys', async () => {
+    await expect(
+      serverUpdateUserProfile('u1', {
+        communicationPreferences: { foo: true } as unknown as Parameters<typeof serverUpdateUserProfile>[1]['communicationPreferences'],
+      }),
+    ).rejects.toBeInstanceOf(InvalidProfileUpdateError);
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects non-boolean communicationPreferences values', async () => {
+    await expect(
+      serverUpdateUserProfile('u1', {
+        communicationPreferences: { emailNotifications: 'yes' as unknown as boolean },
+      }),
+    ).rejects.toBeInstanceOf(InvalidProfileUpdateError);
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects non-object communicationPreferences payloads', async () => {
+    await expect(
+      serverUpdateUserProfile('u1', {
+        communicationPreferences: 'enabled' as unknown as Parameters<typeof serverUpdateUserProfile>[1]['communicationPreferences'],
+      }),
+    ).rejects.toBeInstanceOf(InvalidProfileUpdateError);
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it('drops unknown top-level fields silently (whitelist gate)', async () => {
+    await serverUpdateUserProfile('u1', {
+      teamId: 'alpha',
+      permissions: ['admin:everything'],
+    } as unknown as Parameters<typeof serverUpdateUserProfile>[1]);
+    expect(capturedWrites[0]).toEqual({ teamId: 'alpha', updatedAt: 'SERVER_TIMESTAMP' });
+  });
+});

--- a/src/lib/db/server/userService.ts
+++ b/src/lib/db/server/userService.ts
@@ -5,6 +5,7 @@
 import { getAdminDb } from '../admin';
 import { COLLECTIONS } from '../collections';
 import { FieldValue } from 'firebase-admin/firestore';
+import type { CommunicationPreferences } from '@/types/user';
 
 /**
  * Updates a user's editable profile fields. Only whitelisted keys are accepted
@@ -16,22 +17,77 @@ import { FieldValue } from 'firebase-admin/firestore';
  * `project_settings_page.md` PR-C. The route layer also 400s explicitly on
  * any `phoneNumber` field so the rejection is loud, not silent.
  */
-const PROFILE_WRITABLE_FIELDS = [
+const STRING_FIELDS = [
   'teamId',
   'profileImage',
   'enlistmentCycle',
   'address',
 ] as const;
-type ProfileWritableField = (typeof PROFILE_WRITABLE_FIELDS)[number];
+type StringField = (typeof STRING_FIELDS)[number];
+
+const COMM_PREF_BOOLEAN_KEYS = [
+  'emailNotifications',
+  'equipmentTransferAlerts',
+  'systemUpdates',
+  'schedulingAlerts',
+  'emergencyNotifications',
+] as const;
+type CommPrefBooleanKey = (typeof COMM_PREF_BOOLEAN_KEYS)[number];
+
+export type ProfileUpdatePayload = Partial<Record<StringField, string>> & {
+  communicationPreferences?: Partial<Pick<CommunicationPreferences, CommPrefBooleanKey>>;
+};
+
+export class InvalidProfileUpdateError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidProfileUpdateError';
+  }
+}
+
+/**
+ * Validates a `communicationPreferences` patch — only known boolean keys are
+ * allowed. Unknown keys reject hard so clients can't smuggle arbitrary nested
+ * data into the users doc via this surface.
+ *
+ * Writes use dotted field paths so a partial patch only touches the keys the
+ * caller sent and leaves the other preference flags intact.
+ */
+function buildCommPrefDotPaths(
+  raw: unknown,
+  actorUid: string,
+): Record<string, unknown> {
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new InvalidProfileUpdateError('communicationPreferences must be an object');
+  }
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(raw)) {
+    if (!(COMM_PREF_BOOLEAN_KEYS as readonly string[]).includes(key)) {
+      throw new InvalidProfileUpdateError(`unknown communicationPreferences key: ${key}`);
+    }
+    if (typeof value !== 'boolean') {
+      throw new InvalidProfileUpdateError(`communicationPreferences.${key} must be boolean`);
+    }
+    out[`communicationPreferences.${key}`] = value;
+  }
+  if (Object.keys(out).length === 0) return out;
+  out['communicationPreferences.lastUpdated'] = FieldValue.serverTimestamp();
+  out['communicationPreferences.updatedBy'] = actorUid;
+  return out;
+}
 
 export async function serverUpdateUserProfile(
   uid: string,
-  updates: Partial<Record<ProfileWritableField, string>>,
+  updates: ProfileUpdatePayload,
+  actorUid: string = uid,
 ): Promise<void> {
   const db = getAdminDb();
   const filtered: Record<string, unknown> = {};
-  for (const key of PROFILE_WRITABLE_FIELDS) {
+  for (const key of STRING_FIELDS) {
     if (updates[key] !== undefined) filtered[key] = updates[key];
+  }
+  if (updates.communicationPreferences !== undefined) {
+    Object.assign(filtered, buildCommPrefDotPaths(updates.communicationPreferences, actorUid));
   }
   if (Object.keys(filtered).length === 0) return;
   filtered.updatedAt = FieldValue.serverTimestamp();

--- a/src/lib/userProfileService.ts
+++ b/src/lib/userProfileService.ts
@@ -4,6 +4,14 @@
  */
 
 import { apiFetch } from '@/lib/apiFetch';
+import type { CommunicationPreferences } from '@/types/user';
+
+export type CommunicationPreferencesPatch = Partial<
+  Pick<
+    CommunicationPreferences,
+    'emailNotifications' | 'equipmentTransferAlerts' | 'systemUpdates' | 'schedulingAlerts' | 'emergencyNotifications'
+  >
+>;
 
 export interface ProfileUpdates {
   teamId?: string;
@@ -11,6 +19,7 @@ export interface ProfileUpdates {
   phoneNumber?: string;
   enlistmentCycle?: string;
   address?: string;
+  communicationPreferences?: CommunicationPreferencesPatch;
 }
 
 export async function updateUserProfile(uid: string, updates: ProfileUpdates): Promise<void> {


### PR DESCRIPTION
## Summary
- Server: `serverUpdateUserProfile` now accepts `communicationPreferences` (boolean allowlist: `emailNotifications`, `equipmentTransferAlerts`, `systemUpdates`, `schedulingAlerts`, `emergencyNotifications`). Writes use **dotted field paths** so a partial patch only touches the toggled key — sibling flags survive. Stamps `lastUpdated` + `updatedBy` for audit.
- Route: `PATCH /api/users/profile` surfaces `InvalidProfileUpdateError` as `400` and forwards the actor uid to the service.
- UI: Settings → Notifications toggles are no longer placeholders. Optimistic update + rollback on error via `useToast`, in-flight state shown with `cursor-wait`. New shared `<NotificationToggleRow>` with `role="switch"` + `aria-checked`.
- Tests: 8 new unit tests in `src/lib/db/server/__tests__/userService.test.ts` lock in whitelist gating, shape validation rejects, dotted-path partial-patch behaviour, and actor-uid default.
- Docs: backlog 2.3 marked shipped; `docs/firebase-operations.md`, the API route doc, the settings page doc, and a new `userService.md` + `NotificationToggleRow.md` all updated.

## Test plan
- [x] `npm run lint` clean
- [x] `npx jest src/lib/db/server/__tests__/userService.test.ts` — 8 passed
- [x] `npm test` — full suite 684 passed
- [x] `npm run build` — production build green
- [ ] Manual: toggle email / equipment alerts in `/settings`, refresh, confirm state persists; check Firestore doc shows `communicationPreferences.{key}` flipped + `lastUpdated`/`updatedBy` populated.
- [ ] Manual: throw a network error (offline) and confirm UI rolls back with a danger toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)