### PR TITLE
fix(system-config): RTL-correct round-activation toggle thumb

### DIFF
--- a/docs/codebase/src/components/management/tabs/SystemConfigTab.md
+++ b/docs/codebase/src/components/management/tabs/SystemConfigTab.md
@@ -37,6 +37,14 @@ notification email, "system info" block, "perform backup now" / "reset
 settings" buttons — were not persisted and not on the Phase 1 spec. They are
 removed; reintroduce them with real backing if that work returns.
 
+## Round-activation toggle
+
+Headless UI `<Switch>` bound to `roundOpen`. The thumb is **absolutely
+positioned** with the logical `start-1` (off) / `start-6` (on) properties —
+the previous `flex + translate-x-*` pattern pushed the thumb out of the pill
+in RTL because `translate-x` is physical. Same fix applied earlier to
+`NotificationToggleRow`.
+
 ## Open
 
 - The ammunition recipient is the only field today. Subsequent phases may add

--- a/src/components/management/tabs/SystemConfigTab.tsx
+++ b/src/components/management/tabs/SystemConfigTab.tsx
@@ -142,14 +142,14 @@ export default function SystemConfigTab() {
             checked={roundOpen}
             onChange={setRoundOpen}
             className={cn(
-              'relative inline-flex h-6 w-11 items-center rounded-full transition-colors',
+              'relative inline-flex h-6 w-11 shrink-0 rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2',
               roundOpen ? 'bg-success-500' : 'bg-neutral-300'
             )}
           >
             <span
               className={cn(
-                'inline-block h-4 w-4 transform rounded-full bg-white transition-transform',
-                roundOpen ? 'translate-x-6' : 'translate-x-1'
+                'absolute top-1/2 -translate-y-1/2 h-4 w-4 rounded-full bg-white shadow-sm transition-all',
+                roundOpen ? 'start-6' : 'start-1'
               )}
             />
           </Switch>


### PR DESCRIPTION
## Summary
- Round-activation toggle in Management → System Settings rendered the thumb outside the pill in RTL (both states).
- Cause: `flex + translate-x-*` — `translate-x` is physical, the flex layout was logical, so the thumb shifted off the right edge.
- Fix: absolute-positioned thumb with logical `start-1` (off) / `start-6` (on), matching the existing fix on `NotificationToggleRow`.

## Test plan
- [ ] Management → System Settings → toggle "Round Activation" off → thumb sits inside the right edge of the pill
- [ ] Toggle on → thumb moves to inside the left edge, pill turns success-green
- [ ] Save → reload → persisted state restores the same thumb position
- [ ] Non-admin: section greys out, toggle does nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)