### PR TITLE
fix(settings): trim row descriptions, format phone, hide raw audit error

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -17,6 +17,7 @@ import { readProfileImageCache, writeProfileImageCache } from '@/lib/profileImag
 import { computeDaysLeft } from '@/components/settings/PendingDeletionBanner';
 import { useToast } from '@/components/ui/Toast';
 import { updateUserProfile } from '@/lib/userProfileService';
+import { formatPhoneForDisplay } from '@/utils/validationUtils';
 import type { Timestamp } from 'firebase/firestore';
 
 type NotifPrefKey = 'emailNotifications' | 'equipmentTransferAlerts';
@@ -118,7 +119,9 @@ export default function SettingsPage() {
     enhancedUser?.communicationPreferences?.equipmentTransferAlerts,
   ]);
 
-  const userPhoneNumber = enhancedUser?.phoneNumber || '—';
+  const userPhoneNumber = enhancedUser?.phoneNumber
+    ? formatPhoneForDisplay(enhancedUser.phoneNumber)
+    : '—';
 
   const handleNotifToggle = async (key: NotifPrefKey) => {
     if (savingPref || !enhancedUser?.uid) return;
@@ -222,14 +225,9 @@ export default function SettingsPage() {
               <div className="flex items-center justify-between p-4 border border-neutral-200 rounded-xl hover:bg-neutral-50 transition-colors">
                 <div className="flex items-center gap-4">
                   <KeyIcon className="w-5 h-5 text-neutral-400" />
-                  <div>
-                    <h3 className="font-medium text-neutral-900">
-                      {TEXT_CONSTANTS.SETTINGS.CHANGE_PASSWORD}
-                    </h3>
-                    <p className="text-sm text-neutral-500">
-                      {TEXT_CONSTANTS.SETTINGS.CHANGE_PASSWORD_DESCRIPTION}
-                    </p>
-                  </div>
+                  <h3 className="font-medium text-neutral-900">
+                    {TEXT_CONSTANTS.SETTINGS.CHANGE_PASSWORD}
+                  </h3>
                 </div>
                 <button
                   type="button"
@@ -289,9 +287,6 @@ export default function SettingsPage() {
                 saving={savingPref === 'equipmentTransferAlerts'}
                 onToggle={() => handleNotifToggle('equipmentTransferAlerts')}
               />
-              <p className="text-xs text-neutral-500 ps-1">
-                {TEXT_CONSTANTS.SETTINGS.NOTIFICATION_PREFS_NOTE}
-              </p>
             </div>
           </div>
 
@@ -316,14 +311,9 @@ export default function SettingsPage() {
               <div className="flex items-center justify-between p-4 border border-neutral-200 rounded-xl">
                 <div className="flex items-center gap-4">
                   <LockIcon className="w-5 h-5 text-neutral-400" />
-                  <div>
-                    <h3 className="font-medium text-neutral-900">
-                      {TEXT_CONSTANTS.SETTINGS.REQUEST_PERMISSION}
-                    </h3>
-                    <p className="text-sm text-neutral-500">
-                      {TEXT_CONSTANTS.SETTINGS.REQUEST_PERMISSION_DESC}
-                    </p>
-                  </div>
+                  <h3 className="font-medium text-neutral-900">
+                    {TEXT_CONSTANTS.SETTINGS.REQUEST_PERMISSION}
+                  </h3>
                 </div>
                 <button
                   type="button"
@@ -341,7 +331,7 @@ export default function SettingsPage() {
               separated from the rest of the settings to make accidental
               clicks less likely. */}
           <div className="bg-white rounded-2xl shadow-lg p-6 mb-8 border-2 border-danger-200">
-            <div className="flex items-center gap-3 mb-2">
+            <div className="flex items-center gap-3 mb-6">
               <div className="p-2 bg-danger-100 rounded-lg">
                 <AlertTriangleIcon className="w-5 h-5 text-danger-600" />
               </div>
@@ -349,9 +339,6 @@ export default function SettingsPage() {
                 {TEXT_CONSTANTS.SETTINGS.DANGER_ZONE}
               </h2>
             </div>
-            <p className="text-sm text-neutral-600 mb-6 ps-1">
-              {TEXT_CONSTANTS.SETTINGS.DANGER_ZONE_DESCRIPTION}
-            </p>
 
             <div className="flex items-center justify-between p-4 border border-danger-200 rounded-xl bg-danger-50">
               <div className="flex items-center gap-4">

--- a/src/components/settings/AccountActivitySection.tsx
+++ b/src/components/settings/AccountActivitySection.tsx
@@ -180,7 +180,6 @@ function AccountActivityBody({ entries, loading, error, onRetry, selfUid }: Body
           <AlertCircleIcon className="w-4 h-4" aria-hidden="true" />
           <span>{TEXT_CONSTANTS.SETTINGS.ACCOUNT_ACTIVITY_ERROR}</span>
         </div>
-        <p className="text-xs text-danger-700/80 font-mono break-all" dir="ltr">{error}</p>
         <button type="button" onClick={onRetry} className="btn-ghost text-sm text-danger-700">
           {TEXT_CONSTANTS.SETTINGS.ACCOUNT_ACTIVITY_RETRY}
         </button>

--- a/src/constants/text.ts
+++ b/src/constants/text.ts
@@ -1341,8 +1341,7 @@ export const TEXT_CONSTANTS = {
     DELETE_ACCOUNT_BTN_SHORT: 'מחק',
     DANGER_ZONE: 'איזור מסוכן',
     DANGER_ZONE_DESCRIPTION: 'פעולות בלתי הפיכות. הקפד לקרוא לפני ביצוע.',
-    REVOKE_SESSIONS_DESCRIPTION:
-      'מנתק את כל הסשנים האחרים שלך — כל מכשיר אחר יידרש להתחבר מחדש. המכשיר הנוכחי יישאר מחובר.',
+    REVOKE_SESSIONS_DESCRIPTION: 'מנתק את כל המכשירים האחרים שמחוברים',
     REVOKE_SESSIONS_CONFIRM_TITLE: 'לנתק מכשירים אחרים?',
     REVOKE_SESSIONS_CONFIRM_BODY:
       'מכשירים אחרים שמחוברים עם החשבון שלך יידרשו להתחבר מחדש. פעולה זו נכנסת לתוקף מיידית.',


### PR DESCRIPTION
## Summary

Follow-up trim pass on the Settings page after the previous refactor:

- Drop the "לשינוי הסיסמה..." description from the Change Password row — modal already walks the user through.
- Drop "פעולות בלתי הפיכות..." description from the Danger Zone card title — red border + AlertTriangle + section name already carry meaning.
- Drop "שלח בקשה למנהל המערכת..." description from the disabled Request Permission row.
- Drop the bottom "ההגדרות נשמרות מיידית..." note from the Notifications section.
- Shorten Revoke Sessions row subtitle to "מנתק את כל המכשירים האחרים שמחוברים".
- Format the phone number on the Update Phone row with `formatPhoneForDisplay` so it reads `0XX-XXX-XXXX` instead of the raw E.164.
- Account Activity error block no longer prints the raw error string — back to just "טעינת הפעילות נכשלה" + retry. The previous dump overwhelmed the card.

## Test plan

- [ ] Settings: Change Password / Request Permission / Danger Zone show no description text under their titles.
- [ ] Notifications section: no trailing note paragraph.
- [ ] Revoke Sessions row reads "מנתק את כל המכשירים האחרים שמחוברים".
- [ ] Phone number renders as `0XX-XXX-XXXX`.
- [ ] Account Activity error path shows the short Hebrew error + retry button only, no raw stack/JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)