### PR TITLE
fix(logistics): phone-book filter layout + extract filter strings

### DIFF
--- a/docs/codebase/src/components/logistics/LogisticsInventoryPage.md
+++ b/docs/codebase/src/components/logistics/LogisticsInventoryPage.md
@@ -1,0 +1,40 @@
+# LogisticsInventoryPage
+
+**File:** `src/components/logistics/LogisticsInventoryPage.tsx`
+
+Inventory landing for אפסנאות (non-serialized supplies). Mounted by `src/app/logistics/page.tsx` inside `AuthGuard` + `AppShell`. Templates seed the catalogue; items are quantity-tracked entries that inherit name + category from their template.
+
+## Composition
+
+```
+LogisticsInventoryPage
+  ├ "הוסף פריט" button   (privileged users only; disabled when no templates exist)
+  ├ No-templates info banner (only when templates.length === 0)
+  ├ Filter row
+  │    ├ search input (full width)
+  │    └ grid-cols-2: [category] [subcategory]
+  ├ Inventory table   (or loading / error / empty / no-match state)
+  └ AddLogisticsItemModal / EditLogisticsItemModal portals + toast
+```
+
+## Filters
+
+Layout matches the phone-book pattern: full-width search on top, two filter dropdowns side-by-side at every breakpoint (`grid-cols-2 gap-2`).
+
+- **search** — substring match on `name`, `category`, `subcategory`, `location`, `currentHolderName`.
+- **category** — `string | null` picked from the categories actually present on items. Sorted with `localeCompare('he')`.
+- **subcategory** — same shape, narrowed to the subcategories that occur under the currently selected category (or all when category is `'all'`).
+
+Categories and subcategories are stored on `LogisticsItem` / `LogisticsTemplate` as **freeform strings**, not as references into the `categories` collection — this is intentional per `src/types/logistics.ts` (the unit-specific אפסנאות taxonomy is deliberately separate from the equipment categories collection). No id→name resolution is needed.
+
+## Strings
+
+Filter labels and the "הוסף פריט" button text come from `TEXT_CONSTANTS.FEATURES.LOGISTICS` in `src/constants/text.ts`:
+
+- `SEARCH_PLACEHOLDER`, `ALL_CATEGORIES`, `ALL_SUBCATEGORIES`, `FILTER_BY_CATEGORY`, `FILTER_BY_SUBCATEGORY`, `ADD_ITEM`.
+
+Remaining Hebrew strings in this component (empty states, toast messages, table headers, delete confirmation) are still inline and tracked as a follow-up cleanup.
+
+## Permissions
+
+`canEdit` is true for `ADMIN`, `SYSTEM_MANAGER`, `MANAGER`, `TEAM_LEADER` user types. Add/edit/delete actions are hidden from non-editors.

--- a/src/components/logistics/LogisticsInventoryPage.tsx
+++ b/src/components/logistics/LogisticsInventoryPage.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { Plus, Search, Pencil, Trash2 } from 'lucide-react';
 import { Select } from '@/components/ui';
 import { cn } from '@/lib/cn';
+import { TEXT_CONSTANTS } from '@/constants/text';
 import { useAuth } from '@/contexts/AuthContext';
 import { UserType } from '@/types/user';
 import { useLogisticsItems } from '@/hooks/useLogisticsItems';
@@ -97,7 +98,7 @@ export default function LogisticsInventoryPage() {
             className="inline-flex items-center gap-2 px-4 py-2 bg-primary-600 hover:bg-primary-700 disabled:bg-neutral-300 text-white text-sm font-medium rounded-lg shadow-sm transition-colors"
           >
             <Plus className="w-4 h-4" />
-            הוסף פריט
+            {TEXT_CONSTANTS.FEATURES.LOGISTICS.ADD_ITEM}
           </button>
         )}
       </div>
@@ -108,36 +109,38 @@ export default function LogisticsInventoryPage() {
         </div>
       )}
 
-      <div className="bg-white rounded-xl border border-neutral-200 p-3 mb-4 grid grid-cols-1 sm:grid-cols-4 gap-2">
-        <div className="sm:col-span-2 relative">
+      <div className="bg-white rounded-xl border border-neutral-200 p-3 mb-4 space-y-2">
+        <div className="relative">
           <Search className="absolute start-3 top-1/2 -translate-y-1/2 w-4 h-4 text-neutral-400" />
           <input
             type="search"
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
-            placeholder="חיפוש שם, קטגוריה, מיקום או מחזיק..."
+            placeholder={TEXT_CONSTANTS.FEATURES.LOGISTICS.SEARCH_PLACEHOLDER}
             className="w-full ps-9 pe-3 py-2 text-sm border border-neutral-200 rounded-lg bg-neutral-50 focus:bg-white focus:ring-2 focus:ring-primary-500"
           />
         </div>
-        <Select
-          value={categoryFilter === 'all' ? null : categoryFilter}
-          onChange={(v) => {
-            setCategoryFilter(v === null ? 'all' : (v as string));
-            setSubcategoryFilter('all');
-          }}
-          options={categoryOptions.map((c) => ({ value: c, label: c }))}
-          placeholder="כל הקטגוריות"
-          clearable
-          ariaLabel="סינון לפי קטגוריה"
-        />
-        <Select
-          value={subcategoryFilter === 'all' ? null : subcategoryFilter}
-          onChange={(v) => setSubcategoryFilter(v === null ? 'all' : (v as string))}
-          options={subcategoryOptions.map((c) => ({ value: c, label: c }))}
-          placeholder="כל תתי-הקטגוריות"
-          clearable
-          ariaLabel="סינון לפי תת-קטגוריה"
-        />
+        <div className="grid grid-cols-2 gap-2">
+          <Select
+            value={categoryFilter === 'all' ? null : categoryFilter}
+            onChange={(v) => {
+              setCategoryFilter(v === null ? 'all' : (v as string));
+              setSubcategoryFilter('all');
+            }}
+            options={categoryOptions.map((c) => ({ value: c, label: c }))}
+            placeholder={TEXT_CONSTANTS.FEATURES.LOGISTICS.ALL_CATEGORIES}
+            clearable
+            ariaLabel={TEXT_CONSTANTS.FEATURES.LOGISTICS.FILTER_BY_CATEGORY}
+          />
+          <Select
+            value={subcategoryFilter === 'all' ? null : subcategoryFilter}
+            onChange={(v) => setSubcategoryFilter(v === null ? 'all' : (v as string))}
+            options={subcategoryOptions.map((c) => ({ value: c, label: c }))}
+            placeholder={TEXT_CONSTANTS.FEATURES.LOGISTICS.ALL_SUBCATEGORIES}
+            clearable
+            ariaLabel={TEXT_CONSTANTS.FEATURES.LOGISTICS.FILTER_BY_SUBCATEGORY}
+          />
+        </div>
       </div>
 
       {error && (

--- a/src/constants/text.ts
+++ b/src/constants/text.ts
@@ -241,7 +241,13 @@ export const TEXT_CONSTANTS = {
     },
     LOGISTICS: {
       TITLE: 'אפסנאות',
-      DESCRIPTION: 'ניהול ציוד לא-ממוספר וכמויות'
+      DESCRIPTION: 'ניהול ציוד לא-ממוספר וכמויות',
+      SEARCH_PLACEHOLDER: 'חיפוש שם, קטגוריה, מיקום או מחזיק...',
+      ALL_CATEGORIES: 'כל הקטגוריות',
+      ALL_SUBCATEGORIES: 'כל תתי-הקטגוריות',
+      FILTER_BY_CATEGORY: 'סינון לפי קטגוריה',
+      FILTER_BY_SUBCATEGORY: 'סינון לפי תת-קטגוריה',
+      ADD_ITEM: 'הוסף פריט'
     },
     EQUIPMENT: {
       TITLE: 'צלם',


### PR DESCRIPTION
## Summary
- `/logistics` category + subcategory dropdowns were stacked under the search input on mobile (`grid-cols-1 sm:grid-cols-4`). Align with the phone-book layout: full-width search on top, two dropdowns side-by-side at every breakpoint (`grid-cols-2 gap-2`).
- Filter labels and the "הוסף פריט" button moved out of inline JSX into `TEXT_CONSTANTS.FEATURES.LOGISTICS` per the project rule (no inline Hebrew in components).
- **Note on category id resolution:** logistics category/subcategory are intentionally stored as freeform strings, not references into the equipment `categories` collection (see `src/types/logistics.ts:8-10` — the unit-specific אפסנאות taxonomy is deliberately separate). So no id→name resolution is needed on this page. Equipment's separate id-resolution fix is shipped on `fix/equipment-filter-resolve-category-and-layout`.

## Test plan
- [ ] On `/logistics`, the search input is full-width on the top of the filter card.
- [ ] Category + subcategory dropdowns sit side-by-side underneath at all breakpoints (including mobile).
- [ ] Selecting a category still narrows the subcategory list to that category's subs.
- [ ] Labels (`כל הקטגוריות`, `כל תתי-הקטגוריות`, search placeholder, "הוסף פריט") render unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)