### PR TITLE
feat(settings): success step + 'sign out other devices now' CTA on phone change

### DIFF
--- a/docs/codebase/src/components/settings/ChangePhoneModal.md
+++ b/docs/codebase/src/components/settings/ChangePhoneModal.md
@@ -32,9 +32,11 @@ enterOtp — 6-digit code input
   ↓
   applyVerifiedPhoneCredential (Firebase updatePhoneNumber + force-refresh idToken)
   ↓
-  POST /api/users/phone-change/confirm (server validates + mirrors)
+  POST /api/users/phone-change/confirm (server validates + mirrors + sessionEpoch fence)
   ↓
-success toast → modal closes
+success — green confirmation card + optional manual "sign out other devices now" CTA
+  ↓ Done (or X / backdrop)
+onSuccess() fires → modal closes
 ```
 
 A "חזור — שנה מספר" link in `enterOtp` resets back to `enterNumber` and invalidates the prior `verificationId` so a new SMS can be requested with a different number.
@@ -67,5 +69,5 @@ Hebrew strings live in `TEXT_CONSTANTS.SETTINGS.CHANGE_PHONE_*`. English mirrors
 ## Deferred polish (out of PR-C)
 
 - ~~Pre-flight explainer card listing the prerequisites before step 1.~~ ✅ Shipped 2026-05-14 on `feat/phone-change-preflight` — new `preflight` step lists SMS, password reauth, other-device logout, and rate limit before the reauth step. Bullets keyed under `CHANGE_PHONE_PREFLIGHT_*`.
-- "Sign out other devices now" explicit CTA in the success state. (sessionEpoch fence already cuts them on next API call — the CTA would just confirm it visually.)
+- ~~"Sign out other devices now" explicit CTA in the success state.~~ ✅ Shipped 2026-05-14 on `feat/phone-change-sign-out-cta` — new `success` step with green confirmation card + a manual "Sign out other devices now" button that hits `/api/users/sessions/revoke` directly (idempotent bump on top of the `sessionEpoch` fence the confirm route already stamped). On revoke success the button collapses to a "✓ Other devices signed out" badge. `closeAndCleanup` fires `onSuccess()` when dismissed from the success step so the parent toast still surfaces if the user X-closes instead of clicking Done. Strings keyed under `CHANGE_PHONE_SUCCESS_*` + `CHANGE_PHONE_SIGN_OUT_NOW_*`.
 - Old-phone notification (email + SMS) — blocked on PR-E channel pick.

--- a/src/components/settings/ChangePhoneModal.tsx
+++ b/src/components/settings/ChangePhoneModal.tsx
@@ -7,7 +7,7 @@ import {
   DialogPanel,
   DialogTitle,
 } from '@headlessui/react';
-import { Eye, EyeOff, X, ArrowRight, ShieldAlert } from 'lucide-react';
+import { Eye, EyeOff, X, ArrowRight, ShieldAlert, CheckCircle2, LogOut } from 'lucide-react';
 import {
   reauthEmailPassword,
   verifyNewPhone,
@@ -22,6 +22,7 @@ import {
   confirmPhoneChange,
   cancelPhoneChange,
 } from '@/lib/phoneChangeClient';
+import { revokeOtherSessions } from '@/lib/sessionsClient';
 import { TEXT_CONSTANTS } from '@/constants/text';
 
 const RECAPTCHA_CONTAINER_ID = 'change-phone-recaptcha';
@@ -33,7 +34,9 @@ interface Props {
   onSuccess: () => void;
 }
 
-type Step = 'preflight' | 'reauth' | 'enterNumber' | 'enterOtp';
+type Step = 'preflight' | 'reauth' | 'enterNumber' | 'enterOtp' | 'success';
+
+type RevokeState = 'idle' | 'submitting' | 'done' | 'error';
 
 export default function ChangePhoneModal({ open, onClose, onSuccess }: Props) {
   const [step, setStep] = useState<Step>('preflight');
@@ -45,6 +48,8 @@ export default function ChangePhoneModal({ open, onClose, onSuccess }: Props) {
   const [pendingNonce, setPendingNonce] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [revokeState, setRevokeState] = useState<RevokeState>('idle');
+  const [revokeError, setRevokeError] = useState<string | null>(null);
 
   const hasPendingRef = useRef(false);
 
@@ -59,6 +64,8 @@ export default function ChangePhoneModal({ open, onClose, onSuccess }: Props) {
       setPendingNonce(null);
       setSubmitting(false);
       setError(null);
+      setRevokeState('idle');
+      setRevokeError(null);
       hasPendingRef.current = false;
       // Council recommendation: reset reCAPTCHA on mount. The module-level
       // cachedVerifier survives across React mounts; if registration ran
@@ -72,6 +79,12 @@ export default function ChangePhoneModal({ open, onClose, onSuccess }: Props) {
     if (hasPendingRef.current) {
       void cancelPhoneChange();
       hasPendingRef.current = false;
+    }
+    // On the success step the phone change already committed; closing via
+    // X / backdrop should still fire the parent's success callback so the
+    // toast surfaces. Pre-success closures stay cancel-only.
+    if (step === 'success') {
+      onSuccess();
     }
     onClose();
   };
@@ -167,13 +180,35 @@ export default function ChangePhoneModal({ open, onClose, onSuccess }: Props) {
       }
 
       hasPendingRef.current = false;
-      onSuccess();
-      onClose();
+      setStep('success');
     } catch (err) {
       setError(mapFirebaseAuthError(err));
     } finally {
       setSubmitting(false);
     }
+  };
+
+  // Success-state revoke. Server already bumped `users.sessionEpoch` to
+  // `auth_time` during phone-change confirm, so other devices were already
+  // fenced. Hitting `/api/users/sessions/revoke` here bumps the epoch a
+  // second time — idempotent in effect, but gives the user an explicit
+  // affordance + visual ack instead of trusting the silent server-side fence.
+  const onRevokeOthersNow = async () => {
+    if (revokeState === 'submitting' || revokeState === 'done') return;
+    setRevokeError(null);
+    setRevokeState('submitting');
+    const result = await revokeOtherSessions();
+    if (result.success) {
+      setRevokeState('done');
+    } else {
+      setRevokeState('error');
+      setRevokeError(result.error || TEXT_CONSTANTS.SETTINGS.REVOKE_SESSIONS_ERROR);
+    }
+  };
+
+  const finishSuccess = () => {
+    onSuccess();
+    onClose();
   };
 
   const goBackToNumberStep = () => {
@@ -357,6 +392,57 @@ export default function ChangePhoneModal({ open, onClose, onSuccess }: Props) {
                 submittingLabel={TEXT_CONSTANTS.SETTINGS.CHANGE_PHONE_SUBMITTING}
               />
             </form>
+          )}
+
+          {step === 'success' && (
+            <div className="space-y-4">
+              <div className="flex items-start gap-3 p-3 bg-success-50 border border-success-200 rounded-lg">
+                <CheckCircle2 className="w-5 h-5 text-success-700 flex-shrink-0 mt-0.5" aria-hidden="true" />
+                <div className="text-sm text-success-900">
+                  <p className="font-medium">
+                    {TEXT_CONSTANTS.SETTINGS.CHANGE_PHONE_SUCCESS_TITLE}
+                  </p>
+                  <p className="mt-1 text-success-800">
+                    {TEXT_CONSTANTS.SETTINGS.CHANGE_PHONE_SUCCESS_BODY}
+                  </p>
+                </div>
+              </div>
+
+              {revokeState === 'done' ? (
+                <div
+                  className="flex items-center gap-2 text-sm text-success-700 bg-success-50 border border-success-200 rounded-lg px-3 py-2"
+                  role="status"
+                >
+                  <CheckCircle2 className="w-4 h-4" aria-hidden="true" />
+                  {TEXT_CONSTANTS.SETTINGS.CHANGE_PHONE_SIGN_OUT_NOW_DONE}
+                </div>
+              ) : (
+                <button
+                  type="button"
+                  onClick={onRevokeOthersNow}
+                  disabled={revokeState === 'submitting'}
+                  className="btn-secondary w-full text-sm flex items-center justify-center gap-2"
+                >
+                  <LogOut className="w-4 h-4" aria-hidden="true" />
+                  {revokeState === 'submitting'
+                    ? TEXT_CONSTANTS.SETTINGS.CHANGE_PHONE_SIGN_OUT_NOW_SUBMITTING
+                    : TEXT_CONSTANTS.SETTINGS.CHANGE_PHONE_SIGN_OUT_NOW_BUTTON}
+                </button>
+              )}
+              {revokeState === 'error' && revokeError && (
+                <ErrorBox message={revokeError} />
+              )}
+
+              <div className="flex items-center justify-end pt-2">
+                <button
+                  type="button"
+                  onClick={finishSuccess}
+                  className="btn-primary"
+                >
+                  {TEXT_CONSTANTS.SETTINGS.CHANGE_PHONE_SUCCESS_DONE}
+                </button>
+              </div>
+            </div>
           )}
 
           <div id={RECAPTCHA_CONTAINER_ID} />

--- a/src/constants/text.en.ts
+++ b/src/constants/text.en.ts
@@ -52,6 +52,13 @@ export const TEXT_EN = {
     CHANGE_PHONE_SUBMIT_OTP: 'Confirm phone change',
     CHANGE_PHONE_SUBMITTING: 'Updating...',
     CHANGE_PHONE_SUCCESS: 'Phone number updated. Your other devices were signed out.',
+    CHANGE_PHONE_SUCCESS_TITLE: 'Phone number updated',
+    CHANGE_PHONE_SUCCESS_BODY:
+      'The new number is saved. Your other devices will be signed out automatically on their next request to the server.',
+    CHANGE_PHONE_SIGN_OUT_NOW_BUTTON: 'Sign out other devices now',
+    CHANGE_PHONE_SIGN_OUT_NOW_SUBMITTING: 'Signing out...',
+    CHANGE_PHONE_SIGN_OUT_NOW_DONE: 'Other devices signed out ✓',
+    CHANGE_PHONE_SUCCESS_DONE: 'Done',
     CHANGE_PHONE_SAME_NUMBER: 'The new number matches the existing one — nothing to change.',
     CHANGE_PHONE_INVALID_E164: 'Phone number must be in international format (e.g. +972501234567).',
     CHANGE_PHONE_RATE_LIMITED: 'Try again in a moment. Only one change per minute is allowed.',

--- a/src/constants/text.ts
+++ b/src/constants/text.ts
@@ -1311,6 +1311,13 @@ export const TEXT_CONSTANTS = {
     CHANGE_PHONE_SUBMIT_OTP: 'אשר שינוי מספר',
     CHANGE_PHONE_SUBMITTING: 'מעדכן...',
     CHANGE_PHONE_SUCCESS: 'מספר הטלפון עודכן בהצלחה. מכשירים אחרים שלך נותקו.',
+    CHANGE_PHONE_SUCCESS_TITLE: 'מספר הטלפון עודכן',
+    CHANGE_PHONE_SUCCESS_BODY:
+      'המספר החדש נשמר. מכשירים אחרים שלך ינותקו אוטומטית בפעולה הבאה שלהם מול השרת.',
+    CHANGE_PHONE_SIGN_OUT_NOW_BUTTON: 'נתק מכשירים אחרים עכשיו',
+    CHANGE_PHONE_SIGN_OUT_NOW_SUBMITTING: 'מנתק...',
+    CHANGE_PHONE_SIGN_OUT_NOW_DONE: 'מכשירים אחרים נותקו ✓',
+    CHANGE_PHONE_SUCCESS_DONE: 'סיום',
     CHANGE_PHONE_SAME_NUMBER: 'המספר החדש זהה למספר הקיים — אין שינוי לבצע.',
     CHANGE_PHONE_INVALID_E164: 'מספר טלפון חייב להיות בפורמט בינלאומי (לדוגמה +972501234567).',
     CHANGE_PHONE_RATE_LIMITED: 'נסה שוב בעוד רגע. אפשר לבקש שינוי פעם בדקה.',


### PR DESCRIPTION
## Summary
- New `success` step in `ChangePhoneModal`. Confirm no longer fires `onSuccess()` + `onClose()` immediately — it transitions to a green confirmation card so the user sees the result and can act on it.
- Manual **"Sign out other devices now"** CTA hits `/api/users/sessions/revoke` directly. Server already bumped `users.sessionEpoch` during phone-change confirm, so this is an idempotent second bump; the button exists so users get an explicit affordance + visible "✓ Other devices signed out" badge instead of trusting the silent server-side fence.
- `Done` / X / backdrop dismiss from the success step all fire the parent `onSuccess()` callback, so the existing `CHANGE_PHONE_SUCCESS` toast still surfaces regardless of how the user exits the success state.
- Closes the last "Deferred polish" item on `ChangePhoneModal.md` (pre-flight step shipped #91, this CTA shipped here, only old-phone notification remains — blocked on PR-E sender pick).
- Bilingual strings added: `CHANGE_PHONE_SUCCESS_TITLE` / `CHANGE_PHONE_SUCCESS_BODY` / `CHANGE_PHONE_SIGN_OUT_NOW_BUTTON` / `CHANGE_PHONE_SIGN_OUT_NOW_SUBMITTING` / `CHANGE_PHONE_SIGN_OUT_NOW_DONE` / `CHANGE_PHONE_SUCCESS_DONE` in both `text.ts` and `text.en.ts`.

## Why
The sessionEpoch fence is invisible — devices fail on their next API hit, but a user sitting on the settings page never sees that happen. The CTA + ✓ badge close the feedback loop and reuse the proven revoke-sessions endpoint.

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` — 701 passed (unchanged)
- [x] `npm run build` — production build green
- [ ] Manual: trigger phone change, confirm success step renders, click "Sign out other devices now", verify badge swap.
- [ ] Manual: trigger phone change, X-close the success step, verify the parent toast still fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)