### PR TITLE
fix(mobile): 16px font-size floor needs !important (bug #23 follow-up)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -220,11 +220,16 @@
    Gated on `pointer: coarse` so desktop layouts keep their compact form
    controls; only touch viewports get the 16px floor. Checkbox/radio/file
    inputs are excluded since they don't trigger the zoom and the size bump
-   would distort their hit-box. */
+   would distort their hit-box.
+   `!important` is required because Tailwind's `text-sm` / `text-xs` utility
+   classes have higher CSS specificity (0,1,0) than a bare `textarea`
+   selector (0,0,1) and would otherwise override the 16px floor. The
+   override is scoped to the exact controls that trigger the zoom, on the
+   exact viewports that need it, so the blast radius is contained. */
 @media (pointer: coarse) {
   input:not([type="checkbox"]):not([type="radio"]):not([type="file"]):not([type="range"]):not([type="color"]),
   textarea,
   select {
-    font-size: 16px;
+    font-size: 16px !important;
   }
 }


### PR DESCRIPTION
## Summary

PR #100 added a `@media (pointer: coarse)` rule that pinned `input` / `textarea` / `select` to `font-size: 16px` to prevent iOS/Android focus-zoom (bug #23). But Tailwind utility classes like `text-sm` have higher CSS specificity than bare tag selectors, so the rule never applied to the controls that use those classes (i.e. most of them). Mobile browsers continued to auto-zoom on focus — operator confirmed the bug was still reproducing on the equipment exchange-request modal.

This PR adds `!important` to the floor so it actually wins. Override stays scoped to form controls on `pointer: coarse` viewports — desktop layouts are untouched, hit-boxes for checkbox/radio/file/range/color still excluded.

## Test plan

- [ ] iPhone Safari: `/equipment` → ⋮ → "בקשת החלפה" → focus the reason textarea. No zoom. Close modal — site at original scale.
- [ ] Same on "החלף בפריט אחר" search input, ReportModal textarea, ReturnModal textarea, AddEquipmentWizard inputs.
- [ ] Desktop unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)