### PR TITLE
feat(cron): credentialAuditLog 1y TTL purge route + schedule

### DIFF
--- a/docs/codebase/src/app/api/cron/purge-credential-audit-log/README.md
+++ b/docs/codebase/src/app/api/cron/purge-credential-audit-log/README.md
@@ -1,0 +1,62 @@
+# POST /api/cron/purge-credential-audit-log
+
+**File:** `src/app/api/cron/purge-credential-audit-log/route.ts`
+**Status:** Active (PR-C follow-up — Council Q5=a, 1-year retention)
+
+## Purpose
+
+Daily retention sweep for `credentialAuditLog`. Deletes any entry whose `timestamp` is older than the retention window (default 365 days). Vercel Cron invokes this route daily at 03:30 UTC (offset 30 min from the sweep-account-deletions cron so the two don't compete for the same warm-start slot). Configured in `vercel.json`.
+
+## Auth
+
+Header: `Authorization: Bearer ${process.env.CRON_SECRET}`. Verification uses `crypto.timingSafeEqual`. Vercel auto-injects the same `Authorization` header on scheduled invocations once `CRON_SECRET` is set in the project env. The secret is shared with `sweep-account-deletions` — both cron routes trust the same operator-rotated value.
+
+**Not** bearer-Firebase-token gated. This is a system-to-system endpoint with its own trust boundary — do not try to reuse `getActorFromRequest`.
+
+## Production-project gate
+
+Refuses with 503 unless `NEXT_PUBLIC_FIREBASE_PROJECT_ID === 'sayeret-givati-1983'`. A preview or dev deployment that accidentally inherits a real cron schedule cannot vaporise prod audit history.
+
+## Query flags
+
+| Flag | Default | Clamp | Effect |
+|---|---|---|---|
+| `?dryRun=true` | `false` | — | Pages through the matching set without writing. Safety net for first manual hit. |
+| `?ageDays=N` | `365` | 1..3650 | Override retention window. |
+| `?maxDeletes=N` | `5000` | 1..10000 | Per-invocation hard cap on deletes. A run that hits the cap returns `truncated: true` so the next tick picks up the rest. |
+
+## Response
+
+200 with `PurgeResult`:
+
+```json
+{
+  "success": true,
+  "examined": 412,
+  "deleted": 412,
+  "failed": 0,
+  "dryRun": false,
+  "ageDays": 365,
+  "cutoff": "2025-05-14T03:30:00.000Z",
+  "durationMs": 1815,
+  "truncated": false
+}
+```
+
+Error responses:
+- `401 unauthorized` — bearer mismatch.
+- `503 cron_disabled` — `CRON_SECRET` env var missing.
+- `503 wrong_project` — running outside the prod Firebase project.
+- `400 bad_age_days` / `bad_max_deletes` — query param is not a number.
+- `500 purge_failed` — service threw at the top level.
+
+## Observability
+
+A single `[cron/purge-credential-audit-log] done` log per run carries the full `PurgeResult`. A batch-level commit failure mid-run emits `batch delete failed: <message>` and bails out — `failed` is non-zero on the response; the next scheduled run will retry the same `< cutoff` query.
+
+## Related
+
+- `src/lib/db/server/credentialAuditService.ts` — `serverPurgeCredentialAuditLog` + `CREDENTIAL_AUDIT_RETENTION_DAYS`.
+- `scripts/purge-credential-audit-log.js` — operator-callable mirror that loads `.env.local` directly. Run with `--dry-run`, `--age-days N`, `--project <id>`.
+- `vercel.json` — schedule entry (`30 3 * * *`).
+- `project_settings_page` memory — PR-C Council follow-up list.

--- a/docs/codebase/src/lib/db/server/credentialAuditService.md
+++ b/docs/codebase/src/lib/db/server/credentialAuditService.md
@@ -32,18 +32,19 @@ The document is append-only — no update or delete path exists in this codebase
 
 - `writeCredentialAuditEvent(args)` — appends one entry; returns the generated doc id. Optional fields are omitted from the document when not supplied (and `metadata` is dropped when an empty object is passed).
 - `listCredentialAuditForUser(uid, limit = 50)` — newest-first, scoped to a single target user. Caller-elevation enforcement is the API route's job — this service trusts its caller.
+- `serverPurgeCredentialAuditLog(opts)` — paged retention sweep. Deletes entries whose `timestamp` is older than `opts.ageDays ?? CREDENTIAL_AUDIT_RETENTION_DAYS`. Pages 500 docs per batch (Firestore commit limit). Hard cap via `opts.maxDeletes` (default 5000) — runs that hit the cap return `truncated: true` so the next tick resumes from the same cutoff. `opts.dryRun` examines without writing. Bails out on a batch commit failure rather than retrying the same broken page — `failed` is non-zero on the response and the next tick retries.
+- `CREDENTIAL_AUDIT_RETENTION_DAYS = 365` — Council answer Q5=a (PR-C).
 
 ## Tests
 
-`src/lib/db/server/__tests__/credentialAuditService.test.ts` covers:
-- Minimal write shape (server timestamp, no optional fields leak).
-- IP + User-Agent included when supplied.
-- Empty `metadata` object dropped.
-- Non-empty `metadata` preserved.
-- List scopes by uid, orders descending on `timestamp`, applies default + custom limits.
+- `credentialAuditService.test.ts` — write shape (server timestamp, optional-field gating, empty-metadata drop) + list scoping/ordering/limit (10 cases).
+- `credentialAuditServicePurge.test.ts` — purge paged delete, multi-page iteration, dry-run, maxDeletes cap with `truncated`, batch-failure bail-out, cutoff math (8 cases).
 
 ## Related
 
-- API route: `src/app/api/auth/audit/route.ts`.
+- Write surface: `src/app/api/auth/audit/route.ts`.
+- Read surface: `src/components/settings/AccountActivitySection.tsx` via `GET /api/auth/audit`.
 - Client wrapper: `src/lib/credentialAuditClient.ts`.
-- Settings PR plan: `project_settings_page.md` PR-D.
+- Scheduled retention: `src/app/api/cron/purge-credential-audit-log/route.ts` (03:30 UTC daily via `vercel.json`).
+- Operator-callable retention: `scripts/purge-credential-audit-log.js`.
+- Settings PR plan: `project_settings_page.md` PR-D + PR-C Council Q5.

--- a/jest.setup.new.js
+++ b/jest.setup.new.js
@@ -38,12 +38,17 @@ const localStorageMock = {
 }
 global.localStorage = localStorageMock
 
-// Mock navigator.clipboard
-Object.assign(navigator, {
-  clipboard: {
-    writeText: jest.fn(),
-  },
-})
+// Mock navigator.clipboard. Guarded — the @jest-environment node tests
+// (cron/API routes) run before jsdom is installed, and older CI Node
+// versions don't expose `navigator` as a global. Skip silently there;
+// those tests never touch clipboard anyway.
+if (typeof navigator !== 'undefined') {
+  Object.assign(navigator, {
+    clipboard: {
+      writeText: jest.fn(),
+    },
+  })
+}
 
 // Mock window.alert
 global.alert = jest.fn()

--- a/src/app/api/cron/purge-credential-audit-log/__tests__/route.test.ts
+++ b/src/app/api/cron/purge-credential-audit-log/__tests__/route.test.ts
@@ -1,0 +1,147 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for POST /api/cron/purge-credential-audit-log. Validates the four
+ * guards in order — CRON_SECRET set, prod-project gate, bearer auth, query
+ * clamping — plus the happy path forwarding to `serverPurgeCredentialAuditLog`.
+ *
+ * The underlying service is mocked here; its own behaviour is covered in
+ * `credentialAuditServicePurge.test.ts`.
+ */
+
+const purgeMock = jest.fn();
+jest.mock('@/lib/db/server/credentialAuditService', () => ({
+  serverPurgeCredentialAuditLog: purgeMock,
+  CREDENTIAL_AUDIT_RETENTION_DAYS: 365,
+}));
+
+import { POST } from '../route';
+
+const PROD_PROJECT_ID = 'sayeret-givati-1983';
+
+function mkRequest(opts: { secret?: string; url?: string } = {}): Request {
+  const headers = new Headers();
+  if (opts.secret !== undefined) headers.set('authorization', `Bearer ${opts.secret}`);
+  return new Request(opts.url ?? 'https://example.com/api/cron/purge-credential-audit-log', {
+    method: 'POST',
+    headers,
+  });
+}
+
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  purgeMock.mockReset();
+  process.env = { ...originalEnv };
+  process.env.CRON_SECRET = 'test-secret';
+  process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID = PROD_PROJECT_ID;
+});
+
+afterAll(() => {
+  process.env = originalEnv;
+});
+
+describe('POST /api/cron/purge-credential-audit-log', () => {
+  it('503 when CRON_SECRET unset', async () => {
+    delete process.env.CRON_SECRET;
+    const res = await POST(mkRequest({ secret: 'anything' }));
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body).toMatchObject({ success: false, error: 'cron_disabled' });
+    expect(purgeMock).not.toHaveBeenCalled();
+  });
+
+  it('503 when project id is not the prod project', async () => {
+    process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID = 'some-preview-project';
+    const res = await POST(mkRequest({ secret: 'test-secret' }));
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body).toMatchObject({ success: false, error: 'wrong_project' });
+    expect(purgeMock).not.toHaveBeenCalled();
+  });
+
+  it('401 when bearer token missing', async () => {
+    const res = await POST(mkRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it('401 when bearer token wrong', async () => {
+    const res = await POST(mkRequest({ secret: 'wrong-secret' }));
+    expect(res.status).toBe(401);
+  });
+
+  it('400 when ageDays is not numeric', async () => {
+    const res = await POST(
+      mkRequest({
+        secret: 'test-secret',
+        url: 'https://example.com/api/cron/purge-credential-audit-log?ageDays=banana',
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('bad_age_days');
+  });
+
+  it('clamps ageDays to 1..3650', async () => {
+    purgeMock.mockResolvedValue({ deleted: 0, examined: 0 });
+    await POST(
+      mkRequest({
+        secret: 'test-secret',
+        url: 'https://example.com/api/cron/purge-credential-audit-log?ageDays=9999',
+      }),
+    );
+    expect(purgeMock).toHaveBeenCalledWith(
+      expect.objectContaining({ ageDays: 3650 }),
+    );
+
+    purgeMock.mockClear();
+    await POST(
+      mkRequest({
+        secret: 'test-secret',
+        url: 'https://example.com/api/cron/purge-credential-audit-log?ageDays=0',
+      }),
+    );
+    expect(purgeMock).toHaveBeenCalledWith(
+      expect.objectContaining({ ageDays: 1 }),
+    );
+  });
+
+  it('passes dryRun=true through', async () => {
+    purgeMock.mockResolvedValue({ deleted: 0, examined: 0 });
+    await POST(
+      mkRequest({
+        secret: 'test-secret',
+        url: 'https://example.com/api/cron/purge-credential-audit-log?dryRun=true',
+      }),
+    );
+    expect(purgeMock).toHaveBeenCalledWith(
+      expect.objectContaining({ dryRun: true }),
+    );
+  });
+
+  it('returns 200 with service result on success', async () => {
+    const result = {
+      examined: 10,
+      deleted: 10,
+      failed: 0,
+      dryRun: false,
+      ageDays: 365,
+      cutoff: '2025-05-14T00:00:00.000Z',
+      durationMs: 5,
+      truncated: false,
+    };
+    purgeMock.mockResolvedValue(result);
+    const res = await POST(mkRequest({ secret: 'test-secret' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({ success: true, ...result });
+  });
+
+  it('500 when service throws', async () => {
+    purgeMock.mockRejectedValue(new Error('boom'));
+    const res = await POST(mkRequest({ secret: 'test-secret' }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body).toMatchObject({ success: false, error: 'purge_failed' });
+  });
+});

--- a/src/app/api/cron/purge-credential-audit-log/route.ts
+++ b/src/app/api/cron/purge-credential-audit-log/route.ts
@@ -1,0 +1,115 @@
+/**
+ * POST /api/cron/purge-credential-audit-log
+ *
+ * Daily retention sweep for `credentialAuditLog`. Council answer Q5=a — 1
+ * year retention. Anything older than `ageDays` (default 365) is deleted.
+ * Designed for Vercel Cron — see `vercel.json`.
+ *
+ * Auth: `Authorization: Bearer ${CRON_SECRET}`. Same shared secret the
+ * sweep-account-deletions cron uses. Verification with
+ * `crypto.timingSafeEqual` to avoid timing leaks.
+ *
+ * Production-project gate: refuses with 503 unless the project id is the
+ * real prod project — guards against an accidentally-deployed preview
+ * environment vaporising audit history on its first cron tick.
+ *
+ * Query flags:
+ *  - `?dryRun=true` — examines but never writes. Safety net for the first
+ *    manual hit.
+ *  - `?ageDays=N` — override retention window. Clamped 1..3650. Default
+ *    `CREDENTIAL_AUDIT_RETENTION_DAYS`.
+ *  - `?maxDeletes=N` — per-invocation cap. Clamped 1..10000. Default 5000.
+ *    A run that hits the cap returns `truncated: true` so the next tick
+ *    picks up the rest.
+ *
+ * Response: `PurgeResult` body, plus a single `console.log` summary so the
+ * Vercel function logs carry a retention trail.
+ */
+import { NextResponse } from 'next/server';
+import { timingSafeEqual } from 'crypto';
+import {
+  CREDENTIAL_AUDIT_RETENTION_DAYS,
+  serverPurgeCredentialAuditLog,
+} from '@/lib/db/server/credentialAuditService';
+
+const PROD_PROJECT_ID = 'sayeret-givati-1983';
+
+function isAuthorized(request: Request): boolean {
+  const expected = process.env.CRON_SECRET;
+  if (!expected) return false;
+  const header = request.headers.get('authorization') ?? '';
+  const presented = header.startsWith('Bearer ') ? header.slice(7) : '';
+  if (!presented) return false;
+  const a = Buffer.from(presented);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) return false;
+  try {
+    return timingSafeEqual(a, b);
+  } catch {
+    return false;
+  }
+}
+
+function clampInt(raw: string | null, min: number, max: number, fallback: number): number | null {
+  if (raw === null) return fallback;
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return null;
+  return Math.max(min, Math.min(max, Math.trunc(n)));
+}
+
+export async function POST(request: Request) {
+  if (!process.env.CRON_SECRET) {
+    return NextResponse.json(
+      { success: false, error: 'cron_disabled', message: 'CRON_SECRET is not configured' },
+      { status: 503 },
+    );
+  }
+
+  if (process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID !== PROD_PROJECT_ID) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'wrong_project',
+        message: `Cron disabled outside the prod project (current: ${process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID ?? 'unset'})`,
+      },
+      { status: 503 },
+    );
+  }
+
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ success: false, error: 'unauthorized' }, { status: 401 });
+  }
+
+  const url = new URL(request.url);
+  const dryRun = url.searchParams.get('dryRun') === 'true';
+  const ageDays = clampInt(
+    url.searchParams.get('ageDays'),
+    1,
+    3650,
+    CREDENTIAL_AUDIT_RETENTION_DAYS,
+  );
+  if (ageDays === null) {
+    return NextResponse.json(
+      { success: false, error: 'bad_age_days', message: 'ageDays must be a number 1..3650' },
+      { status: 400 },
+    );
+  }
+  const maxDeletes = clampInt(url.searchParams.get('maxDeletes'), 1, 10000, 5000);
+  if (maxDeletes === null) {
+    return NextResponse.json(
+      { success: false, error: 'bad_max_deletes', message: 'maxDeletes must be a number 1..10000' },
+      { status: 400 },
+    );
+  }
+
+  console.log('[cron/purge-credential-audit-log] starting', { dryRun, ageDays, maxDeletes });
+  try {
+    const result = await serverPurgeCredentialAuditLog({ dryRun, ageDays, maxDeletes });
+    console.log('[cron/purge-credential-audit-log] done', result);
+    return NextResponse.json({ success: true, ...result });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('[cron/purge-credential-audit-log] FAILED', message);
+    return NextResponse.json({ success: false, error: 'purge_failed', message }, { status: 500 });
+  }
+}

--- a/src/lib/db/server/__tests__/credentialAuditServicePurge.test.ts
+++ b/src/lib/db/server/__tests__/credentialAuditServicePurge.test.ts
@@ -56,8 +56,8 @@ const state: QueryState = {
 };
 
 const queryChain = () => ({
-  where: (_field: string, _op: string, _value: unknown) => queryChain(),
-  orderBy: (_field: string, _direction: string) => queryChain(),
+  where: () => queryChain(),
+  orderBy: () => queryChain(),
   limit: (n: number) => {
     state.limits.push(n);
     return {

--- a/src/lib/db/server/__tests__/credentialAuditServicePurge.test.ts
+++ b/src/lib/db/server/__tests__/credentialAuditServicePurge.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Tests for `serverPurgeCredentialAuditLog`. Verifies paged deletion, dry-run,
+ * the maxDeletes cap (truncated flag), retention-window math, idempotence on
+ * an empty page, and batch-failure bail-out.
+ *
+ * The Firestore mock here is per-test — each test seeds its own `pages` array
+ * and the query `.get()` returns the next page, simulating the implementation
+ * pattern where the next iteration's `where('timestamp', '<', cutoff)` query
+ * automatically returns the next batch once the previous batch is deleted.
+ */
+
+jest.mock('firebase-admin/firestore', () => {
+  class FakeTimestamp {
+    constructor(public ms: number) {}
+    static fromMillis(ms: number) {
+      return new FakeTimestamp(ms);
+    }
+    toMillis() {
+      return this.ms;
+    }
+  }
+  return {
+    FieldValue: { serverTimestamp: () => 'SERVER_TIMESTAMP' },
+    Timestamp: FakeTimestamp,
+  };
+});
+
+jest.mock('firebase-admin/app', () => ({
+  initializeApp: () => ({}),
+  getApps: () => [],
+  cert: () => ({}),
+  applicationDefault: () => ({}),
+}));
+
+interface FakeDoc {
+  id: string;
+  ref: { id: string };
+}
+
+interface QueryState {
+  pages: FakeDoc[][];
+  pageIdx: number;
+  deletedIds: string[];
+  batchCommitShouldThrow: boolean;
+  batchCommitCalls: number;
+  limits: number[];
+}
+
+const state: QueryState = {
+  pages: [],
+  pageIdx: 0,
+  deletedIds: [],
+  batchCommitShouldThrow: false,
+  batchCommitCalls: 0,
+  limits: [],
+};
+
+const queryChain = () => ({
+  where: (_field: string, _op: string, _value: unknown) => queryChain(),
+  orderBy: (_field: string, _direction: string) => queryChain(),
+  limit: (n: number) => {
+    state.limits.push(n);
+    return {
+      get: async () => {
+        if (state.pageIdx >= state.pages.length) return { empty: true, size: 0, docs: [] };
+        const docs = state.pages[state.pageIdx];
+        state.pageIdx += 1;
+        // Clamp the returned page to the requested limit, matching real Firestore.
+        const truncated = docs.slice(0, n);
+        return { empty: truncated.length === 0, size: truncated.length, docs: truncated };
+      },
+    };
+  },
+});
+
+const collectionMock = jest.fn(() => queryChain());
+
+const batchMock = () => {
+  const pending: string[] = [];
+  return {
+    delete: (ref: { id: string }) => {
+      pending.push(ref.id);
+    },
+    commit: async () => {
+      state.batchCommitCalls += 1;
+      if (state.batchCommitShouldThrow) throw new Error('boom');
+      state.deletedIds.push(...pending);
+    },
+  };
+};
+
+jest.mock('@/lib/db/admin', () => ({
+  getAdminDb: jest.fn(() => ({
+    collection: collectionMock,
+    batch: batchMock,
+  })),
+}));
+
+import {
+  serverPurgeCredentialAuditLog,
+  CREDENTIAL_AUDIT_RETENTION_DAYS,
+} from '../credentialAuditService';
+
+beforeEach(() => {
+  state.pages = [];
+  state.pageIdx = 0;
+  state.deletedIds = [];
+  state.batchCommitShouldThrow = false;
+  state.batchCommitCalls = 0;
+  state.limits = [];
+  collectionMock.mockClear();
+});
+
+function pageOf(ids: string[]): FakeDoc[] {
+  return ids.map((id) => ({ id, ref: { id } }));
+}
+
+describe('serverPurgeCredentialAuditLog', () => {
+  it('default retention is 365 days', () => {
+    expect(CREDENTIAL_AUDIT_RETENTION_DAYS).toBe(365);
+  });
+
+  it('returns zero counts when nothing is past cutoff', async () => {
+    state.pages = []; // empty result
+    const result = await serverPurgeCredentialAuditLog();
+    expect(result).toMatchObject({
+      examined: 0,
+      deleted: 0,
+      failed: 0,
+      dryRun: false,
+      truncated: false,
+      ageDays: 365,
+    });
+    expect(state.batchCommitCalls).toBe(0);
+  });
+
+  it('deletes a full page and stops when the next page is empty', async () => {
+    state.pages = [pageOf(['a1', 'a2', 'a3'])];
+    const result = await serverPurgeCredentialAuditLog({ ageDays: 30 });
+    expect(state.deletedIds).toEqual(['a1', 'a2', 'a3']);
+    expect(result.deleted).toBe(3);
+    expect(result.examined).toBe(3);
+    expect(result.failed).toBe(0);
+    expect(result.truncated).toBe(false);
+    expect(result.ageDays).toBe(30);
+    expect(state.batchCommitCalls).toBe(1);
+  });
+
+  it('iterates multiple pages until empty', async () => {
+    state.pages = [pageOf(['a1', 'a2']), pageOf(['a3', 'a4']), pageOf(['a5'])];
+    const result = await serverPurgeCredentialAuditLog();
+    expect(state.deletedIds).toEqual(['a1', 'a2', 'a3', 'a4', 'a5']);
+    expect(result.deleted).toBe(5);
+    expect(result.truncated).toBe(false);
+  });
+
+  it('dry-run examines without committing batches', async () => {
+    state.pages = [pageOf(['a1', 'a2']), pageOf(['a3'])];
+    const result = await serverPurgeCredentialAuditLog({ dryRun: true });
+    expect(state.deletedIds).toEqual([]); // nothing actually deleted
+    expect(state.batchCommitCalls).toBe(0);
+    expect(result.deleted).toBe(3); // dry-run still reports the planned count
+    expect(result.dryRun).toBe(true);
+    expect(result.examined).toBe(3);
+  });
+
+  it('honours maxDeletes cap and reports truncated=true', async () => {
+    // Two real pages exist, but maxDeletes=3 should clamp the second page's
+    // limit to 1 doc and then stop without asking for another page.
+    state.pages = [pageOf(['a1', 'a2']), pageOf(['a3', 'a4', 'a5']), pageOf(['a6'])];
+    const result = await serverPurgeCredentialAuditLog({ maxDeletes: 3 });
+    expect(result.deleted).toBe(3);
+    expect(result.truncated).toBe(true);
+    expect(state.deletedIds).toEqual(['a1', 'a2', 'a3']);
+    // The limit passed to the second page must be remaining=1, not 500.
+    expect(state.limits).toEqual([3, 1]);
+  });
+
+  it('bails out on batch commit failure without spinning retries', async () => {
+    state.pages = [pageOf(['a1', 'a2']), pageOf(['a3'])];
+    state.batchCommitShouldThrow = true;
+    const result = await serverPurgeCredentialAuditLog();
+    expect(result.failed).toBe(2);
+    expect(result.deleted).toBe(0);
+    expect(state.batchCommitCalls).toBe(1); // did not retry second page
+  });
+
+  it('cutoff is now - ageDays', async () => {
+    state.pages = [];
+    const now = new Date('2026-05-14T00:00:00Z');
+    const result = await serverPurgeCredentialAuditLog({ ageDays: 10, now });
+    const cutoff = new Date(result.cutoff).getTime();
+    expect(now.getTime() - cutoff).toBe(10 * 24 * 60 * 60 * 1000);
+  });
+});

--- a/src/lib/db/server/credentialAuditService.ts
+++ b/src/lib/db/server/credentialAuditService.ts
@@ -8,8 +8,17 @@
  */
 import { getAdminDb } from '../admin';
 import { COLLECTIONS } from '../collections';
-import { FieldValue } from 'firebase-admin/firestore';
+import { FieldValue, Timestamp } from 'firebase-admin/firestore';
 import type { CredentialAuditEntry, CredentialAuditEventType } from '@/types/credentialAudit';
+
+/**
+ * Council answer Q5=a — `credentialAuditLog` retains 1 year.
+ *
+ * Exposed as a constant so the cron route, the manual script, and tests can
+ * all agree on the window. Override via the `?ageDays=` query in the cron
+ * route or `--age-days` on `scripts/purge-credential-audit-log.js`.
+ */
+export const CREDENTIAL_AUDIT_RETENTION_DAYS = 365;
 
 interface WriteArgs {
   uid: string;
@@ -60,4 +69,110 @@ export async function listCredentialAuditForUser(
     .limit(limit)
     .get();
   return snap.docs.map((d) => ({ id: d.id, ...(d.data() as CredentialAuditEntry) }));
+}
+
+export interface PurgeOptions {
+  /** Retention window in days. Entries older than this are deleted. */
+  ageDays?: number;
+  /** Skip writes; log planned deletions only. */
+  dryRun?: boolean;
+  /**
+   * Hard cap on total deletes per invocation. Vercel cron tasks have a 60s
+   * default budget, so this stops one tick from running away on a backfill.
+   * Anything remaining rolls into the next scheduled run.
+   */
+  maxDeletes?: number;
+  /** Inject a clock for tests. */
+  now?: Date;
+}
+
+export interface PurgeResult {
+  examined: number;
+  deleted: number;
+  failed: number;
+  dryRun: boolean;
+  ageDays: number;
+  cutoff: string;
+  durationMs: number;
+  truncated: boolean;
+}
+
+const DEFAULT_MAX_DELETES = 5000;
+const PAGE_SIZE = 500;
+
+/**
+ * Page through `credentialAuditLog` deleting any entry older than the
+ * retention cutoff. Mirrors `scripts/purge-credential-audit-log.js` so the
+ * manual operator path and the scheduled cron stay byte-for-byte aligned.
+ *
+ * Resumable + idempotent: deletes by document reference in 500-doc batches
+ * (Firestore's commit limit). A partial run aborts cleanly — the next tick
+ * picks up at the same cutoff and finds the remaining stragglers.
+ */
+export async function serverPurgeCredentialAuditLog(
+  opts: PurgeOptions = {},
+): Promise<PurgeResult> {
+  const startedAtMs = Date.now();
+  const ageDays = opts.ageDays ?? CREDENTIAL_AUDIT_RETENTION_DAYS;
+  const dryRun = !!opts.dryRun;
+  const maxDeletes = opts.maxDeletes ?? DEFAULT_MAX_DELETES;
+  const now = opts.now ?? new Date();
+  const cutoffMs = now.getTime() - ageDays * 24 * 60 * 60 * 1000;
+  const cutoffTs = Timestamp.fromMillis(cutoffMs);
+
+  const db = getAdminDb();
+  let deleted = 0;
+  let failed = 0;
+  let examined = 0;
+  let truncated = false;
+
+  // Iterate pages until either the query is empty or we hit the per-tick cap.
+  // No startAfter cursor needed: every iteration deletes the entries it saw,
+  // so the next `< cutoff` query returns the next page automatically.
+  while (deleted + failed < maxDeletes) {
+    const remaining = maxDeletes - (deleted + failed);
+    const pageSize = Math.min(PAGE_SIZE, remaining);
+    const snap = await db
+      .collection(COLLECTIONS.CREDENTIAL_AUDIT_LOG)
+      .where('timestamp', '<', cutoffTs)
+      .orderBy('timestamp', 'asc')
+      .limit(pageSize)
+      .get();
+    if (snap.empty) break;
+    examined += snap.size;
+
+    if (dryRun) {
+      deleted += snap.size;
+      continue;
+    }
+
+    const batch = db.batch();
+    for (const d of snap.docs) batch.delete(d.ref);
+    try {
+      await batch.commit();
+      deleted += snap.size;
+    } catch (e) {
+      failed += snap.size;
+      console.error(
+        '[credentialAuditLog/purge] batch delete failed:',
+        e instanceof Error ? e.message : String(e),
+      );
+      // A batch failure is non-fatal — bail out so we don't spin retrying
+      // the same broken page. Next tick will hit it again.
+      break;
+    }
+  }
+
+  if (deleted + failed >= maxDeletes) truncated = true;
+
+  return {
+    examined,
+    deleted,
+    failed,
+    dryRun,
+    ageDays,
+    cutoff: new Date(cutoffMs).toISOString(),
+    durationMs: Date.now() - startedAtMs,
+    truncated,
+  };
 }

--- a/vercel.json
+++ b/vercel.json
@@ -4,6 +4,10 @@
     {
       "path": "/api/cron/sweep-account-deletions",
       "schedule": "0 3 * * *"
+    },
+    {
+      "path": "/api/cron/purge-credential-audit-log",
+      "schedule": "30 3 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Scheduled retention sweep for `credentialAuditLog` enforcing **Council Q5=a** (1-year retention).
- New `POST /api/cron/purge-credential-audit-log` route. Mirrors existing `sweep-account-deletions` cron: `CRON_SECRET` bearer with `crypto.timingSafeEqual`, prod-project gate (refuses outside `sayeret-givati-1983`), `?dryRun=true` / `?ageDays=N` (clamp 1..3650) / `?maxDeletes=N` (clamp 1..10000) query flags.
- New `serverPurgeCredentialAuditLog(opts)` in `credentialAuditService.ts`. Pages 500 docs per batch (Firestore commit limit). Hard cap via `maxDeletes` so a backlog resumes across ticks (`truncated: true` flag in the response). Bails out on batch-commit failure rather than spinning retries; non-zero `failed` count surfaces in the response.
- `vercel.json` schedule: `30 3 * * *` (30 min offset from the existing 03:00 UTC sweep-account-deletions cron).
- Operator-callable `scripts/purge-credential-audit-log.js` unchanged — same retention math via `CREDENTIAL_AUDIT_RETENTION_DAYS = 365`.

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` — 701 passed (was 684, +17 new tests across two files)
  - 8 service tests in `credentialAuditServicePurge.test.ts` cover empty result, single page, multi-page iteration, dry-run, maxDeletes cap with truncated, batch-failure bail-out, cutoff math.
  - 9 route tests in `purge-credential-audit-log/__tests__/route.test.ts` cover CRON_SECRET 503, wrong-project 503, missing/wrong bearer 401, `bad_age_days` 400, ageDays clamp, dryRun passthrough, 200 success, 500 service-throw.
- [x] `npm run build` — production build green
- [ ] **Operator:** confirm `CRON_SECRET` is set in Vercel production env. Same secret as `sweep-account-deletions` (already pending from earlier session). Both crons reuse it.
- [ ] **Operator (first hit):** invoke with `?dryRun=true` first to confirm the cutoff query returns the expected counts before live deletes.

## Schedule

| Cron | UTC | Vercel path |
|---|---|---|
| Account-deletion sweep | 03:00 | `/api/cron/sweep-account-deletions` |
| Credential audit purge | 03:30 | `/api/cron/purge-credential-audit-log` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)