### PR TITLE
feat(offline): persistent Firestore cache (phase 1)

### DIFF
--- a/docs/codebase/src/lib/firebase.md
+++ b/docs/codebase/src/lib/firebase.md
@@ -1,23 +1,39 @@
 # firebase.ts
 
-**File:** `src/lib/firebase.ts`  
-**Lines:** 22  
+**File:** `src/lib/firebase.ts`
 **Status:** Active
 
 ## Purpose
 
-Firebase initialization and configuration. Initializes the Firebase app, Firestore database, and Firebase Auth instances using environment variables.
+Firebase client SDK initialization. Initializes the Firebase app, Firestore database (with persistent IndexedDB cache in browsers), Firebase Auth, Storage, and App Check.
 
 ## Exports
 
 | Export | Type | Description |
 |--------|------|-------------|
-| `app` | `FirebaseApp` | Initialized Firebase app instance |
-| `db` | `Firestore` | Firestore database instance |
+| `app` (default) | `FirebaseApp` | Initialized Firebase app instance |
+| `db` | `Firestore` | Firestore database instance — browser path is persistence-enabled |
 | `auth` | `Auth` | Firebase Auth instance |
+| `storage` | `FirebaseStorage` | Firebase Storage instance |
+
+## Persistent Firestore cache (P1)
+
+In browsers, `db` is built via `initializeFirestore` with:
+
+- `persistentLocalCache({ tabManager: persistentSingleTabManager({ forceOwnership: false }) })`
+
+Effects:
+- Reads survive reloads — `getDoc` / `getDocs` / `onSnapshot` serve from IndexedDB while offline or before the network responds.
+- Multi-tab safe. Only one tab owns writes; others read from the shared cache (`forceOwnership: false`).
+- HMR-safe. A second initialization attempt on the same app falls back to `getFirestore(app)`.
+
+In SSR / server contexts (`typeof window === 'undefined'`), `db` falls back to `getFirestore(app)` (memory cache only) so Node imports don't trip on the IndexedDB-only persistent cache.
+
+Tradeoff: the IDB cache grows with read volume. Phase 7 introduces explicit invalidation hooks (S5 in `docs/spec/offline-first.md`) for permission/role revocation.
 
 ## Notes
 
-- All Firestore operations across the codebase use this `db` instance.
+- All client Firestore operations across the codebase use this `db` instance.
 - All auth operations use this `auth` instance.
-- Mock version exists at `src/lib/__mocks__/firebase.ts` for tests.
+- Mock at `src/lib/__mocks__/firebase.ts` exposes `initializeFirestore`, `persistentLocalCache`, `persistentSingleTabManager` as no-op `jest.fn()` stubs.
+- See `docs/spec/offline-first.md` Phase 1 for the migration context.

--- a/docs/spec/offline-first.md
+++ b/docs/spec/offline-first.md
@@ -170,6 +170,7 @@ As each phase ships, findings are reflected in:
 
 ## Resume Pointer
 
-- ✅ **Phase 0** — this spec lands, `OFFLINE_REPLAY_CONCURRENCY` flag in `src/lib/offline/config.ts`.
-- ⬜ **Phase 1** — enable Firestore persistent cache in `src/lib/firebase.ts`. PR title: `feat(offline): persistent Firestore cache (phase 1)`.
-- ⬜ **Phase 2..8** — see table above.
+- ✅ **Phase 0** — spec + `OFFLINE_REPLAY_CONCURRENCY` flag (PR #121).
+- ✅ **Phase 1** — Firestore persistent cache enabled in `src/lib/firebase.ts` (browser path uses `persistentLocalCache` + `persistentSingleTabManager({ forceOwnership: false })`; SSR falls back to in-memory).
+- ⬜ **Phase 2** — `next.config.ts` remote-image patterns + bundle-budget CI gate.
+- ⬜ **Phase 3..8** — see table above.

--- a/src/lib/__mocks__/firebase.ts
+++ b/src/lib/__mocks__/firebase.ts
@@ -15,6 +15,9 @@ export const initializeApp = () => ({});
 
 // firebase/firestore
 export const getFirestore = () => ({});
+export const initializeFirestore = jest.fn(() => ({}));
+export const persistentLocalCache = jest.fn((opts?: unknown) => ({ kind: 'persistent', opts }));
+export const persistentSingleTabManager = jest.fn((opts?: unknown) => ({ kind: 'single-tab', opts }));
 export const collection = jest.fn();
 export const doc = jest.fn();
 export const getDoc = jest.fn();

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,5 +1,11 @@
-import { initializeApp, getApps } from "firebase/app";
-import { getFirestore } from "firebase/firestore";
+import { initializeApp, getApps, type FirebaseApp } from "firebase/app";
+import {
+  getFirestore,
+  initializeFirestore,
+  persistentLocalCache,
+  persistentSingleTabManager,
+  type Firestore,
+} from "firebase/firestore";
 import { getAuth } from "firebase/auth";
 import { getStorage } from "firebase/storage";
 import { ensureAppCheckInitialized } from "./appCheck";
@@ -16,8 +22,28 @@ const firebaseConfig = {
 // Initialize Firebase
 const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
 
-// Initialize Firestore, Auth, and Storage
-export const db = getFirestore(app);
+// Browser path uses an IndexedDB-backed persistent cache so reads survive
+// reloads and serve while offline (P1 of offline-first migration —
+// docs/spec/offline-first.md). Server / SSR path falls back to in-memory.
+// `persistentSingleTabManager({ forceOwnership: false })` lets multi-tab use
+// proceed; only one tab owns the writer at a time, others read.
+function initDb(firebaseApp: FirebaseApp): Firestore {
+  if (typeof window === 'undefined') {
+    return getFirestore(firebaseApp);
+  }
+  try {
+    return initializeFirestore(firebaseApp, {
+      localCache: persistentLocalCache({
+        tabManager: persistentSingleTabManager({ forceOwnership: false }),
+      }),
+    });
+  } catch {
+    // HMR / second import after the app was already initialized once.
+    return getFirestore(firebaseApp);
+  }
+}
+
+export const db = initDb(app);
 export const auth = getAuth(app);
 export const storage = getStorage(app);
 


### PR DESCRIPTION
## Summary
- Enable Firestore persistent IndexedDB cache in the browser via `initializeFirestore` + `persistentLocalCache({ tabManager: persistentSingleTabManager({ forceOwnership: false }) })`.
- SSR / Node path falls back to `getFirestore(app)` (memory cache) since IndexedDB is browser-only.
- HMR-safe — a second init attempt on the same app falls back to `getFirestore(app)` instead of throwing.
- Mock `src/lib/__mocks__/firebase.ts` updated with no-op stubs.

## Behavior change
- Reads (`getDoc`/`getDocs`/`onSnapshot`) now survive page reload and serve while offline.
- Multi-tab safe: only one tab owns writes, others read from shared cache (`forceOwnership: false`).

## Test plan
- [x] All 254 `src/lib/__tests__/` tests pass (`npx jest src/lib/__tests__/`).
- [x] `npm run lint` clean on changed files.
- [ ] Manual: open app, navigate, hard-reload — list pages render from cache before network responds.
- [ ] Manual: DevTools → Offline → navigate — cached pages still render.

Refs: `docs/spec/offline-first.md` Phase 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)