### PR TITLE
docs(bugs): 4 phone book bugs — refresh stale, mobile rows, filter stack, page scroll

### DIFF
--- a/docs/bugs.md
+++ b/docs/bugs.md
@@ -17,6 +17,38 @@
     - **Expected:** when the item has no real serial number, hide both the `צ:` label *and* the value. Don't show "צ: 7af3-...-bc9d" — show nothing in that slot. Mirrors the equipment-domain fix from bugs #18 / #16 / #15 where non-serialized items stop pretending to have a serial.
     - **Likely fix surface:** the ammo list renderer that resolves `item.id` / `item.serialNumber` to the inline `[צ: ...]` chip. Gate the chip on `hasSerialNumber === true` (and backfill the flag on ammo items the same way `backfill-equipment-has-serial.js` did for equipment, if ammo docs don't already carry it).
 
+26. **Phone book "refresh" doesn't reflect upstream deletions** *(phone book)*
+    - **Repro:** delete a row from `authorized_personnel` (admin → Manage Personnel → delete). Open Phone Book. Click the refresh button. The deleted person still appears in the list. A hard page reload (F5) is the only way to evict them.
+    - **Why:** the phone book cache (`phoneBookCache` localStorage seed used to paint instantly on reload) is not invalidated on refresh — refresh probably re-renders from the same cached array, or the server-side query backing the refresh doesn't notice the upstream `authorized_personnel` deletion because the row was synthesised from `users ∪ authorized_personnel` and the join key (`militaryPersonalNumberHash`) still points to a `users` doc that the personnel deletion didn't touch.
+    - **Likely fix surface:**
+      - Refresh path: invalidate `phoneBookCache` localStorage before re-fetching so the UI doesn't paint the stale set first.
+      - Server: when `authorized_personnel/{hash}` is deleted, also delete the matching `phoneBook/{hash}` doc (or mark it inactive). Same write-through pattern as `serverUpsertPhoneBookFromUser` on create/update — but for the deletion path. Check `adminUtils.deleteUserByMilitaryHash` / `serverDeletePersonnel` for the hook point.
+      - Alternatively: phone-book query filters out rows whose backing personnel doc is missing.
+    - **Note:** this isn't a stale-cache-only bug — the underlying `phoneBook` collection itself probably also retains the row, since `scripts/backfill-phone-book.js` doesn't have a delete pass either.
+
+27. **Phone book table: rows clip data on mobile, need to be expandable** *(phone book, RAISED 3RD TIME)*
+    - **Operator note:** "as I told you three time already" — this is the third time the table-not-mobile-friendly pattern has been raised for the phone book. Same pattern that bug #21 fixed for the admin `UsersTab` is needed here.
+    - **Repro:** Phone Book on a phone-sized viewport. The table renders horizontal columns that overflow the viewport, so the user has to horizontally-scroll inside the row to see the data that's been cut off.
+    - **Expected behaviour:** rewrite the phone-book table to a list of expandable cards mirroring `UsersTab` (bug #21 fix) and `EquipmentTable`. Compact card visible state should show **name + phone + team**. Expand reveals the rest (email / userType / military ID / source / isRegistered / photoURL / address — whichever the row carries).
+    - **Likely fix surface:**
+      - `src/app/phone-book/page.tsx` (and any `PhoneBookTable.tsx` / `PhoneBookRow.tsx` if extracted) — drop the table layout, render a `<ul>` of Headless UI `<Disclosure>` rows.
+      - Copy the compact-card pattern from `UsersTab.tsx` (initials + name + suffix badge). Phone book doesn't have a registered-pending distinction but the `source: 'users' | 'authorized_personnel'` already distinguishes "real account" vs "personnel-only" rows — could surface as a small badge if it adds value.
+      - Reuse `formatPhoneForDisplay` from the existing utility for phone rendering.
+    - **Reference fix:** bug #21 (`feat/users-tab-expandable-mobile-friendly`, 2026-05-14).
+
+28. **Phone book filters stack vertically instead of using horizontal space** *(phone book)*
+    - **Repro:** Phone Book → look at the filter bar. The search input and both dropdown filters are stacked one above the other, eating vertical space and making the page feel cramped.
+    - **Expected layout:**
+      - **Row 1:** name search input (full width).
+      - **Row 2:** both dropdown filters side-by-side (split the row 50/50, or whatever sizing the existing `Select` components prefer with `flex-1`).
+    - **Likely fix surface:** the filters container in `src/app/phone-book/page.tsx`. Wrap the search in its own row; wrap both dropdowns in a `flex gap-3` row beneath it. On mobile (`sm:`-down) keep them stacked vertically if needed to avoid cramped Selects.
+
+29. **Phone book list overflows page height — need in-container scroll** *(phone book)*
+    - **Repro:** Phone Book with enough rows to scroll. The whole **page** scrolls instead of just the list inside its container, so the filter bar and page header scroll off-screen as the user moves down the list.
+    - **Expected behaviour:** the list container takes the remaining viewport height and scrolls internally (`max-h-[...] overflow-y-auto`), keeping filters + header pinned. Same pattern bug #21 used (`max-h-[28rem] overflow-y-auto` on `UsersTab`).
+    - **Why this matters here specifically:** the phone-book page only renders this one list — there is no other content the user could need to scroll to. Page scroll is wasted, in-container scroll matches user intent.
+    - **Likely fix surface:** the list wrapper in `src/app/phone-book/page.tsx`. Pick the height bound: `max-h-[calc(100vh-Npx)]` for "fill remaining viewport" or `max-h-[36rem]` for "give the page some breathing room below the list". Match the visual treatment used by `UsersTab` so the patterns stay consistent.
+
 25. **Stored / returned-to-army items still appear in the active list with full action set**
     - **Repro:** Equipment page. Items in `STORED` (`STATUS_STORED` from PR #76) and items returned to army (the "return" action that flips status to `RETIRED`) currently sit in the same list as active holdings and expose the full action menu.
     - **Expected behaviour:**


### PR DESCRIPTION
## Summary
Four open bugs raised by operator on the phone book page:

- **#26** Refresh button doesn't reflect upstream `authorized_personnel` deletions — the phone-book row stays. Likely both stale cache AND missing delete write-through on the personnel deletion path (mirrors the create/update write-through that already exists via `serverUpsertPhoneBookFromUser`).
- **#27** Phone book table not mobile-friendly (operator: "as I told you three time already"). Rewrite to expandable cards mirroring bug #21's fix to `UsersTab`. Compact card: name + phone + team. Expand reveals the rest.
- **#28** Filters stack vertically instead of using horizontal space. Should be: search row, then both dropdowns side-by-side underneath.
- **#29** Page-level scroll instead of in-container scroll. Single-purpose page; list should scroll internally with header + filters pinned. Same max-h pattern bug #21 used.

Docs-only. No code change.

## Test plan
- [x] Manual review of `docs/bugs.md` rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)