### PR TITLE
refactor(settings): UI unification — pills, buttons, danger zone, phone dedup, account_created log

### DIFF
--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -6,6 +6,7 @@ import { FieldValue } from 'firebase-admin/firestore';
 import { UserType } from '@/types/user';
 import { UserRole } from '@/types/equipment';
 import { serverUpsertPhoneBookFromUser } from '@/lib/db/server/phoneBookService';
+import { writeCredentialAuditEvent } from '@/lib/db/server/credentialAuditService';
 
 export async function POST(request: NextRequest) {
   try {
@@ -99,6 +100,27 @@ export async function POST(request: NextRequest) {
       email: profile.email,
       userType: profile.userType as UserType,
     });
+
+    // Seed the credential audit log so the new user has at least one entry to
+    // see in Settings → Account Activity from day one. Fire-and-forget — never
+    // block registration on the audit write.
+    const ip =
+      request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+      request.headers.get('x-real-ip') ||
+      undefined;
+    const userAgent = request.headers.get('user-agent') || undefined;
+    try {
+      await writeCredentialAuditEvent({
+        uid,
+        actorUid: uid,
+        actorUserType: String(profile.userType),
+        eventType: 'ACCOUNT_CREATED',
+        ip,
+        userAgent,
+      });
+    } catch (e) {
+      console.warn('[API] /auth/register: account_created audit write failed:', e);
+    }
 
     return NextResponse.json({ success: true, uid, message: 'User profile created successfully' });
   } catch (error) {

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -66,17 +66,6 @@ export default function ProfilePage() {
     }
   };
 
-  const handlePhoneUpdate = async (newPhoneNumber: string) => {
-    setPhoneNumber(newPhoneNumber);
-    if (!enhancedUser) return;
-    try {
-      await updateUserProfile(enhancedUser.uid, { phoneNumber: newPhoneNumber });
-      await refreshEnhancedUser();
-    } catch (err) {
-      console.error('[profile] failed to save phone', err);
-    }
-  };
-
   return (
     <AuthGuard>
       <AppShell
@@ -173,7 +162,6 @@ export default function ProfilePage() {
                 user={enhancedUser}
                 authEmail={user?.email}
                 phoneNumber={phoneNumber}
-                onPhoneUpdate={handlePhoneUpdate}
                 onSaved={refreshEnhancedUser}
               />
             )}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -15,7 +15,6 @@ import NotificationToggleRow from '@/components/settings/NotificationToggleRow';
 import { cancelAccountDeletion } from '@/lib/accountDeletionClient';
 import { readProfileImageCache, writeProfileImageCache } from '@/lib/profileImageCache';
 import { computeDaysLeft } from '@/components/settings/PendingDeletionBanner';
-import { Select } from '@/components/ui';
 import { useToast } from '@/components/ui/Toast';
 import { updateUserProfile } from '@/lib/userProfileService';
 import type { Timestamp } from 'firebase/firestore';
@@ -31,12 +30,11 @@ import {
   KeyIcon,
   ShieldCheckIcon,
   BellIcon,
-  GlobeIcon,
-  PaletteIcon,
   LockIcon,
   TrashIcon,
   MailIcon,
   PackageIcon,
+  AlertTriangleIcon,
   ChevronRightIcon
 } from 'lucide-react';
 
@@ -87,10 +85,6 @@ export default function SettingsPage() {
       NOTIF_DEFAULTS.equipmentTransferAlerts,
   }));
   const [savingPref, setSavingPref] = useState<NotifPrefKey | null>(null);
-  const [settings, setSettings] = useState({
-    language: 'hebrew',
-    theme: 'light'
-  });
 
   // Profile image state. Drop legacy blob: URLs from the old mock — they error on render.
   // Seed from localStorage so the avatar paints instantly on reload (Firestore
@@ -124,9 +118,7 @@ export default function SettingsPage() {
     enhancedUser?.communicationPreferences?.equipmentTransferAlerts,
   ]);
 
-  // TODO: Replace with actual data when backend is implemented
-  const mockPhoneNumber = enhancedUser?.phoneNumber || '+972-50-123-4567';
-  const mockPendingTransfers = 3; // Placeholder for notification badge
+  const userPhoneNumber = enhancedUser?.phoneNumber || '—';
 
   const handleNotifToggle = async (key: NotifPrefKey) => {
     if (savingPref || !enhancedUser?.uid) return;
@@ -149,17 +141,11 @@ export default function SettingsPage() {
     }
   };
 
-  const handleButtonClick = (action: string) => {
-    // TODO: Implement actual actions when backend is ready
-    console.log(`${action} clicked - UI only, no backend action`);
-  };
-
-  // Handle profile image update
+  // Handle profile image update — Firestore persistence already happens inside
+  // ProfileImageUpload's own upload pipeline; we just sync local + cache.
   const handleImageUpdate = (newImageUrl: string) => {
     setProfileImageUrl(newImageUrl);
     writeProfileImageCache(enhancedUser?.uid, newImageUrl);
-    // TODO: Update image in Firestore
-    console.log('Profile image updated in settings:', newImageUrl);
   };
 
   return (
@@ -201,12 +187,16 @@ export default function SettingsPage() {
                     </p>
                   </div>
                 </div>
-                <div className="text-sm text-success-600 bg-success-50 px-3 py-1 rounded-full">
-                  ✅ פעיל
-                </div>
+                <span className="inline-flex items-center gap-1 text-xs text-success-700 bg-success-50 border border-success-200 px-2.5 py-1 rounded-full whitespace-nowrap">
+                  <span aria-hidden>✓</span>
+                  <span>פעיל</span>
+                </span>
               </div>
 
-              {/* Update Phone Number */}
+              {/* Update Phone Number — single canonical edit surface for the
+                  user's phone. The duplicated read-only "Linked Phone" row
+                  that used to live in Account Security was removed, since
+                  the phone value is already shown right here. */}
               <div className="flex items-center justify-between p-4 border border-neutral-200 rounded-xl hover:bg-neutral-50 transition-colors">
                 <div className="flex items-center gap-4">
                   <PhoneIcon className="w-5 h-5 text-neutral-400" />
@@ -214,15 +204,15 @@ export default function SettingsPage() {
                     <h3 className="font-medium text-neutral-900">
                       {TEXT_CONSTANTS.SETTINGS.UPDATE_PHONE}
                     </h3>
-                    <p className="text-sm text-neutral-500">
-                      {mockPhoneNumber}
+                    <p className="text-sm text-neutral-500" dir="ltr">
+                      {userPhoneNumber}
                     </p>
                   </div>
                 </div>
                 <button
                   type="button"
                   onClick={() => setChangePhoneOpen(true)}
-                  className="btn-primary text-sm"
+                  className="btn-primary text-sm min-w-[5rem]"
                 >
                   עדכן
                 </button>
@@ -244,9 +234,9 @@ export default function SettingsPage() {
                 <button
                   type="button"
                   onClick={() => setChangePasswordOpen(true)}
-                  className="btn-primary text-sm"
+                  className="btn-primary text-sm min-w-[5rem]"
                 >
-                  {TEXT_CONSTANTS.SETTINGS.CHANGE_PASSWORD}
+                  {TEXT_CONSTANTS.SETTINGS.CHANGE_PASSWORD_BTN_SHORT}
                 </button>
               </div>
             </div>
@@ -264,19 +254,6 @@ export default function SettingsPage() {
             </div>
 
             <div className="space-y-4">
-              <div className="p-4 border border-neutral-200 rounded-xl">
-                <div className="flex items-center gap-4">
-                  <PhoneIcon className="w-5 h-5 text-neutral-400" />
-                  <div>
-                    <h3 className="font-medium text-neutral-900">
-                      {TEXT_CONSTANTS.SETTINGS.LINKED_PHONE}
-                    </h3>
-                    <p className="text-sm text-neutral-500">
-                      {TEXT_CONSTANTS.SETTINGS.PHONE_NUMBER} {mockPhoneNumber}
-                    </p>
-                  </div>
-                </div>
-              </div>
               <RevokeSessionsRow />
             </div>
           </div>
@@ -318,79 +295,17 @@ export default function SettingsPage() {
             </div>
           </div>
 
-          {/* Language & Display Section */}
+          {/* Language & Display section removed — i18n + theming (PR-F) is
+              still pending. Both selects were `disabled` and gave the wrong
+              signal that a choice was possible. Section will return once
+              the language toggle is wired. */}
+
+          {/* Permissions — keep request-permission entry. Delete-account
+              moves into its own "איזור מסוכן" section below. */}
           <div className="bg-white rounded-2xl shadow-lg p-6 mb-8">
             <div className="flex items-center gap-3 mb-6">
-              <div className="p-2 bg-orange-100 rounded-lg">
-                <GlobeIcon className="w-5 h-5 text-orange-600" />
-              </div>
-              <h2 className="text-xl font-bold text-neutral-900">
-                {TEXT_CONSTANTS.SETTINGS.LANGUAGE_DISPLAY}
-              </h2>
-            </div>
-
-            <div className="space-y-4">
-              {/* Language Selector */}
-              <div className="flex items-center justify-between p-4 border border-neutral-200 rounded-xl">
-                <div className="flex items-center gap-4">
-                  <GlobeIcon className="w-5 h-5 text-neutral-400" />
-                  <div>
-                    <h3 className="font-medium text-neutral-900">
-                      {TEXT_CONSTANTS.SETTINGS.LANGUAGE_SELECTOR}
-                    </h3>
-                    <p className="text-sm text-neutral-500">
-                      {settings.language === 'hebrew' ? TEXT_CONSTANTS.SETTINGS.LANGUAGE_HEBREW : TEXT_CONSTANTS.SETTINGS.LANGUAGE_ENGLISH}
-                    </p>
-                  </div>
-                </div>
-                <div className="min-w-[10rem]">
-                  <Select
-                    value={settings.language}
-                    onChange={(v) => v && setSettings(prev => ({ ...prev, language: v }))}
-                    options={[
-                      { value: 'hebrew', label: TEXT_CONSTANTS.SETTINGS.LANGUAGE_HEBREW },
-                      { value: 'english', label: TEXT_CONSTANTS.SETTINGS.LANGUAGE_ENGLISH },
-                    ]}
-                    disabled
-                    ariaLabel={TEXT_CONSTANTS.SETTINGS.LANGUAGE_HEBREW}
-                  />
-                </div>
-              </div>
-
-              {/* Theme Switcher */}
-              <div className="flex items-center justify-between p-4 border border-neutral-200 rounded-xl">
-                <div className="flex items-center gap-4">
-                  <PaletteIcon className="w-5 h-5 text-neutral-400" />
-                  <div>
-                    <h3 className="font-medium text-neutral-900">
-                      {TEXT_CONSTANTS.SETTINGS.THEME_SWITCHER}
-                    </h3>
-                    <p className="text-sm text-neutral-500">
-                      {settings.theme === 'light' ? TEXT_CONSTANTS.SETTINGS.THEME_LIGHT : TEXT_CONSTANTS.SETTINGS.THEME_DARK}
-                    </p>
-                  </div>
-                </div>
-                <div className="min-w-[10rem]">
-                  <Select
-                    value={settings.theme}
-                    onChange={(v) => v && setSettings(prev => ({ ...prev, theme: v }))}
-                    options={[
-                      { value: 'light', label: TEXT_CONSTANTS.SETTINGS.THEME_LIGHT },
-                      { value: 'dark', label: TEXT_CONSTANTS.SETTINGS.THEME_DARK },
-                    ]}
-                    disabled
-                    ariaLabel={TEXT_CONSTANTS.SETTINGS.THEME_SWITCHER}
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-
-          {/* Privacy & Permissions Section */}
-          <div className="bg-white rounded-2xl shadow-lg p-6 mb-8">
-            <div className="flex items-center gap-3 mb-6">
-              <div className="p-2 bg-danger-100 rounded-lg">
-                <LockIcon className="w-5 h-5 text-danger-600" />
+              <div className="p-2 bg-primary-100 rounded-lg">
+                <LockIcon className="w-5 h-5 text-primary-600" />
               </div>
               <h2 className="text-xl font-bold text-neutral-900">
                 {TEXT_CONSTANTS.SETTINGS.PRIVACY_PERMISSIONS}
@@ -398,8 +313,7 @@ export default function SettingsPage() {
             </div>
 
             <div className="space-y-4">
-              {/* Request Permission */}
-              <div className="flex items-center justify-between p-4 border border-neutral-200 rounded-xl hover:bg-neutral-50 transition-colors">
+              <div className="flex items-center justify-between p-4 border border-neutral-200 rounded-xl">
                 <div className="flex items-center gap-4">
                   <LockIcon className="w-5 h-5 text-neutral-400" />
                   <div>
@@ -412,77 +326,71 @@ export default function SettingsPage() {
                   </div>
                 </div>
                 <button
-                  onClick={() => handleButtonClick('requestPermission')}
+                  type="button"
                   disabled
-                  className="px-4 py-2 text-sm bg-neutral-100 text-neutral-400 rounded-lg cursor-not-allowed flex items-center gap-2"
+                  className="px-4 py-2 text-sm bg-neutral-100 text-neutral-400 rounded-lg cursor-not-allowed flex items-center gap-2 min-w-[5rem]"
                 >
                   {TEXT_CONSTANTS.SETTINGS.REQUEST_PERMISSION}
                   <ChevronRightIcon className="w-4 h-4" />
                 </button>
               </div>
-
-              {/* Delete Account — swaps to cancel-deletion button when a request is pending. */}
-              <div className="flex items-center justify-between p-4 border border-danger-200 rounded-xl bg-danger-50">
-                <div className="flex items-center gap-4">
-                  <TrashIcon className="w-5 h-5 text-danger-500" />
-                  <div>
-                    <h3 className="font-medium text-danger-900">
-                      {hasPendingDeletion
-                        ? TEXT_CONSTANTS.SETTINGS.DELETE_ACCOUNT_PENDING_TITLE
-                        : TEXT_CONSTANTS.SETTINGS.DELETE_ACCOUNT}
-                    </h3>
-                    <p className="text-sm text-danger-600">
-                      {hasPendingDeletion
-                        ? TEXT_CONSTANTS.SETTINGS.DELETE_ACCOUNT_PENDING_DAYS_LEFT(
-                            daysUntilHardDelete(enhancedUser?.deletionRequestedAt),
-                          )
-                        : TEXT_CONSTANTS.SETTINGS.DELETE_ACCOUNT_WARNING}
-                    </p>
-                  </div>
-                </div>
-                {hasPendingDeletion ? (
-                  <button
-                    type="button"
-                    onClick={handleCancelDeletion}
-                    disabled={cancellingDeletion}
-                    className="btn-ghost text-sm border border-danger-300 text-danger-700"
-                  >
-                    {cancellingDeletion
-                      ? TEXT_CONSTANTS.SETTINGS.DELETE_ACCOUNT_CANCELLING
-                      : TEXT_CONSTANTS.SETTINGS.DELETE_ACCOUNT_CANCEL_BUTTON}
-                  </button>
-                ) : (
-                  <button
-                    type="button"
-                    onClick={() => setDeleteAccountOpen(true)}
-                    className="btn-danger text-sm"
-                  >
-                    {TEXT_CONSTANTS.SETTINGS.DELETE_ACCOUNT}
-                  </button>
-                )}
-              </div>
             </div>
           </div>
 
-          {/* TODO: Equipment Transfer Notifications Info Box */}
-          <div className="bg-info-50 rounded-2xl p-6 border border-info-200">
-            <div className="flex items-start gap-4">
-              <div className="p-2 bg-info-100 rounded-lg">
-                <PackageIcon className="w-5 h-5 text-info-600" />
+          {/* Danger Zone — destructive, irreversible actions. Visually
+              separated from the rest of the settings to make accidental
+              clicks less likely. */}
+          <div className="bg-white rounded-2xl shadow-lg p-6 mb-8 border-2 border-danger-200">
+            <div className="flex items-center gap-3 mb-2">
+              <div className="p-2 bg-danger-100 rounded-lg">
+                <AlertTriangleIcon className="w-5 h-5 text-danger-600" />
               </div>
-              <div className="flex-1">
-                <h3 className="font-medium text-info-900 mb-2">
-                  {TEXT_CONSTANTS.SETTINGS.TRANSFER_REQUESTS}
-                </h3>
-                <p className="text-sm text-info-700 mb-4">
-                  כרגע יש {mockPendingTransfers} בקשות העברת ציוד ממתינות לטיפול. 
-                  כאשר המערכת תהיה מוכנה, תוכל לקבל התראות אוטומטיות על בקשות אלו.
-                </p>
-                <div className="flex items-center gap-2 text-sm text-info-600">
-                  <BellIcon className="w-4 h-4" />
-                  <span>התראות יופעלו בעדכון עתידי</span>
+              <h2 className="text-xl font-bold text-danger-700">
+                {TEXT_CONSTANTS.SETTINGS.DANGER_ZONE}
+              </h2>
+            </div>
+            <p className="text-sm text-neutral-600 mb-6 ps-1">
+              {TEXT_CONSTANTS.SETTINGS.DANGER_ZONE_DESCRIPTION}
+            </p>
+
+            <div className="flex items-center justify-between p-4 border border-danger-200 rounded-xl bg-danger-50">
+              <div className="flex items-center gap-4">
+                <TrashIcon className="w-5 h-5 text-danger-500" />
+                <div>
+                  <h3 className="font-medium text-danger-900">
+                    {hasPendingDeletion
+                      ? TEXT_CONSTANTS.SETTINGS.DELETE_ACCOUNT_PENDING_TITLE
+                      : TEXT_CONSTANTS.SETTINGS.DELETE_ACCOUNT}
+                  </h3>
+                  <p className="text-sm text-danger-600">
+                    {hasPendingDeletion
+                      ? TEXT_CONSTANTS.SETTINGS.DELETE_ACCOUNT_PENDING_DAYS_LEFT(
+                          daysUntilHardDelete(enhancedUser?.deletionRequestedAt),
+                        )
+                      : TEXT_CONSTANTS.SETTINGS.DELETE_ACCOUNT_WARNING}
+                  </p>
                 </div>
               </div>
+              {hasPendingDeletion ? (
+                <button
+                  type="button"
+                  onClick={handleCancelDeletion}
+                  disabled={cancellingDeletion}
+                  className="btn-ghost text-sm border border-danger-300 text-danger-700 min-w-[5rem]"
+                >
+                  {cancellingDeletion
+                    ? TEXT_CONSTANTS.SETTINGS.DELETE_ACCOUNT_CANCELLING
+                    : TEXT_CONSTANTS.SETTINGS.DELETE_ACCOUNT_CANCEL_BUTTON}
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => setDeleteAccountOpen(true)}
+                  className="btn-danger text-sm min-w-[5rem]"
+                >
+                  {TEXT_CONSTANTS.SETTINGS.DELETE_ACCOUNT_BTN_SHORT}
+                </button>
+              )}
             </div>
           </div>
         </div>

--- a/src/components/profile/ContactInfoSection.tsx
+++ b/src/components/profile/ContactInfoSection.tsx
@@ -1,16 +1,15 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import Link from 'next/link';
 import type { EnhancedAuthUser } from '@/types/user';
 import { TEXT_CONSTANTS } from '@/constants/text';
 import { updateUserProfile } from '@/lib/userProfileService';
-import PhoneNumberUpdate from '@/components/profile/PhoneNumberUpdate';
 
 interface Props {
   user: EnhancedAuthUser;
   authEmail: string | undefined;
   phoneNumber: string;
-  onPhoneUpdate: (newPhone: string) => Promise<void> | void;
   onSaved: () => Promise<void> | void;
 }
 
@@ -19,7 +18,7 @@ interface Props {
  * dedicated update component. Address is editable behind the same
  * section-level pencil pattern used by `MilitaryInfoSection`.
  */
-export default function ContactInfoSection({ user, authEmail, phoneNumber, onPhoneUpdate, onSaved }: Props) {
+export default function ContactInfoSection({ user, authEmail, phoneNumber, onSaved }: Props) {
   const [editing, setEditing] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -79,22 +78,20 @@ export default function ContactInfoSection({ user, authEmail, phoneNumber, onPho
           <div className="text-neutral-900">{user.email || authEmail || TEXT_CONSTANTS.PROFILE.NOT_AVAILABLE}</div>
         </div>
 
-        {/* Phone is identity-anchor and needs its own re-verification ceremony
-            (real OTP path lands in the queued Settings PR-C). Outside edit
-            mode we render it as plain text — the PhoneNumberUpdate sub-flow
-            (with its own Update button + OTP) only appears when the section
-            is in edit mode. This avoids two competing action surfaces at
-            rest and preserves the seam PR-C will land on. */}
+        {/* Phone change moved to /settings — that's the canonical surface
+            with the real OTP flow. Rendered here as plain text plus a link
+            so the two pages stop competing. */}
         <div>
           <label className="block text-sm font-medium text-neutral-700 mb-1">{TEXT_CONSTANTS.PROFILE.PHONE_NUMBER_LABEL}</label>
-          {editing ? (
-            <PhoneNumberUpdate
-              currentPhoneNumber={phoneNumber}
-              onPhoneUpdate={onPhoneUpdate}
-            />
-          ) : (
+          <div className="flex items-center justify-between gap-3">
             <div className="text-neutral-900" dir="ltr">{phoneNumber || TEXT_CONSTANTS.PROFILE.NOT_AVAILABLE}</div>
-          )}
+            <Link
+              href="/settings"
+              className="text-sm text-primary-600 hover:text-primary-800 underline-offset-2 hover:underline shrink-0"
+            >
+              עדכן בהגדרות
+            </Link>
+          </div>
         </div>
 
         <div>

--- a/src/components/settings/AccountActivitySection.tsx
+++ b/src/components/settings/AccountActivitySection.tsx
@@ -16,6 +16,7 @@ import {
   ShieldOffIcon,
   TrashIcon,
   UndoIcon,
+  UserPlusIcon,
   UserXIcon,
   ActivityIcon,
 } from 'lucide-react';
@@ -28,6 +29,7 @@ import type { CredentialAuditEventType } from '@/types/credentialAudit';
 import { cn } from '@/lib/cn';
 
 const EVENT_ICON: Record<CredentialAuditEventType, React.ComponentType<{ className?: string }>> = {
+  ACCOUNT_CREATED: UserPlusIcon,
   PASSWORD_CHANGED: KeyIcon,
   PHONE_CHANGED: PhoneIcon,
   EMAIL_CHANGED: MailIcon,
@@ -39,6 +41,7 @@ const EVENT_ICON: Record<CredentialAuditEventType, React.ComponentType<{ classNa
 };
 
 const EVENT_LABEL: Record<CredentialAuditEventType, string> = {
+  ACCOUNT_CREATED: TEXT_CONSTANTS.SETTINGS.ACCOUNT_EVENT_ACCOUNT_CREATED,
   PASSWORD_CHANGED: TEXT_CONSTANTS.SETTINGS.ACCOUNT_EVENT_PASSWORD_CHANGED,
   PHONE_CHANGED: TEXT_CONSTANTS.SETTINGS.ACCOUNT_EVENT_PHONE_CHANGED,
   EMAIL_CHANGED: TEXT_CONSTANTS.SETTINGS.ACCOUNT_EVENT_EMAIL_CHANGED,
@@ -177,6 +180,7 @@ function AccountActivityBody({ entries, loading, error, onRetry, selfUid }: Body
           <AlertCircleIcon className="w-4 h-4" aria-hidden="true" />
           <span>{TEXT_CONSTANTS.SETTINGS.ACCOUNT_ACTIVITY_ERROR}</span>
         </div>
+        <p className="text-xs text-danger-700/80 font-mono break-all" dir="ltr">{error}</p>
         <button type="button" onClick={onRetry} className="btn-ghost text-sm text-danger-700">
           {TEXT_CONSTANTS.SETTINGS.ACCOUNT_ACTIVITY_RETRY}
         </button>
@@ -185,8 +189,9 @@ function AccountActivityBody({ entries, loading, error, onRetry, selfUid }: Body
   }
   if (!entries || entries.length === 0) {
     return (
-      <div className="text-sm text-neutral-500 py-4 text-center">
-        {TEXT_CONSTANTS.SETTINGS.ACCOUNT_ACTIVITY_EMPTY}
+      <div className="flex flex-col items-center gap-2 p-6 border border-dashed border-neutral-200 rounded-xl text-center">
+        <ActivityIcon className="w-6 h-6 text-neutral-400" aria-hidden="true" />
+        <p className="text-sm text-neutral-600">{TEXT_CONSTANTS.SETTINGS.ACCOUNT_ACTIVITY_EMPTY}</p>
       </div>
     );
   }

--- a/src/components/settings/NotificationToggleRow.tsx
+++ b/src/components/settings/NotificationToggleRow.tsx
@@ -42,13 +42,17 @@ export default function NotificationToggleRow({
         aria-label={title}
         onClick={onToggle}
         disabled={saving}
-        className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 ${
+        className={`relative inline-flex h-6 w-11 shrink-0 rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 ${
           saving ? 'cursor-wait opacity-60' : 'cursor-pointer'
         } ${enabled ? 'bg-primary-600' : 'bg-neutral-300'}`}
       >
+        {/* Absolute-positioned thumb with logical `start-*` so RTL flips it
+            correctly. The previous flex+translate-x approach pushed the thumb
+            out of the pill in RTL (translate-x is physical, layout was
+            logical). */}
         <span
-          className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
-            enabled ? 'translate-x-6' : 'translate-x-1'
+          className={`absolute top-1/2 -translate-y-1/2 h-4 w-4 rounded-full bg-white shadow-sm transition-all ${
+            enabled ? 'start-6' : 'start-1'
           }`}
         />
       </button>

--- a/src/components/settings/RevokeSessionsRow.tsx
+++ b/src/components/settings/RevokeSessionsRow.tsx
@@ -58,9 +58,9 @@ export default function RevokeSessionsRow() {
         <button
           type="button"
           onClick={() => setConfirmOpen(true)}
-          className="btn-primary text-sm"
+          className="btn-primary text-sm min-w-[5rem]"
         >
-          {TEXT_CONSTANTS.SETTINGS.REVOKE_SESSIONS}
+          {TEXT_CONSTANTS.SETTINGS.REVOKE_SESSIONS_BTN_SHORT}
         </button>
       </div>
 

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -39,7 +39,7 @@ export function ToastProvider({ children }: { children: ReactNode }) {
   return (
     <ToastContext.Provider value={{ showToast }}>
       {children}
-      <div className="fixed bottom-6 start-1/2 -translate-x-1/2 z-[10000] flex flex-col gap-2 pointer-events-none">
+      <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-[10000] flex flex-col gap-2 pointer-events-none">
         <AnimatePresence>
           {toasts.map((t) => (
             <motion.div

--- a/src/constants/text.ts
+++ b/src/constants/text.ts
@@ -1360,6 +1360,7 @@ export const TEXT_CONSTANTS = {
     ACCOUNT_ACTIVITY_DEVICE: 'מכשיר',
     ACCOUNT_ACTIVITY_ACTOR_SELF: 'על ידך',
     ACCOUNT_ACTIVITY_ACTOR_ADMIN: 'על ידי מנהל מערכת',
+    ACCOUNT_EVENT_ACCOUNT_CREATED: 'פתיחת חשבון',
     ACCOUNT_EVENT_PASSWORD_CHANGED: 'הסיסמה שונתה',
     ACCOUNT_EVENT_PHONE_CHANGED: 'מספר הטלפון שונה',
     ACCOUNT_EVENT_EMAIL_CHANGED: 'כתובת המייל שונתה',

--- a/src/constants/text.ts
+++ b/src/constants/text.ts
@@ -1336,6 +1336,11 @@ export const TEXT_CONSTANTS = {
 
     // Revoke other sessions
     REVOKE_SESSIONS: 'התנתק ממכשירים אחרים',
+    REVOKE_SESSIONS_BTN_SHORT: 'התנתק',
+    CHANGE_PASSWORD_BTN_SHORT: 'שנה',
+    DELETE_ACCOUNT_BTN_SHORT: 'מחק',
+    DANGER_ZONE: 'איזור מסוכן',
+    DANGER_ZONE_DESCRIPTION: 'פעולות בלתי הפיכות. הקפד לקרוא לפני ביצוע.',
     REVOKE_SESSIONS_DESCRIPTION:
       'מנתק את כל הסשנים האחרים שלך — כל מכשיר אחר יידרש להתחבר מחדש. המכשיר הנוכחי יישאר מחובר.',
     REVOKE_SESSIONS_CONFIRM_TITLE: 'לנתק מכשירים אחרים?',

--- a/src/types/credentialAudit.ts
+++ b/src/types/credentialAudit.ts
@@ -15,6 +15,7 @@
 import type { Timestamp } from 'firebase/firestore';
 
 export type CredentialAuditEventType =
+  | 'ACCOUNT_CREATED'
   | 'PASSWORD_CHANGED'
   | 'PHONE_CHANGED'
   | 'EMAIL_CHANGED'


### PR DESCRIPTION
## Summary

Operator-reviewed refactor of the Settings page. 7 items addressed across 4 commits on this branch:

1. **Buttons unified** — every action button uses `btn-primary text-sm min-w-[5rem]` (or `btn-danger` for destructive) so shapes/sizes match. Long labels shortened ("התנתק ממכשירים אחרים" → "התנתק", "שנה סיסמה" → "שנה", "מחק חשבון" → "מחק"); the full title still lives under the row icon for context.
2. **Toast position fix** — physical `left-1/2 -translate-x-1/2` instead of logical `start-1/2 -translate-x-1/2`. Toasts were rendering half-off the left edge in RTL because the anchor was logical but the transform was physical. Toasts now center correctly on every direction.
3. **Phone duplication cleaned up** — "Linked Phone" read-only row dropped from Account Security (it duplicated the phone displayed in the Update Phone row right above). `/profile`'s `ContactInfoSection` no longer renders the mock-OTP `PhoneNumberUpdate` — replaced with read-only display + a "עדכן בהגדרות" link to /settings, the canonical phone-change surface.
4. **Account activity** — new `ACCOUNT_CREATED` audit event emitted by `/api/auth/register` so newly-registered users always have at least one entry instead of an empty (or error-looking) state. Error block now also prints the raw error message in LTR monospace for operator diagnosis. Empty-state block redesigned with a dashed border + activity icon so it reads as a real empty state.
5. **Toggle thumb fix** — `NotificationToggleRow` was using flex layout + `translate-x-*` physical transforms, so the on/off thumb fell out of the pill in RTL. Switched to absolute positioning anchored to logical `start-1` / `start-6` so the thumb sits inside the track and animates correctly in both directions.
6. **Language section removed** — the language and theme selects were both `disabled` waiting on PR-F (i18n + theming). They were giving a false "you can pick" signal. Section will return when the language toggle is wired.
7. **Danger zone** — delete-account row split out of "Privacy & Permissions" into its own dedicated red-bordered card titled "איזור מסוכן" with a warning glyph and an explicit "פעולות בלתי הפיכות" description. Cancel-deletion / delete-button still swap based on `hasPendingDeletion`.

Profile-image "פעיל" pill switched to `inline-flex items-center` with a neutral ✓ glyph so the badge baseline-aligns. The hardcoded `mockPendingTransfers = 3` info box at the bottom of the page was dropped (placeholder content). Dead `handlePhoneUpdate` handler removed from `/profile`.

`npm run build`, `npm run lint`, `npm test` all pass.

## Test plan

- [ ] Settings → buttons all read short ("עדכן" / "שנה" / "התנתק" / "מחק"), same width and pill shape.
- [ ] Profile-image card right-side badge reads "✓ פעיל" centered vertically with the icon and text.
- [ ] Trigger any settings action (e.g. revoke sessions) — toast appears centered horizontally on the page, not cut off on the left.
- [ ] Notification toggles: thumb sits inside the gray/purple track in both states, on the leading edge when off and trailing edge when on (in RTL).
- [ ] Settings shows no Language & Display section.
- [ ] "איזור מסוכן" card sits at the bottom with red border, AlertTriangle glyph, and the delete-account row inside.
- [ ] Settings does NOT show a second "Linked Phone" read-only row in Account Security.
- [ ] /profile contact card: phone is read-only with a "עדכן בהגדרות" link that routes to /settings.
- [ ] New user registers → `/api/auth/register` writes ACCOUNT_CREATED audit entry. Open Settings → Account Activity → shows "פתיחת חשבון" row.
- [ ] Account Activity error path: trigger by signing out / clearing token → block shows error icon + raw message in LTR monospace + retry button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)