### PR TITLE
fix(layout): trim AppShell bottom padding (less empty whitespace on every page)

### DIFF
--- a/src/app/components/AppShell.tsx
+++ b/src/app/components/AppShell.tsx
@@ -28,7 +28,7 @@ export default function AppShell({
   showBackArrow = false,
   showFab = true,
   hidePageHeader = false,
-  mainClassName = 'flex-1 px-4 sm:px-6 pb-24 lg:pb-12',
+  mainClassName = 'flex-1 px-4 sm:px-6 pb-12 lg:pb-8',
   children,
 }: AppShellProps) {
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -156,7 +156,6 @@ export default function SettingsPage() {
       <AppShell
         title={TEXT_CONSTANTS.SETTINGS.PAGE_TITLE}
         subtitle={TEXT_CONSTANTS.SETTINGS.PAGE_SUBTITLE}
-        mainClassName="px-4 sm:px-6 pb-12"
       >
         <div className="max-w-4xl mx-auto w-full">
           {/* Profile Settings Section */}


### PR DESCRIPTION
## Summary

`AppShell`'s default `mainClassName` was `flex-1 px-4 sm:px-6 pb-24 lg:pb-12` — the `pb-24` (96px) created a noticeable white gap at the bottom of every page, even on short content. Tightened to `pb-12 lg:pb-8` (48px / 32px). The FAB is `fixed`, so the smaller clear zone is still enough that it doesn't obscure the last card on full scroll.

Also reverted the settings-page-specific `mainClassName` override from the previous PR (no longer needed, default now matches).

## Test plan

- [ ] Every page: gap below the last content card is smaller, no large empty white area.
- [ ] FAB still floats clear of the last card when scrolled to bottom on a long page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)