### PR TITLE
fix(equipment): cap card list at ~4 rows with internal scroll

### DIFF
--- a/src/components/equipment/EquipmentTable.tsx
+++ b/src/components/equipment/EquipmentTable.tsx
@@ -85,7 +85,7 @@ export default function EquipmentTable({
         selectedCount={Array.from(selectedIds).filter((id) => sorted.some((s) => s.id === id)).length}
       />
 
-      <ul className="space-y-2">
+      <ul className="space-y-2 max-h-72 overflow-y-auto pe-1">
         {sorted.map((item) => (
           <EquipmentRow
             key={item.id}


### PR DESCRIPTION
## Summary

Equipment page rendered every card inline → long lists pushed page chrome way past the fold. Wrapped the card `<ul>` with `max-h-72 overflow-y-auto pe-1`: list shows ~4 cards, rest scrolls internally. `pe-1` keeps the scrollbar from sitting tight against the card edges in RTL.

Same bound the phone-book already uses.

## Test plan

- [ ] `/equipment` with 10+ items: list shows ~4 cards; scroll wheel inside the list reveals the rest while the toolbar / filters stay pinned.
- [ ] Expand a card inside the list: panel expands, container scrolls to fit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)