### PR TITLE
fix(equipment): resolve category ids to names + phone-book filter layout

### DIFF
--- a/docs/codebase/src/app/equipment/page.md
+++ b/docs/codebase/src/app/equipment/page.md
@@ -22,11 +22,11 @@ Modals (portal-style, not nested under AppShell): AddEquipmentWizard, ReportModa
 
 ## Filters
 
-`FilterBar` shows three controls in a 4-col grid (search spans 2):
+`FilterBar` follows the phone-book layout pattern: full-width search input on top, two filter dropdowns (status + category) in a `grid-cols-2` row beneath. The two dropdowns stay side-by-side at every breakpoint.
 
-- search — substring match on serial id, product name, holder, category, location
+- search — substring match on serial id, product name, holder, resolved category name (via `useCategoryLookup`), location
 - status — `EquipmentStatus | null` via shared `Select`
-- category — `string | null`, options derived live from the visible `equipment` list (sorted with `localeCompare('he')`), so the dropdown only shows categories that actually appear in the currently-scoped data. `'all'` is represented as `null` to the Select and reset by the clear button.
+- category — `string | null` (the categoryId stored on `Equipment.category`). The dropdown is keyed by id but labelled with the human-readable name resolved through `useCategoryLookup` (which loads the categories tree once and exposes O(1) id→name lookup). Options are limited to category ids actually present in the currently-scoped equipment, sorted by resolved name with `localeCompare('he')`. `'all'` is represented as `null` to the Select and reset by the clear button. If a category id can't be resolved (deactivated or missing), the id itself is used as the fallback label.
 
 ## Scope handling
 

--- a/src/app/equipment/page.tsx
+++ b/src/app/equipment/page.tsx
@@ -28,6 +28,7 @@ import PersonalAmmunitionSection from '@/components/equipment/PersonalAmmunition
 import TeamAmmunitionSection from '@/components/equipment/TeamAmmunitionSection';
 import { Select } from '@/components/ui';
 import { useSystemConfig } from '@/hooks/useSystemConfig';
+import { useCategoryLookup } from '@/hooks/useCategoryLookup';
 import {
   requestExchange,
   approveExchangeRequest,
@@ -93,6 +94,7 @@ function EquipmentPageContent() {
   const [submitting, setSubmitting] = useState(false);
   const { config: systemConfig } = useSystemConfig();
   const roundOpen = !!systemConfig?.roundOpen;
+  const { categoryName } = useCategoryLookup();
 
   // Auto-open wizard when notification deep-links here
   useEffect(() => {
@@ -102,13 +104,15 @@ function EquipmentPageContent() {
   }, [resumeTemplate, resumeDraft, activeModal]);
 
   const categoryOptions = useMemo(() => {
-    const set = new Set<string>();
+    const ids = new Set<string>();
     for (const it of equipment) {
       const c = (it.category ?? '').trim();
-      if (c) set.add(c);
+      if (c) ids.add(c);
     }
-    return Array.from(set).sort((a, b) => a.localeCompare(b, 'he'));
-  }, [equipment]);
+    return Array.from(ids)
+      .map((id) => ({ value: id, label: categoryName(id) ?? id }))
+      .sort((a, b) => a.label.localeCompare(b.label, 'he'));
+  }, [equipment, categoryName]);
 
   const filtered = useMemo(() => {
     return equipment.filter((it) => {
@@ -116,17 +120,18 @@ function EquipmentPageContent() {
       if (categoryFilter !== 'all' && it.category !== categoryFilter) return false;
       if (searchTerm) {
         const q = searchTerm.toLowerCase();
+        const resolvedCategory = (categoryName(it.category) ?? it.category).toLowerCase();
         const hit =
           it.id.toLowerCase().includes(q) ||
           it.productName.toLowerCase().includes(q) ||
           it.currentHolder.toLowerCase().includes(q) ||
-          it.category.toLowerCase().includes(q) ||
+          resolvedCategory.includes(q) ||
           (it.location ?? '').toLowerCase().includes(q);
         if (!hit) return false;
       }
       return true;
     });
-  }, [equipment, statusFilter, categoryFilter, searchTerm]);
+  }, [equipment, statusFilter, categoryFilter, searchTerm, categoryName]);
 
   const closeModal = () => {
     setActiveModal(null);
@@ -419,11 +424,11 @@ function FilterBar({
   onStatusChange: (s: EquipmentStatus | 'all') => void;
   categoryFilter: string | 'all';
   onCategoryChange: (c: string | 'all') => void;
-  categoryOptions: string[];
+  categoryOptions: { value: string; label: string }[];
 }) {
   return (
-    <div className="bg-white rounded-b-xl border-x border-b border-neutral-200 p-3 mb-4 grid grid-cols-1 sm:grid-cols-4 gap-2">
-      <div className="sm:col-span-2 relative">
+    <div className="bg-white rounded-b-xl border-x border-b border-neutral-200 p-3 mb-4 space-y-2">
+      <div className="relative">
         <Search className="absolute start-3 top-1/2 -translate-y-1/2 w-4 h-4 text-neutral-400" />
         <input
           type="search"
@@ -433,28 +438,30 @@ function FilterBar({
           className="w-full ps-9 pe-3 py-2 text-sm border border-neutral-200 rounded-lg bg-neutral-50 focus:bg-white focus:ring-2 focus:ring-primary-500"
         />
       </div>
-      <Select
-        value={statusFilter === 'all' ? null : statusFilter}
-        onChange={(v) => onStatusChange(v === null ? 'all' : (v as EquipmentStatus))}
-        options={[
-          { value: EquipmentStatus.AVAILABLE, label: TEXT_CONSTANTS.FEATURES.EQUIPMENT.STATUS_OPTIONS.AVAILABLE },
-          { value: EquipmentStatus.SECURITY, label: TEXT_CONSTANTS.FEATURES.EQUIPMENT.STATUS_OPTIONS.SECURITY },
-          { value: EquipmentStatus.REPAIR, label: TEXT_CONSTANTS.FEATURES.EQUIPMENT.STATUS_OPTIONS.REPAIR },
-          { value: EquipmentStatus.LOST, label: TEXT_CONSTANTS.FEATURES.EQUIPMENT.STATUS_OPTIONS.LOST },
-          { value: EquipmentStatus.PENDING_TRANSFER, label: TEXT_CONSTANTS.FEATURES.EQUIPMENT.STATUS_OPTIONS.PENDING_TRANSFER },
-        ]}
-        placeholder={TEXT_CONSTANTS.FEATURES.EQUIPMENT.ALL_STATUSES}
-        clearable
-        ariaLabel={TEXT_CONSTANTS.FEATURES.EQUIPMENT.ALL_STATUSES}
-      />
-      <Select
-        value={categoryFilter === 'all' ? null : categoryFilter}
-        onChange={(v) => onCategoryChange(v === null ? 'all' : (v as string))}
-        options={categoryOptions.map((c) => ({ value: c, label: c }))}
-        placeholder={TEXT_CONSTANTS.FEATURES.EQUIPMENT.ALL_CATEGORIES}
-        clearable
-        ariaLabel={TEXT_CONSTANTS.FEATURES.EQUIPMENT.ALL_CATEGORIES}
-      />
+      <div className="grid grid-cols-2 gap-2">
+        <Select
+          value={statusFilter === 'all' ? null : statusFilter}
+          onChange={(v) => onStatusChange(v === null ? 'all' : (v as EquipmentStatus))}
+          options={[
+            { value: EquipmentStatus.AVAILABLE, label: TEXT_CONSTANTS.FEATURES.EQUIPMENT.STATUS_OPTIONS.AVAILABLE },
+            { value: EquipmentStatus.SECURITY, label: TEXT_CONSTANTS.FEATURES.EQUIPMENT.STATUS_OPTIONS.SECURITY },
+            { value: EquipmentStatus.REPAIR, label: TEXT_CONSTANTS.FEATURES.EQUIPMENT.STATUS_OPTIONS.REPAIR },
+            { value: EquipmentStatus.LOST, label: TEXT_CONSTANTS.FEATURES.EQUIPMENT.STATUS_OPTIONS.LOST },
+            { value: EquipmentStatus.PENDING_TRANSFER, label: TEXT_CONSTANTS.FEATURES.EQUIPMENT.STATUS_OPTIONS.PENDING_TRANSFER },
+          ]}
+          placeholder={TEXT_CONSTANTS.FEATURES.EQUIPMENT.ALL_STATUSES}
+          clearable
+          ariaLabel={TEXT_CONSTANTS.FEATURES.EQUIPMENT.ALL_STATUSES}
+        />
+        <Select
+          value={categoryFilter === 'all' ? null : categoryFilter}
+          onChange={(v) => onCategoryChange(v === null ? 'all' : (v as string))}
+          options={categoryOptions}
+          placeholder={TEXT_CONSTANTS.FEATURES.EQUIPMENT.ALL_CATEGORIES}
+          clearable
+          ariaLabel={TEXT_CONSTANTS.FEATURES.EQUIPMENT.ALL_CATEGORIES}
+        />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Equipment category filter dropdown was showing raw `categoryId` strings because `Equipment.category` is a reference into the `categories` collection (see `src/types/equipment.ts:18`), but `FilterBar` was using the id as both value and label.
- Resolve display names through the existing `useCategoryLookup` hook and build `{ value: id, label: name }` options, sorted by Hebrew locale on the resolved name. Falls back to the raw id when a category has been deactivated/missing.
- Search now matches the **resolved** category name as well, so typing a Hebrew category in the search field still hits its items.
- Filter row now matches the phone-book pattern: full-width search on top, two dropdowns in `grid-cols-2 gap-2` underneath at every breakpoint (was `grid-cols-1 sm:grid-cols-4` which stacked on mobile).

## Test plan
- [ ] On `/equipment`, the category filter dropdown lists Hebrew names (e.g. נשק, אופטיקה), not UUIDs.
- [ ] Selecting a category still filters correctly (value is still the id under the hood).
- [ ] Search by category Hebrew text matches the right items.
- [ ] On mobile width, status + category dropdowns sit side-by-side, not stacked.
- [ ] If a category is deactivated/deleted, items keep showing the raw id as a fallback label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)