### PR TITLE
feat(logistics): אפסנאות inventory page (rename + functional UI)

### DIFF
--- a/docs/codebase/src/app/logistics/page.md
+++ b/docs/codebase/src/app/logistics/page.md
@@ -1,9 +1,56 @@
-# page.tsx (Logistics)
+# /logistics page
 
 **File:** `src/app/logistics/page.tsx`
-**Lines:** 21
-**Status:** Placeholder — ⏳ TODO
+**Status:** Active
+**User-facing title:** אפסנאות (renamed from לוגיסטיקה)
 
 ## Purpose
 
-Logistics management page (`/logistics`). Renders `ComingSoon`. Same structure as all 5 placeholder pages.
+Inventory management for non-serialized supplies — the unit's "אפסנאות"
+catalogue. Mirrors the equipment page UX but each row is a quantity-tracked
+entry (no צ/serial number, no exchange flow, no daily report). Items are
+created from templates managed in `Management → תבניות אפסנאות` (see
+`LogisticsTemplatesTab.md`).
+
+## Composition
+
+```
+AuthGuard
+  AppShell (title = "📦 אפסנאות")
+    LogisticsInventoryPage
+      ├ Add-item button (TL+)
+      ├ FilterBar (search + category + subcategory dropdowns)
+      └ Inventory table | empty-state | loading | error
+      ├ AddLogisticsItemModal  (pick template → quantity/location/holder/notes)
+      └ EditLogisticsItemModal (quantity/location/holder/notes)
+```
+
+## Data flow
+
+- Reads `logisticsItems` via `useLogisticsItems` hook (client SDK, sorted by name).
+- Writes via `apiFetch` → `POST/PUT/DELETE /api/logistics-items` (TL+ gate).
+- Categories + subcategories are taken from the **items themselves** (distinct
+  values, RTL-sorted). The item snapshots `name`/`category`/`subcategory` from
+  its template at create time, so later template renames do not silently
+  rewrite the inventory rows.
+- Subcategory filter is scoped by the active category filter: pick a category
+  → the subcategory dropdown narrows accordingly.
+
+## Permissions
+
+- View: any authenticated user.
+- Create / edit / delete: ADMIN / SYSTEM_MANAGER / MANAGER / TEAM_LEADER.
+  Enforced on `/api/logistics-items`; UI hides the buttons for everyone else.
+
+## Empty states
+
+- No templates → info banner directing managers to `Management → תבניות
+  אפסנאות`; the Add button stays disabled.
+- No items → "אין פריטים. הוסף פריט ראשון."
+- Filter matches nothing → "לא נמצאו פריטים התואמים לסינון."
+
+## Holder
+
+The first cut stores `currentHolderName` only — a freeform string, not a
+user reference. Upgrading this to a real `UserSearchInput`-backed holder
+(plus per-user item views) is a follow-up.

--- a/src/app/api/logistics-items/route.ts
+++ b/src/app/api/logistics-items/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from 'next/server';
+import {
+  serverCreateLogisticsItem,
+  serverUpdateLogisticsItem,
+  serverDeleteLogisticsItem,
+  validateLogisticsItemInput,
+} from '@/lib/db/server/logisticsItemsService';
+import { getActorOrError } from '@/lib/db/server/auth';
+import { UserType } from '@/types/user';
+
+function requireTL(userType: UserType): NextResponse | null {
+  const ok =
+    userType === UserType.ADMIN ||
+    userType === UserType.SYSTEM_MANAGER ||
+    userType === UserType.MANAGER ||
+    userType === UserType.TEAM_LEADER;
+  if (ok) return null;
+  return NextResponse.json(
+    { success: false, error: 'Forbidden: only team-leader+ may modify logistics items' },
+    { status: 403 }
+  );
+}
+
+export async function POST(request: Request) {
+  try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
+    const forbidden = requireTL(actorOrError.userType);
+    if (forbidden) return forbidden;
+    const body = await request.json();
+    const input = validateLogisticsItemInput({ ...body, createdBy: actorOrError.uid });
+    const id = await serverCreateLogisticsItem(input);
+    return NextResponse.json({ success: true, id });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('[API] logistics-items POST failed:', message);
+    return NextResponse.json({ success: false, error: message }, { status: 400 });
+  }
+}
+
+export async function PUT(request: Request) {
+  try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
+    const forbidden = requireTL(actorOrError.userType);
+    if (forbidden) return forbidden;
+    const { id, ...updates } = await request.json();
+    if (!id || typeof id !== 'string') {
+      return NextResponse.json({ success: false, error: 'Item id is required' }, { status: 400 });
+    }
+    await serverUpdateLogisticsItem(id, updates);
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('[API] logistics-items PUT failed:', message);
+    return NextResponse.json({ success: false, error: message }, { status: 400 });
+  }
+}
+
+export async function DELETE(request: Request) {
+  try {
+    const actorOrError = await getActorOrError(request);
+    if (actorOrError instanceof NextResponse) return actorOrError;
+    const forbidden = requireTL(actorOrError.userType);
+    if (forbidden) return forbidden;
+    const { id } = await request.json();
+    if (!id || typeof id !== 'string') {
+      return NextResponse.json({ success: false, error: 'Item id is required' }, { status: 400 });
+    }
+    await serverDeleteLogisticsItem(id);
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('[API] logistics-items DELETE failed:', message);
+    return NextResponse.json({ success: false, error: message }, { status: 500 });
+  }
+}

--- a/src/app/logistics/page.tsx
+++ b/src/app/logistics/page.tsx
@@ -2,19 +2,17 @@
 
 import AuthGuard from '@/components/auth/AuthGuard';
 import AppShell from '@/app/components/AppShell';
-import ComingSoon from '@/components/ui/ComingSoon';
 import { TEXT_CONSTANTS } from '@/constants/text';
+import LogisticsInventoryPage from '@/components/logistics/LogisticsInventoryPage';
 
 export default function LogisticsPage() {
   return (
     <AuthGuard>
-      <AppShell title={TEXT_CONSTANTS.FEATURES.LOGISTICS.TITLE}>
-        <ComingSoon
-          title={TEXT_CONSTANTS.FEATURES.LOGISTICS.TITLE}
-          description={TEXT_CONSTANTS.FEATURES.LOGISTICS.DESCRIPTION}
-          expectedDate="רבעון שני 2025"
-          showBackButton={false}
-        />
+      <AppShell
+        title={`📦 ${TEXT_CONSTANTS.FEATURES.LOGISTICS.TITLE}`}
+        subtitle={TEXT_CONSTANTS.FEATURES.LOGISTICS.DESCRIPTION}
+      >
+        <LogisticsInventoryPage />
       </AppShell>
     </AuthGuard>
   );

--- a/src/components/logistics/AddLogisticsItemModal.tsx
+++ b/src/components/logistics/AddLogisticsItemModal.tsx
@@ -1,0 +1,152 @@
+'use client';
+
+import React, { useState } from 'react';
+import { X, Save } from 'lucide-react';
+import { Select } from '@/components/ui';
+import { createLogisticsItem } from '@/lib/logistics/itemsRepository';
+import type { LogisticsTemplate } from '@/types/logistics';
+
+interface Props {
+  templates: LogisticsTemplate[];
+  onClose: () => void;
+  onCreated: () => void;
+  onError: (message: string) => void;
+}
+
+export default function AddLogisticsItemModal({ templates, onClose, onCreated, onError }: Props) {
+  const [templateId, setTemplateId] = useState<string | null>(null);
+  const [quantity, setQuantity] = useState<string>('1');
+  const [location, setLocation] = useState('');
+  const [holderName, setHolderName] = useState('');
+  const [notes, setNotes] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const templateOptions = templates.map((t) => ({
+    value: t.id,
+    label: t.category ? `${t.name} — ${t.category}` : t.name,
+  }));
+
+  const handleSubmit = async () => {
+    if (!templateId) {
+      onError('יש לבחור תבנית');
+      return;
+    }
+    const qty = Number(quantity);
+    if (!Number.isFinite(qty) || qty < 0) {
+      onError('כמות חייבת להיות מספר חיובי');
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await createLogisticsItem({
+        templateId,
+        quantity: qty,
+        location: location.trim() || undefined,
+        currentHolderName: holderName.trim() || undefined,
+        notes: notes.trim() || undefined,
+      });
+      onCreated();
+    } catch (e) {
+      onError(e instanceof Error ? e.message : 'יצירה נכשלה');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/30 backdrop-blur-sm flex items-center justify-center z-50 p-4"
+      onClick={() => !submitting && onClose()}
+    >
+      <div
+        className="bg-white rounded-xl shadow-2xl w-full max-w-lg border border-neutral-200"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between px-6 py-4 border-b border-neutral-200">
+          <h3 className="text-lg font-semibold text-neutral-900">פריט חדש</h3>
+          <button
+            onClick={onClose}
+            disabled={submitting}
+            className="text-neutral-400 hover:text-neutral-600"
+            aria-label="סגור"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+        <div className="p-6 space-y-3">
+          <div>
+            <span className="block text-sm font-medium text-neutral-700 mb-1">תבנית *</span>
+            <Select
+              value={templateId}
+              onChange={(v) => setTemplateId(v === null ? null : (v as string))}
+              options={templateOptions}
+              placeholder="בחר תבנית"
+              clearable
+              ariaLabel="תבנית פריט"
+            />
+          </div>
+          <label className="block">
+            <span className="text-sm font-medium text-neutral-700">כמות *</span>
+            <input
+              type="number"
+              min={0}
+              inputMode="numeric"
+              value={quantity}
+              onChange={(e) => setQuantity(e.target.value)}
+              className="mt-1 w-full px-3 py-2 text-sm border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500"
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm font-medium text-neutral-700">מיקום</span>
+            <input
+              type="text"
+              value={location}
+              onChange={(e) => setLocation(e.target.value)}
+              className="mt-1 w-full px-3 py-2 text-sm border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500"
+              placeholder="אופציונלי"
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm font-medium text-neutral-700">מחזיק</span>
+            <input
+              type="text"
+              value={holderName}
+              onChange={(e) => setHolderName(e.target.value)}
+              className="mt-1 w-full px-3 py-2 text-sm border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500"
+              placeholder="אופציונלי"
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm font-medium text-neutral-700">הערות</span>
+            <textarea
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              rows={2}
+              className="mt-1 w-full px-3 py-2 text-sm border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500"
+              placeholder="אופציונלי"
+            />
+          </label>
+        </div>
+        <div className="flex items-center justify-end gap-2 px-6 py-3 border-t border-neutral-200 bg-neutral-50">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={submitting}
+            className="px-4 py-2 text-sm text-neutral-700 hover:bg-neutral-100 rounded-lg"
+          >
+            ביטול
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={submitting}
+            className="inline-flex items-center gap-2 px-4 py-2 text-sm bg-primary-600 hover:bg-primary-700 text-white rounded-lg disabled:bg-neutral-300"
+          >
+            <Save className="w-4 h-4" />
+            {submitting ? 'שומר...' : 'שמור'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/logistics/EditLogisticsItemModal.tsx
+++ b/src/components/logistics/EditLogisticsItemModal.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import React, { useState } from 'react';
+import { X, Save } from 'lucide-react';
+import { updateLogisticsItem } from '@/lib/logistics/itemsRepository';
+import type { LogisticsItem } from '@/types/logistics';
+
+interface Props {
+  item: LogisticsItem;
+  onClose: () => void;
+  onUpdated: () => void;
+  onError: (message: string) => void;
+}
+
+export default function EditLogisticsItemModal({ item, onClose, onUpdated, onError }: Props) {
+  const [quantity, setQuantity] = useState<string>(String(item.quantity));
+  const [location, setLocation] = useState(item.location ?? '');
+  const [holderName, setHolderName] = useState(item.currentHolderName ?? '');
+  const [notes, setNotes] = useState(item.notes ?? '');
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async () => {
+    const qty = Number(quantity);
+    if (!Number.isFinite(qty) || qty < 0) {
+      onError('כמות חייבת להיות מספר חיובי');
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await updateLogisticsItem(item.id, {
+        quantity: qty,
+        location: location.trim(),
+        currentHolderName: holderName.trim(),
+        notes: notes.trim(),
+      });
+      onUpdated();
+    } catch (e) {
+      onError(e instanceof Error ? e.message : 'עדכון נכשל');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/30 backdrop-blur-sm flex items-center justify-center z-50 p-4"
+      onClick={() => !submitting && onClose()}
+    >
+      <div
+        className="bg-white rounded-xl shadow-2xl w-full max-w-lg border border-neutral-200"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between px-6 py-4 border-b border-neutral-200">
+          <div>
+            <h3 className="text-lg font-semibold text-neutral-900">{item.name}</h3>
+            <p className="text-xs text-neutral-500">
+              {item.category}
+              {item.subcategory ? ` · ${item.subcategory}` : ''}
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            disabled={submitting}
+            className="text-neutral-400 hover:text-neutral-600"
+            aria-label="סגור"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+        <div className="p-6 space-y-3">
+          <label className="block">
+            <span className="text-sm font-medium text-neutral-700">כמות *</span>
+            <input
+              type="number"
+              min={0}
+              inputMode="numeric"
+              value={quantity}
+              onChange={(e) => setQuantity(e.target.value)}
+              className="mt-1 w-full px-3 py-2 text-sm border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500"
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm font-medium text-neutral-700">מיקום</span>
+            <input
+              type="text"
+              value={location}
+              onChange={(e) => setLocation(e.target.value)}
+              className="mt-1 w-full px-3 py-2 text-sm border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500"
+              placeholder="אופציונלי"
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm font-medium text-neutral-700">מחזיק</span>
+            <input
+              type="text"
+              value={holderName}
+              onChange={(e) => setHolderName(e.target.value)}
+              className="mt-1 w-full px-3 py-2 text-sm border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500"
+              placeholder="אופציונלי"
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm font-medium text-neutral-700">הערות</span>
+            <textarea
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              rows={2}
+              className="mt-1 w-full px-3 py-2 text-sm border border-neutral-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500"
+              placeholder="אופציונלי"
+            />
+          </label>
+        </div>
+        <div className="flex items-center justify-end gap-2 px-6 py-3 border-t border-neutral-200 bg-neutral-50">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={submitting}
+            className="px-4 py-2 text-sm text-neutral-700 hover:bg-neutral-100 rounded-lg"
+          >
+            ביטול
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={submitting}
+            className="inline-flex items-center gap-2 px-4 py-2 text-sm bg-primary-600 hover:bg-primary-700 text-white rounded-lg disabled:bg-neutral-300"
+          >
+            <Save className="w-4 h-4" />
+            {submitting ? 'שומר...' : 'שמור'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/logistics/LogisticsInventoryPage.tsx
+++ b/src/components/logistics/LogisticsInventoryPage.tsx
@@ -1,0 +1,249 @@
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+import { Plus, Search, Pencil, Trash2 } from 'lucide-react';
+import { Select } from '@/components/ui';
+import { cn } from '@/lib/cn';
+import { useAuth } from '@/contexts/AuthContext';
+import { UserType } from '@/types/user';
+import { useLogisticsItems } from '@/hooks/useLogisticsItems';
+import { listLogisticsTemplates } from '@/lib/logistics/templatesRepository';
+import { deleteLogisticsItem } from '@/lib/logistics/itemsRepository';
+import type { LogisticsItem, LogisticsTemplate } from '@/types/logistics';
+import AddLogisticsItemModal from './AddLogisticsItemModal';
+import EditLogisticsItemModal from './EditLogisticsItemModal';
+
+export default function LogisticsInventoryPage() {
+  const { enhancedUser } = useAuth();
+  const canEdit =
+    !!enhancedUser &&
+    (enhancedUser.userType === UserType.ADMIN ||
+      enhancedUser.userType === UserType.SYSTEM_MANAGER ||
+      enhancedUser.userType === UserType.MANAGER ||
+      enhancedUser.userType === UserType.TEAM_LEADER);
+
+  const { data: items, isLoading, error, refresh } = useLogisticsItems();
+  const [templates, setTemplates] = useState<LogisticsTemplate[]>([]);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [categoryFilter, setCategoryFilter] = useState<string | 'all'>('all');
+  const [subcategoryFilter, setSubcategoryFilter] = useState<string | 'all'>('all');
+  const [addOpen, setAddOpen] = useState(false);
+  const [editing, setEditing] = useState<LogisticsItem | null>(null);
+  const [toast, setToast] = useState<{ kind: 'success' | 'error'; message: string } | null>(null);
+
+  useEffect(() => {
+    listLogisticsTemplates({ activeOnly: true }).then(setTemplates).catch(() => setTemplates([]));
+  }, []);
+
+  const showToast = (kind: 'success' | 'error', message: string) => {
+    setToast({ kind, message });
+    setTimeout(() => setToast(null), 2500);
+  };
+
+  const categoryOptions = useMemo(() => {
+    const set = new Set<string>();
+    for (const it of items) {
+      if (it.category) set.add(it.category);
+    }
+    return Array.from(set).sort((a, b) => a.localeCompare(b, 'he'));
+  }, [items]);
+
+  const subcategoryOptions = useMemo(() => {
+    const set = new Set<string>();
+    for (const it of items) {
+      if (categoryFilter !== 'all' && it.category !== categoryFilter) continue;
+      if (it.subcategory) set.add(it.subcategory);
+    }
+    return Array.from(set).sort((a, b) => a.localeCompare(b, 'he'));
+  }, [items, categoryFilter]);
+
+  const filtered = useMemo(() => {
+    return items.filter((it) => {
+      if (categoryFilter !== 'all' && it.category !== categoryFilter) return false;
+      if (subcategoryFilter !== 'all' && it.subcategory !== subcategoryFilter) return false;
+      if (searchTerm) {
+        const q = searchTerm.toLowerCase();
+        const hit =
+          it.name.toLowerCase().includes(q) ||
+          it.category.toLowerCase().includes(q) ||
+          (it.subcategory ?? '').toLowerCase().includes(q) ||
+          (it.location ?? '').toLowerCase().includes(q) ||
+          (it.currentHolderName ?? '').toLowerCase().includes(q);
+        if (!hit) return false;
+      }
+      return true;
+    });
+  }, [items, categoryFilter, subcategoryFilter, searchTerm]);
+
+  const handleDelete = async (item: LogisticsItem) => {
+    if (!confirm(`למחוק את "${item.name}" (${item.quantity})?`)) return;
+    try {
+      await deleteLogisticsItem(item.id);
+      showToast('success', 'הפריט נמחק');
+      await refresh();
+    } catch (e) {
+      showToast('error', e instanceof Error ? e.message : 'מחיקה נכשלה');
+    }
+  };
+
+  return (
+    <div className="max-w-7xl mx-auto w-full pb-24">
+      <div className="flex items-center justify-between mb-4">
+        {canEdit && (
+          <button
+            type="button"
+            onClick={() => setAddOpen(true)}
+            disabled={templates.length === 0}
+            className="inline-flex items-center gap-2 px-4 py-2 bg-primary-600 hover:bg-primary-700 disabled:bg-neutral-300 text-white text-sm font-medium rounded-lg shadow-sm transition-colors"
+          >
+            <Plus className="w-4 h-4" />
+            הוסף פריט
+          </button>
+        )}
+      </div>
+
+      {templates.length === 0 && (
+        <div className="mb-4 p-3 rounded-lg bg-info-50 border border-info-200 text-info-800 text-sm">
+          אין תבניות אפסנאות. מנהל יכול ליצור תבניות תחת ניהול → תבניות אפסנאות.
+        </div>
+      )}
+
+      <div className="bg-white rounded-xl border border-neutral-200 p-3 mb-4 grid grid-cols-1 sm:grid-cols-4 gap-2">
+        <div className="sm:col-span-2 relative">
+          <Search className="absolute start-3 top-1/2 -translate-y-1/2 w-4 h-4 text-neutral-400" />
+          <input
+            type="search"
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            placeholder="חיפוש שם, קטגוריה, מיקום או מחזיק..."
+            className="w-full ps-9 pe-3 py-2 text-sm border border-neutral-200 rounded-lg bg-neutral-50 focus:bg-white focus:ring-2 focus:ring-primary-500"
+          />
+        </div>
+        <Select
+          value={categoryFilter === 'all' ? null : categoryFilter}
+          onChange={(v) => {
+            setCategoryFilter(v === null ? 'all' : (v as string));
+            setSubcategoryFilter('all');
+          }}
+          options={categoryOptions.map((c) => ({ value: c, label: c }))}
+          placeholder="כל הקטגוריות"
+          clearable
+          ariaLabel="סינון לפי קטגוריה"
+        />
+        <Select
+          value={subcategoryFilter === 'all' ? null : subcategoryFilter}
+          onChange={(v) => setSubcategoryFilter(v === null ? 'all' : (v as string))}
+          options={subcategoryOptions.map((c) => ({ value: c, label: c }))}
+          placeholder="כל תתי-הקטגוריות"
+          clearable
+          ariaLabel="סינון לפי תת-קטגוריה"
+        />
+      </div>
+
+      {error && (
+        <div className="bg-danger-50 border border-danger-200 rounded-lg p-3 mb-4 text-sm text-danger-700">
+          {error}
+        </div>
+      )}
+
+      {isLoading && items.length === 0 ? (
+        <div className="bg-white rounded-xl border border-neutral-200 p-8 text-center">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600 mx-auto" />
+        </div>
+      ) : filtered.length === 0 ? (
+        <div className="bg-white rounded-xl border border-neutral-200 p-8 text-center text-sm text-neutral-500">
+          {items.length === 0 ? 'אין פריטים. הוסף פריט ראשון.' : 'לא נמצאו פריטים התואמים לסינון.'}
+        </div>
+      ) : (
+        <div className="bg-white rounded-xl border border-neutral-200 overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="bg-neutral-50 text-xs uppercase text-neutral-600">
+              <tr>
+                <th className="text-start px-3 py-2">שם</th>
+                <th className="text-start px-3 py-2">קטגוריה</th>
+                <th className="text-start px-3 py-2">תת-קטגוריה</th>
+                <th className="text-start px-3 py-2">כמות</th>
+                <th className="text-start px-3 py-2">מיקום</th>
+                <th className="text-start px-3 py-2">מחזיק</th>
+                {canEdit && <th className="text-start px-3 py-2 w-24">פעולות</th>}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-neutral-100">
+              {filtered.map((it) => (
+                <tr key={it.id} className="hover:bg-neutral-50">
+                  <td className="px-3 py-2 font-medium text-neutral-900">{it.name}</td>
+                  <td className="px-3 py-2 text-neutral-700">{it.category}</td>
+                  <td className="px-3 py-2 text-neutral-700">{it.subcategory ?? '—'}</td>
+                  <td className="px-3 py-2 text-neutral-900 font-semibold">{it.quantity}</td>
+                  <td className="px-3 py-2 text-neutral-700">{it.location ?? '—'}</td>
+                  <td className="px-3 py-2 text-neutral-700">{it.currentHolderName ?? '—'}</td>
+                  {canEdit && (
+                    <td className="px-3 py-2">
+                      <div className="flex items-center gap-1">
+                        <button
+                          type="button"
+                          onClick={() => setEditing(it)}
+                          className="p-1.5 rounded hover:bg-neutral-100 text-neutral-500 hover:text-neutral-800"
+                          aria-label="ערוך"
+                          title="ערוך"
+                        >
+                          <Pencil className="w-3.5 h-3.5" />
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => handleDelete(it)}
+                          className="p-1.5 rounded hover:bg-danger-50 text-danger-500 hover:text-danger-700"
+                          aria-label="מחק"
+                          title="מחק"
+                        >
+                          <Trash2 className="w-3.5 h-3.5" />
+                        </button>
+                      </div>
+                    </td>
+                  )}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {addOpen && (
+        <AddLogisticsItemModal
+          templates={templates}
+          onClose={() => setAddOpen(false)}
+          onCreated={() => {
+            setAddOpen(false);
+            refresh();
+            showToast('success', 'הפריט נוצר');
+          }}
+          onError={(msg) => showToast('error', msg)}
+        />
+      )}
+      {editing && (
+        <EditLogisticsItemModal
+          item={editing}
+          onClose={() => setEditing(null)}
+          onUpdated={() => {
+            setEditing(null);
+            refresh();
+            showToast('success', 'הפריט עודכן');
+          }}
+          onError={(msg) => showToast('error', msg)}
+        />
+      )}
+      {toast && (
+        <div
+          className={cn(
+            'fixed bottom-6 left-1/2 -translate-x-1/2 px-4 py-2 rounded-lg shadow-lg text-sm z-[60]',
+            toast.kind === 'success'
+              ? 'bg-success-50 border border-success-200 text-success-800'
+              : 'bg-danger-50 border border-danger-200 text-danger-800',
+          )}
+        >
+          {toast.message}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/constants/text.ts
+++ b/src/constants/text.ts
@@ -240,8 +240,8 @@ export const TEXT_CONSTANTS = {
       DESCRIPTION: 'מעקב כישורים והרשאות חיילים'
     },
     LOGISTICS: {
-      TITLE: 'לוגיסטיקה',
-      DESCRIPTION: 'ניהול ציוד ואספקה'
+      TITLE: 'אפסנאות',
+      DESCRIPTION: 'ניהול ציוד לא-ממוספר וכמויות'
     },
     EQUIPMENT: {
       TITLE: 'צלם',

--- a/src/hooks/useLogisticsItems.ts
+++ b/src/hooks/useLogisticsItems.ts
@@ -1,0 +1,37 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import type { LogisticsItem } from '@/types/logistics';
+import { listLogisticsItems } from '@/lib/logistics/itemsRepository';
+
+export interface UseLogisticsItemsReturn {
+  data: LogisticsItem[];
+  isLoading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+}
+
+export function useLogisticsItems(): UseLogisticsItemsReturn {
+  const [data, setData] = useState<LogisticsItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const items = await listLogisticsItems();
+      setData(items);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Unexpected error');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  return { data, isLoading, error, refresh };
+}

--- a/src/lib/db/server/logisticsItemsService.ts
+++ b/src/lib/db/server/logisticsItemsService.ts
@@ -1,0 +1,121 @@
+/**
+ * Server-side Logistics Items Service (firebase-admin).
+ *
+ * Items are non-serialized inventory rows in `logisticsItems`. Each item is
+ * created from a template (the template snapshots `name`, `category`, and
+ * `subcategory` onto the item so rename + later edits don't silently
+ * rewrite history). The API route is the permission boundary.
+ */
+import { getAdminDb } from '../admin';
+import { COLLECTIONS } from '../collections';
+import { FieldValue } from 'firebase-admin/firestore';
+import type {
+  CreateLogisticsItemInput,
+  UpdateLogisticsItemInput,
+} from '@/types/logistics';
+
+export interface ValidatedItemInput extends CreateLogisticsItemInput {
+  createdBy: string;
+}
+
+export function validateLogisticsItemInput(input: unknown): ValidatedItemInput {
+  if (!input || typeof input !== 'object') {
+    throw new Error('input is required');
+  }
+  const i = input as Record<string, unknown>;
+  if (typeof i.templateId !== 'string' || !i.templateId.trim()) {
+    throw new Error('templateId is required');
+  }
+  if (typeof i.quantity !== 'number' || !Number.isFinite(i.quantity) || i.quantity < 0) {
+    throw new Error('quantity must be a non-negative number');
+  }
+  if (i.location !== undefined && typeof i.location !== 'string') {
+    throw new Error('location must be a string');
+  }
+  if (i.currentHolderId !== undefined && typeof i.currentHolderId !== 'string') {
+    throw new Error('currentHolderId must be a string');
+  }
+  if (i.currentHolderName !== undefined && typeof i.currentHolderName !== 'string') {
+    throw new Error('currentHolderName must be a string');
+  }
+  if (i.notes !== undefined && typeof i.notes !== 'string') {
+    throw new Error('notes must be a string');
+  }
+  if (typeof i.createdBy !== 'string' || !i.createdBy) {
+    throw new Error('createdBy is required');
+  }
+  return {
+    templateId: i.templateId.trim(),
+    quantity: i.quantity,
+    location: typeof i.location === 'string' ? i.location.trim() || undefined : undefined,
+    currentHolderId:
+      typeof i.currentHolderId === 'string' ? i.currentHolderId.trim() || undefined : undefined,
+    currentHolderName:
+      typeof i.currentHolderName === 'string'
+        ? i.currentHolderName.trim() || undefined
+        : undefined,
+    notes: typeof i.notes === 'string' ? i.notes.trim() || undefined : undefined,
+    createdBy: i.createdBy,
+  };
+}
+
+export async function serverCreateLogisticsItem(input: ValidatedItemInput): Promise<string> {
+  const db = getAdminDb();
+  const templateSnap = await db
+    .collection(COLLECTIONS.LOGISTICS_TEMPLATES)
+    .doc(input.templateId)
+    .get();
+  if (!templateSnap.exists) {
+    throw new Error('Template not found');
+  }
+  const tpl = templateSnap.data() ?? {};
+  const ref = await db.collection(COLLECTIONS.LOGISTICS_ITEMS).add({
+    templateId: input.templateId,
+    name: tpl.name ?? '',
+    category: tpl.category ?? '',
+    subcategory: tpl.subcategory ?? null,
+    quantity: input.quantity,
+    location: input.location ?? null,
+    currentHolderId: input.currentHolderId ?? null,
+    currentHolderName: input.currentHolderName ?? null,
+    notes: input.notes ?? null,
+    createdBy: input.createdBy,
+    createdAt: FieldValue.serverTimestamp(),
+    updatedAt: FieldValue.serverTimestamp(),
+  });
+  return ref.id;
+}
+
+export async function serverUpdateLogisticsItem(
+  itemId: string,
+  updates: UpdateLogisticsItemInput
+): Promise<void> {
+  const patch: Record<string, unknown> = {};
+  if (updates.quantity !== undefined) {
+    if (typeof updates.quantity !== 'number' || !Number.isFinite(updates.quantity) || updates.quantity < 0) {
+      throw new Error('quantity must be a non-negative number');
+    }
+    patch.quantity = updates.quantity;
+  }
+  if (updates.location !== undefined) {
+    patch.location = (updates.location ?? '').toString().trim() || null;
+  }
+  if (updates.currentHolderId !== undefined) {
+    patch.currentHolderId = (updates.currentHolderId ?? '').toString().trim() || null;
+  }
+  if (updates.currentHolderName !== undefined) {
+    patch.currentHolderName = (updates.currentHolderName ?? '').toString().trim() || null;
+  }
+  if (updates.notes !== undefined) {
+    patch.notes = (updates.notes ?? '').toString().trim() || null;
+  }
+  if (Object.keys(patch).length === 0) return;
+  patch.updatedAt = FieldValue.serverTimestamp();
+  const db = getAdminDb();
+  await db.collection(COLLECTIONS.LOGISTICS_ITEMS).doc(itemId).update(patch);
+}
+
+export async function serverDeleteLogisticsItem(itemId: string): Promise<void> {
+  const db = getAdminDb();
+  await db.collection(COLLECTIONS.LOGISTICS_ITEMS).doc(itemId).delete();
+}

--- a/src/lib/logistics/itemsRepository.ts
+++ b/src/lib/logistics/itemsRepository.ts
@@ -1,0 +1,94 @@
+/**
+ * Logistics items — client SDK reads, API-route writes.
+ */
+import {
+  collection,
+  getDocs,
+  query,
+  orderBy,
+  type Query,
+  type Timestamp,
+} from 'firebase/firestore';
+import { db } from '@/lib/firebase';
+import { COLLECTIONS } from '@/lib/db/collections';
+import { apiFetch } from '@/lib/apiFetch';
+import type {
+  LogisticsItem,
+  CreateLogisticsItemInput,
+  UpdateLogisticsItemInput,
+} from '@/types/logistics';
+
+function rowToItem(id: string, data: Record<string, unknown>): LogisticsItem {
+  return {
+    id,
+    templateId: String(data.templateId ?? ''),
+    name: String(data.name ?? ''),
+    category: String(data.category ?? ''),
+    subcategory:
+      typeof data.subcategory === 'string' && data.subcategory.length > 0
+        ? data.subcategory
+        : undefined,
+    quantity: Number(data.quantity ?? 0),
+    location: typeof data.location === 'string' && data.location.length > 0 ? data.location : undefined,
+    currentHolderId:
+      typeof data.currentHolderId === 'string' && data.currentHolderId.length > 0
+        ? data.currentHolderId
+        : undefined,
+    currentHolderName:
+      typeof data.currentHolderName === 'string' && data.currentHolderName.length > 0
+        ? data.currentHolderName
+        : undefined,
+    notes: typeof data.notes === 'string' && data.notes.length > 0 ? data.notes : undefined,
+    createdAt: data.createdAt as Timestamp,
+    updatedAt: data.updatedAt as Timestamp,
+    createdBy: String(data.createdBy ?? ''),
+  };
+}
+
+export async function listLogisticsItems(): Promise<LogisticsItem[]> {
+  try {
+    const q: Query = query(collection(db, COLLECTIONS.LOGISTICS_ITEMS), orderBy('name'));
+    const snapshot = await getDocs(q);
+    return snapshot.docs.map((doc) => rowToItem(doc.id, doc.data()));
+  } catch (error) {
+    try {
+      const snapshot = await getDocs(collection(db, COLLECTIONS.LOGISTICS_ITEMS));
+      const all = snapshot.docs.map((doc) => rowToItem(doc.id, doc.data()));
+      return all.sort((a, b) => a.name.localeCompare(b.name, 'he'));
+    } catch (e) {
+      console.warn('Logistics items read failed:', error, e);
+      return [];
+    }
+  }
+}
+
+export async function createLogisticsItem(input: CreateLogisticsItemInput): Promise<string> {
+  const response = await apiFetch('/api/logistics-items', {
+    method: 'POST',
+    body: JSON.stringify(input),
+  });
+  const result = await response.json();
+  if (!result.success) throw new Error(result.error || 'Failed to create item');
+  return result.id;
+}
+
+export async function updateLogisticsItem(
+  id: string,
+  updates: UpdateLogisticsItemInput
+): Promise<void> {
+  const response = await apiFetch('/api/logistics-items', {
+    method: 'PUT',
+    body: JSON.stringify({ id, ...updates }),
+  });
+  const result = await response.json();
+  if (!result.success) throw new Error(result.error || 'Failed to update item');
+}
+
+export async function deleteLogisticsItem(id: string): Promise<void> {
+  const response = await apiFetch('/api/logistics-items', {
+    method: 'DELETE',
+    body: JSON.stringify({ id }),
+  });
+  const result = await response.json();
+  if (!result.success) throw new Error(result.error || 'Failed to delete item');
+}

--- a/src/utils/navigationUtils.ts
+++ b/src/utils/navigationUtils.ts
@@ -45,10 +45,10 @@ export function getFeatureRoutes(): FeatureRoute[] {
       description: TEXT_CONSTANTS.FEATURES.LOGISTICS.DESCRIPTION,
       icon: "📦",
       href: "/logistics",
-      available: false,
-      color: "bg-gray-400",
+      available: true,
+      color: "bg-primary-600",
       requiresAuth: true,
-      isComingSoon: true
+      isComingSoon: false
     },
     {
       title: TEXT_CONSTANTS.FEATURES.EQUIPMENT.TITLE,


### PR DESCRIPTION
## Summary
Replaces the ComingSoon placeholder at `/logistics` with a real inventory page for non-serialized supplies. Title renamed לוגיסטיקה → אפסנאות; main-nav flag flipped from ComingSoon to active.

Stack:
- `LOGISTICS_ITEMS` collection
- server service + validator (firebase-admin)
- `POST/PUT/DELETE /api/logistics-items` gated **TL+**
- client repository (client SDK reads, API-route writes)
- `useLogisticsItems` hook (standard `{ data, isLoading, error, refresh }`)
- `LogisticsInventoryPage` — search + category + subcategory filters, table
- `AddLogisticsItemModal` — pick template → quantity/location/holder/notes
- `EditLogisticsItemModal` — edit mutable fields on an existing row

Each item **snapshots** `name`/`category`/`subcategory` from its template at create time, so later template renames don't silently rewrite inventory rows. Subcategory filter narrows by the selected category. Holder is a freeform string in this cut — wiring to `UserSearchInput` is a follow-up.

## Dependency
Targets `feat/management-logistics-templates-tab` (PR #117) — that PR adds the templates collection + management tab consumed here. Rebase to `main` after #117 lands.

## Test plan
- [ ] Merge #117 first; then `/logistics` opens with title "אפסנאות"
- [ ] Main-nav card no longer shows ComingSoon
- [ ] As manager: create a template under Management → תבניות אפסנאות → return to /logistics, "הוסף פריט" enabled
- [ ] Add item with quantity / location / holder → appears in table
- [ ] Search + category + subcategory filters compose (AND)
- [ ] Edit quantity → persists after refresh
- [ ] Delete → row removed
- [ ] As regular user: read-only (no Add / Edit / Delete buttons)
- [ ] `POST /api/logistics-items` without TL+ → 403
- [ ] `npm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)