### PR TITLE
fix(convoy): square clear button + equal spread buttons + rename CTA

### DIFF
--- a/public/tools/hmmwvConvoy.html
+++ b/public/tools/hmmwvConvoy.html
@@ -189,13 +189,13 @@
     <div class="section-title" style="color:#2b5c8f;">👥 פיזור אנשים לשיירה</div>
     <div style="position: relative; background: #e8f4fd; border: 1px solid #b8daff; padding: 15px; border-radius: 5px; margin-bottom: 15px;">
         <button type="button" onclick="clearPersonnelList()" aria-label="נקה רשימה" title="נקה רשימה"
-            style="position: absolute; top: 6px; left: 6px; background: #dc3545; color: white; border: none; border-radius: 4px; padding: 2px 8px; font-size: 12px; line-height: 1.4; cursor: pointer; margin: 0;">
-            🗑️ נקה
+            style="position: absolute; top: 6px; left: 6px; width: 32px; height: 32px; min-width: 0; background: #dc3545; color: white; border: none; border-radius: 4px; padding: 0; font-size: 14px; line-height: 1; cursor: pointer; margin: 0; display: inline-flex; align-items: center; justify-content: center;">
+            🗑️
         </button>
         <label style="font-weight: bold; margin-bottom: 8px; display: block;">הדבק רשימת שמות (שם בכל שורה, עם או בלי בולט):</label>
         <textarea id="personnelList" style="height: 120px; margin-top: 0;" placeholder="• יוסי כהן&#10;• דוד לוי&#10;שרה אבן&#10;..."></textarea>
         <div style="display: flex; gap: 10px; margin-top: 10px; flex-wrap: wrap;">
-            <button class="btn-add" type="button" onclick="spreadPersonnel()" style="margin: 0; flex: 2;">פזר אנשים לשיירה ↓</button>
+            <button class="btn-add" type="button" onclick="spreadPersonnel()" style="margin: 0; flex: 1;">פזר אוטומטית ↓</button>
             <button class="btn-special" type="button" onclick="openManualSpread()" style="margin: 0; flex: 1;">פזר ידנית</button>
         </div>
         <div id="spreadResult" style="display: none; margin-top: 10px; padding: 10px; border-radius: 4px;"></div>


### PR DESCRIPTION
## Summary

- 🗑️ clear-list button now 32×32 square (previous fix didn't override the global `button { width: 100%; }`, so it stretched edge to edge). Label dropped to just the trash glyph.
- "פזר אוטומטית" + "פזר ידנית" share the row evenly (both `flex: 1`).
- Renamed "פזר אנשים לשיירה" → "פזר אוטומטית" so it reads as the obvious counterpart to "פזר ידנית".

## Test plan

- [ ] `/tools/convoy` → personnel section: small red square in top-left, icon centered.
- [ ] Click → textarea clears.
- [ ] Bottom row: two buttons of equal width, labels "פזר אוטומטית ↓" + "פזר ידנית".

🤖 Generated with [Claude Code](https://claude.com/claude-code)