### PR TITLE
feat(equipment): add category filter dropdown to the list

### DIFF
--- a/docs/codebase/src/app/equipment/page.md
+++ b/docs/codebase/src/app/equipment/page.md
@@ -13,12 +13,20 @@ AuthGuard
       EquipmentPageContent
         ├ PageHeader  (+ הוסף ציוד button → opens AddEquipmentWizard)
         ├ EquipmentTabs (Self / Team / All — All gated by manager+)
-        ├ FilterBar    (search + status filter)
+        ├ FilterBar    (search + status filter + category filter)
         ├ EquipmentTable (or loading / error / empty state)
         └ BulkActionBar (sticky, surfaces when rows selected)
 ```
 
 Modals (portal-style, not nested under AppShell): AddEquipmentWizard, ReportModal, ReturnModal, TransferModal, ActionHistoryPanel.
+
+## Filters
+
+`FilterBar` shows three controls in a 4-col grid (search spans 2):
+
+- search — substring match on serial id, product name, holder, category, location
+- status — `EquipmentStatus | null` via shared `Select`
+- category — `string | null`, options derived live from the visible `equipment` list (sorted with `localeCompare('he')`), so the dropdown only shows categories that actually appear in the currently-scoped data. `'all'` is represented as `null` to the Select and reset by the clear button.
 
 ## Scope handling
 

--- a/src/app/equipment/page.tsx
+++ b/src/app/equipment/page.tsx
@@ -89,6 +89,7 @@ function EquipmentPageContent() {
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [searchTerm, setSearchTerm] = useState('');
   const [statusFilter, setStatusFilter] = useState<EquipmentStatus | 'all'>('all');
+  const [categoryFilter, setCategoryFilter] = useState<string | 'all'>('all');
   const [submitting, setSubmitting] = useState(false);
   const { config: systemConfig } = useSystemConfig();
   const roundOpen = !!systemConfig?.roundOpen;
@@ -100,9 +101,19 @@ function EquipmentPageContent() {
     }
   }, [resumeTemplate, resumeDraft, activeModal]);
 
+  const categoryOptions = useMemo(() => {
+    const set = new Set<string>();
+    for (const it of equipment) {
+      const c = (it.category ?? '').trim();
+      if (c) set.add(c);
+    }
+    return Array.from(set).sort((a, b) => a.localeCompare(b, 'he'));
+  }, [equipment]);
+
   const filtered = useMemo(() => {
     return equipment.filter((it) => {
       if (statusFilter !== 'all' && it.status !== statusFilter) return false;
+      if (categoryFilter !== 'all' && it.category !== categoryFilter) return false;
       if (searchTerm) {
         const q = searchTerm.toLowerCase();
         const hit =
@@ -115,7 +126,7 @@ function EquipmentPageContent() {
       }
       return true;
     });
-  }, [equipment, statusFilter, searchTerm]);
+  }, [equipment, statusFilter, categoryFilter, searchTerm]);
 
   const closeModal = () => {
     setActiveModal(null);
@@ -212,6 +223,9 @@ function EquipmentPageContent() {
         onSearch={setSearchTerm}
         statusFilter={statusFilter}
         onStatusChange={setStatusFilter}
+        categoryFilter={categoryFilter}
+        onCategoryChange={setCategoryFilter}
+        categoryOptions={categoryOptions}
       />
 
       {loading && equipment.length === 0 ? (
@@ -395,14 +409,20 @@ function FilterBar({
   onSearch,
   statusFilter,
   onStatusChange,
+  categoryFilter,
+  onCategoryChange,
+  categoryOptions,
 }: {
   searchTerm: string;
   onSearch: (s: string) => void;
   statusFilter: EquipmentStatus | 'all';
   onStatusChange: (s: EquipmentStatus | 'all') => void;
+  categoryFilter: string | 'all';
+  onCategoryChange: (c: string | 'all') => void;
+  categoryOptions: string[];
 }) {
   return (
-    <div className="bg-white rounded-b-xl border-x border-b border-neutral-200 p-3 mb-4 grid grid-cols-1 sm:grid-cols-3 gap-2">
+    <div className="bg-white rounded-b-xl border-x border-b border-neutral-200 p-3 mb-4 grid grid-cols-1 sm:grid-cols-4 gap-2">
       <div className="sm:col-span-2 relative">
         <Search className="absolute start-3 top-1/2 -translate-y-1/2 w-4 h-4 text-neutral-400" />
         <input
@@ -426,6 +446,14 @@ function FilterBar({
         placeholder={TEXT_CONSTANTS.FEATURES.EQUIPMENT.ALL_STATUSES}
         clearable
         ariaLabel={TEXT_CONSTANTS.FEATURES.EQUIPMENT.ALL_STATUSES}
+      />
+      <Select
+        value={categoryFilter === 'all' ? null : categoryFilter}
+        onChange={(v) => onCategoryChange(v === null ? 'all' : (v as string))}
+        options={categoryOptions.map((c) => ({ value: c, label: c }))}
+        placeholder={TEXT_CONSTANTS.FEATURES.EQUIPMENT.ALL_CATEGORIES}
+        clearable
+        ariaLabel={TEXT_CONSTANTS.FEATURES.EQUIPMENT.ALL_CATEGORIES}
       />
     </div>
   );

--- a/src/constants/text.ts
+++ b/src/constants/text.ts
@@ -315,6 +315,7 @@ export const TEXT_CONSTANTS = {
       // Search and Filters
       SEARCH_PLACEHOLDER: 'חיפוש לפי מספר סידורי, שם פריט, מחזיק...',
       ALL_STATUSES: 'כל הסטטוסים',
+      ALL_CATEGORIES: 'כל הקטגוריות',
       ALL_CONDITIONS: 'כל המצבים',
       SHOWING_RESULTS: 'מציג {count} מתוך {total} פריטי ציוד',
       NO_EQUIPMENT_FILTERED: 'טרם נוסף ציוד למערכת',


### PR DESCRIPTION
## Summary
- Adds a category dropdown next to the existing status filter on `/equipment`.
- Options are derived live from the visible equipment (distinct `category`, sorted with `localeCompare('he')`).
- FilterBar grid grew from 3 to 4 columns; search still spans 2.

## Test plan
- [ ] `/equipment` shows search + status + category filters in one row on sm+, stacked on mobile
- [ ] Dropdown lists every distinct category present in the current scope (self / team / all)
- [ ] Switching scopes refreshes the option list
- [ ] Selecting a category narrows the table; clearing it (× chip) restores
- [ ] Status filter + category filter compose (AND)
- [ ] `npm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)