### PR TITLE
fix(phone-book): force side-by-side filter dropdowns + cap list at 4 rows

### DIFF
--- a/src/app/phone-book/page.tsx
+++ b/src/app/phone-book/page.tsx
@@ -118,7 +118,7 @@ function PhoneBookContent() {
             className="w-full ps-9 pe-3 py-2 text-sm border border-neutral-200 rounded-lg bg-white focus:ring-2 focus:ring-primary-500"
           />
         </div>
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+        <div className="grid grid-cols-2 gap-2">
           <Select
             value={team}
             onChange={(v) => setTeam(v)}
@@ -167,7 +167,7 @@ function PhoneBookContent() {
         </div>
       ) : (
         <div className="border border-neutral-200 rounded-lg bg-white overflow-hidden">
-          <ul className="divide-y divide-neutral-100 max-h-[calc(100vh-20rem)] overflow-y-auto">
+          <ul className="divide-y divide-neutral-100 max-h-72 overflow-y-auto">
             {filtered.map((e) => (
               <PhoneBookRow
                 key={e.id}


### PR DESCRIPTION
## Summary

- Filter dropdowns were `grid-cols-1 sm:grid-cols-2` (stacked on mobile, side-by-side on `sm`+). Switched to plain `grid-cols-2` so team + role selects sit side-by-side at every viewport.
- List container changed from `max-h-[calc(100vh-20rem)]` to `max-h-72` (~4 rows). Anything past 4 rows scrolls internally; the rest of the page chrome stays visible.

## Test plan

- [ ] `/phone-book` on mobile: team + role dropdowns are side-by-side, not stacked.
- [ ] List shows up to ~4 rows; beyond that the list scrolls inside its container while filters + refresh row stay pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)