### PR TITLE
fix(settings): audit index + button text-center + trim bottom whitespace

### DIFF
--- a/firebase/firestore.indexes.json
+++ b/firebase/firestore.indexes.json
@@ -145,6 +145,20 @@
           "order": "ASCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "credentialAuditLog",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "uid",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "timestamp",
+          "order": "DESCENDING"
+        }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -20,7 +20,7 @@
 @layer components {
   /* Buttons */
   .btn-primary {
-    @apply px-6 py-3 bg-primary-600 text-white rounded-xl font-medium
+    @apply px-6 py-3 bg-primary-600 text-white rounded-xl font-medium text-center
            hover:bg-primary-700 active:scale-[0.98] transition-all duration-200
            focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2
            disabled:opacity-50 disabled:cursor-not-allowed;
@@ -34,12 +34,12 @@
 
   .btn-ghost {
     @apply px-4 py-2 text-neutral-600 hover:text-neutral-900 hover:bg-neutral-100
-           font-medium rounded-xl transition-all duration-200
+           font-medium rounded-xl text-center transition-all duration-200
            focus:outline-none focus:ring-2 focus:ring-neutral-400 focus:ring-offset-2;
   }
 
   .btn-danger {
-    @apply px-4 py-2 bg-danger-600 text-white rounded-xl font-medium
+    @apply px-4 py-2 bg-danger-600 text-white rounded-xl font-medium text-center
            hover:bg-danger-700 active:scale-[0.98] transition-all duration-200
            focus:outline-none focus:ring-2 focus:ring-danger-500 focus:ring-offset-2
            disabled:opacity-50 disabled:cursor-not-allowed;

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -156,6 +156,7 @@ export default function SettingsPage() {
       <AppShell
         title={TEXT_CONSTANTS.SETTINGS.PAGE_TITLE}
         subtitle={TEXT_CONSTANTS.SETTINGS.PAGE_SUBTITLE}
+        mainClassName="px-4 sm:px-6 pb-12"
       >
         <div className="max-w-4xl mx-auto w-full">
           {/* Profile Settings Section */}
@@ -329,8 +330,9 @@ export default function SettingsPage() {
 
           {/* Danger Zone — destructive, irreversible actions. Visually
               separated from the rest of the settings to make accidental
-              clicks less likely. */}
-          <div className="bg-white rounded-2xl shadow-lg p-6 mb-8 border-2 border-danger-200">
+              clicks less likely. No bottom margin — it's the last card so
+              the extra gap was wasted whitespace under the section list. */}
+          <div className="bg-white rounded-2xl shadow-lg p-6 border-2 border-danger-200">
             <div className="flex items-center gap-3 mb-6">
               <div className="p-2 bg-danger-100 rounded-lg">
                 <AlertTriangleIcon className="w-5 h-5 text-danger-600" />


### PR DESCRIPTION
## Summary

1. **credentialAuditLog index** — added a composite `(uid ASC, timestamp DESC)` index to `firebase/firestore.indexes.json`. `listCredentialAuditForUser` runs `where('uid','==').orderBy('timestamp','desc')`, which Firestore rejects without this index — that's why Settings → Account Activity showed "Failed to load" for new users.
2. **Button text centering** — `.btn-primary`, `.btn-danger`, `.btn-ghost` in `globals.css` now include `text-center`. Native `<button>` text alignment inherits from the document, so RTL pages leaned button labels to one side. Affects revoke-sessions row and every `btn-*` site-wide.
3. **Settings bottom whitespace** — dropped `mb-8` from the trailing Danger Zone card (last child, margin was wasted) and tightened `mainClassName` to `pb-12` (was `pb-24 lg:pb-12`). FAB stays clear since it's `fixed`.

## Operator action

After merging, run:
```
firebase deploy --only firestore:indexes --project sayeret-givati-1983
```
Once the new index finishes building (visible in Firebase Console → Indexes), Account Activity will load on first visit instead of returning an index-missing error.

## Test plan

- [ ] After index deploy: Settings → Account Activity loads on first visit for a freshly registered user; shows the ACCOUNT_CREATED row.
- [ ] Buttons across Settings (התנתק / שנה / עדכן / מחק / בטל) have their text horizontally centered.
- [ ] Settings page bottom: gap between Danger Zone card and viewport bottom feels reasonable; FAB still floats clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)