### PR TITLE
feat(tools): expose offline guard-scheduler in /tools

### DIFF
--- a/docs/codebase/src/app/tools/guard-scheduler/page.md
+++ b/docs/codebase/src/app/tools/guard-scheduler/page.md
@@ -1,0 +1,25 @@
+# page.tsx (Guard Scheduler tool)
+
+**File:** `src/app/tools/guard-scheduler/page.tsx`
+**Status:** Active
+
+## Purpose
+
+Embeds the standalone `guard-scheduler.html` tool inside the unified app shell at `/tools/guard-scheduler`. Offline-capable companion to the cloud-backed `/guard-scheduler` route.
+
+## Layout
+
+Wrapped in `AuthGuard` + `AppShell` with `hidePageHeader` and `mainClassName="flex-1 flex flex-col min-h-0"` so the iframe fills remaining viewport height under the unified `TopBar`.
+
+Sub-bar below `TopBar`:
+- "← חזרה לכלים" link → `/tools`
+- "⬇️ הורד" button → triggers download of `/tools/guard-scheduler.html` as `מחולל-שמירות.html`
+
+Iframe loads `/tools/guard-scheduler.html` with `flex-1` to consume the remaining vertical space.
+
+## Relationship to other routes
+
+- `/guard-scheduler` — full React app with Firestore-backed shareable schedules.
+- `/tools/guard-scheduler` — offline embedded copy, no network/auth dependency beyond the AuthGuard wrapper. Saves up to 5 lists in `localStorage`. Author attribution footer (mamash17@gmail.com) is part of the HTML.
+
+Parity between the two algorithms is enforced by `src/lib/__tests__/guardScheduleOfflineParity.test.ts`.

--- a/docs/codebase/src/app/tools/page.md
+++ b/docs/codebase/src/app/tools/page.md
@@ -13,6 +13,7 @@ Additional tools page (`/tools`). Grid of standalone HTML tools — each opens i
 |----|-------|-------|----------|
 | `convoy` | מארגן שיירות | `/tools/convoy` | `/tools/hmmwvConvoy.html` |
 | `logistics` | דרישות מל״מ | `/tools/logistics` | `/tools/logistics.html` |
+| `guard-scheduler` | מחולל שמירות | `/tools/guard-scheduler` | `/tools/guard-scheduler.html` |
 
 ## Design
 

--- a/src/app/tools/guard-scheduler/page.tsx
+++ b/src/app/tools/guard-scheduler/page.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import Link from 'next/link';
+import AppShell from '@/app/components/AppShell';
+import AuthGuard from '@/components/auth/AuthGuard';
+
+function handleDownload() {
+  const link = document.createElement('a');
+  link.href = '/tools/guard-scheduler.html';
+  link.download = 'מחולל-שמירות.html';
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+}
+
+function GuardSchedulerToolContent() {
+  return (
+    <AppShell
+      title="🛡️ מחולל שמירות"
+      hidePageHeader
+      showFab={false}
+      mainClassName="flex-1 flex flex-col min-h-0"
+    >
+      <div className="bg-white border-b border-neutral-200 px-4 py-3 flex items-center justify-between">
+        <Link
+          href="/tools"
+          className="text-primary-600 hover:text-primary-800 font-medium text-sm"
+        >
+          ← חזרה לכלים
+        </Link>
+        <button
+          onClick={handleDownload}
+          className="px-3 py-1.5 text-sm border border-primary-600 text-primary-600 hover:bg-primary-50 rounded-lg transition-colors"
+        >
+          ⬇️ הורד
+        </button>
+      </div>
+      <iframe
+        src="/tools/guard-scheduler.html"
+        className="w-full border-0 flex-1"
+        title="מחולל שמירות"
+      />
+    </AppShell>
+  );
+}
+
+export default function GuardSchedulerToolPage() {
+  return (
+    <AuthGuard>
+      <GuardSchedulerToolContent />
+    </AuthGuard>
+  );
+}

--- a/src/app/tools/page.tsx
+++ b/src/app/tools/page.tsx
@@ -24,6 +24,15 @@ const tools = [
     downloadFile: '/tools/logistics.html',
     color: 'from-primary-600 to-primary-800',
   },
+  {
+    id: 'guard-scheduler',
+    title: 'מחולל שמירות',
+    description: 'בניית לוח שמירות חכם — עמדות, משתתפים ואלגוריתם הוגן. עובד אופליין, שומר עד 5 רשימות במכשיר',
+    icon: '🛡️',
+    href: '/tools/guard-scheduler',
+    downloadFile: '/tools/guard-scheduler.html',
+    color: 'from-primary-600 to-primary-800',
+  },
 ];
 
 export default function ToolsPage() {


### PR DESCRIPTION
## Summary
- Adds `מחולל שמירות` card to the `/tools` list
- New iframe wrapper at `/tools/guard-scheduler` (matches convoy + logistics pattern)
- Reuses the existing `public/tools/guard-scheduler.html` — already has author footer + save-up-to-5 lists

## Test plan
- [ ] Visit `/tools` — guard-scheduler card appears as third tile
- [ ] Click "פתח כלי" → iframe loads, footer with mamash17@gmail.com visible at bottom
- [ ] Click "⬇️ הורד" → downloads `מחולל-שמירות.html`
- [ ] Open downloaded file with browser disconnected — works, "💾 שמור במכשיר" stores up to 5 lists
- [ ] `npm test -- guardScheduleOfflineParity` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)