### PR TITLE
feat(offline): remotePatterns + bundle budget tooling (phase 2)

### DIFF
--- a/bundle-budget.json
+++ b/bundle-budget.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "./scripts/check-bundle-size.js",
+  "description": "Gzipped first-load JS budget for the largest entrypoint. Bumped per phase as the SW / outbox land. See docs/spec/offline-first.md (audit note N5).",
+  "maxFirstLoadKB": null,
+  "phaseDeltas": {
+    "3": { "maxIncreaseKB": 40, "note": "Service Worker shell" },
+    "5": { "maxIncreaseKB": 25, "note": "Outbox + replay loop" }
+  }
+}

--- a/docs/spec/offline-first.md
+++ b/docs/spec/offline-first.md
@@ -171,6 +171,7 @@ As each phase ships, findings are reflected in:
 ## Resume Pointer
 
 - ✅ **Phase 0** — spec + `OFFLINE_REPLAY_CONCURRENCY` flag (PR #121).
-- ✅ **Phase 1** — Firestore persistent cache enabled in `src/lib/firebase.ts` (browser path uses `persistentLocalCache` + `persistentSingleTabManager({ forceOwnership: false })`; SSR falls back to in-memory).
-- ⬜ **Phase 2** — `next.config.ts` remote-image patterns + bundle-budget CI gate.
-- ⬜ **Phase 3..8** — see table above.
+- ✅ **Phase 1** — Firestore persistent cache enabled in `src/lib/firebase.ts` (PR #122).
+- ✅ **Phase 2** — `next.config.ts` Firebase Storage `remotePatterns`. `scripts/check-bundle-size.js` + `bundle-budget.json` + `npm run bundle-budget` script. CI wiring (build job + budget step) lands with P3 PR when the SW adds the first real chunk weight.
+- ⬜ **Phase 3** — Serwist PWA shell + bundle-budget CI step + user-driven `SKIP_WAITING`.
+- ⬜ **Phase 4..8** — see table above.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,31 @@
+const projectId = process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID;
+const storageBucket = process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET;
+
+// Firebase Storage host varies by bucket. Allow both default and configured
+// bucket so next/image is happy with `getDownloadURL` outputs whether the
+// bucket is `<project>.appspot.com` or a custom one.
+const firebaseStorageHosts = Array.from(
+  new Set(
+    [
+      'firebasestorage.googleapis.com',
+      'storage.googleapis.com',
+      projectId ? `${projectId}.firebasestorage.app` : null,
+      storageBucket ? storageBucket : null,
+    ].filter((v): v is string => Boolean(v)),
+  ),
+);
+
 const nextConfig = {
   // Exclude firebase-admin from client-side webpack bundling.
   // It's a Node.js-only package used in API routes only.
   serverExternalPackages: ['firebase-admin'],
+  images: {
+    remotePatterns: firebaseStorageHosts.map((hostname) => ({
+      protocol: 'https' as const,
+      hostname,
+      pathname: '/**',
+    })),
+  },
 };
 
 module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "vercel-build": "npm run build"
+    "vercel-build": "npm run build",
+    "bundle-budget": "node scripts/check-bundle-size.js"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.10",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -36,6 +36,7 @@ You can also export these directly in your shell — `.env.local` never clobbers
 | `purge-phone-change-pending.js` | Delete `phoneChangePending/{uid}` reservations older than `--age-hours` (default 24) | yes | no |
 | `reconcile-phone.js` | Detect / fix drift between Firebase Auth and Firestore `users.phoneNumber`. Report-only without `--fix`. | yes | no |
 | `sweep-account-deletions.js` | Hard-delete soft-deleted users past the 30-day retention window. Mirror of the daily cron. | yes (resumable via `users.deletionStartedAt`) | **yes** |
+| `check-bundle-size.js` | Run after `next build`. Prints gzipped first-load JS of the largest entrypoint. Fails when over `bundle-budget.json.maxFirstLoadKB`. Wired via `npm run bundle-budget`. CI hookup lands with the Serwist SW PR (Phase 3 of `docs/spec/offline-first.md`). | yes | no |
 
 ## Common flags
 

--- a/scripts/check-bundle-size.js
+++ b/scripts/check-bundle-size.js
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+/* eslint-disable @typescript-eslint/no-require-imports */
+/*
+ * Bundle-size budget check. Run after `next build`.
+ *
+ * Reads the largest first-load entrypoint from `.next/build-manifest.json`,
+ * sums its chunks, gzips them, and prints the total. Fails (exit 1) if the
+ * gzipped total exceeds the per-phase budget in `bundle-budget.json`.
+ *
+ * Phase 0/1/2: informational only (no thresholds set).
+ * Phase 3 PR wires this script into CI and sets `maxFirstLoadKB`.
+ *
+ * Refs: docs/spec/offline-first.md (Phase 2, audit note N5).
+ */
+
+const fs = require('fs');
+const path = require('path');
+const zlib = require('zlib');
+
+const PROJECT_ROOT = path.resolve(__dirname, '..');
+const NEXT_DIR = path.join(PROJECT_ROOT, '.next');
+const MANIFEST = path.join(NEXT_DIR, 'build-manifest.json');
+const BUDGET = path.join(PROJECT_ROOT, 'bundle-budget.json');
+
+function fail(msg) {
+  console.error(`[bundle-size] ${msg}`);
+  process.exit(1);
+}
+
+if (!fs.existsSync(MANIFEST)) {
+  fail(`build-manifest.json not found at ${MANIFEST}. Run 'next build' first.`);
+}
+
+const manifest = JSON.parse(fs.readFileSync(MANIFEST, 'utf8'));
+const budget = fs.existsSync(BUDGET) ? JSON.parse(fs.readFileSync(BUDGET, 'utf8')) : {};
+
+function gzippedSize(filePath) {
+  const buf = fs.readFileSync(filePath);
+  return zlib.gzipSync(buf, { level: 9 }).length;
+}
+
+const pages = manifest.pages || {};
+let largest = { route: null, gzipBytes: 0 };
+for (const [route, chunks] of Object.entries(pages)) {
+  let total = 0;
+  for (const chunk of chunks) {
+    const full = path.join(NEXT_DIR, chunk);
+    if (!fs.existsSync(full)) continue;
+    total += gzippedSize(full);
+  }
+  if (total > largest.gzipBytes) {
+    largest = { route, gzipBytes: total };
+  }
+}
+
+if (!largest.route) {
+  fail('No pages found in build manifest.');
+}
+
+const kb = (largest.gzipBytes / 1024).toFixed(2);
+console.log(`[bundle-size] Largest entrypoint: ${largest.route}`);
+console.log(`[bundle-size] Gzipped first-load JS: ${kb} KB`);
+
+const cap = budget.maxFirstLoadKB;
+if (typeof cap === 'number') {
+  if (largest.gzipBytes / 1024 > cap) {
+    fail(`Budget exceeded — ${kb} KB > ${cap} KB cap. Bump bundle-budget.json or trim deps.`);
+  }
+  console.log(`[bundle-size] Under cap (${cap} KB).`);
+} else {
+  console.log('[bundle-size] No cap configured — informational only.');
+}


### PR DESCRIPTION
## Summary
- `next.config.ts` allows Firebase Storage hosts so `next/image` accepts `getDownloadURL` outputs.
- Bundle-size tooling: `scripts/check-bundle-size.js` + `bundle-budget.json` + `npm run bundle-budget`. Reports gzipped first-load JS of the largest entrypoint; fails over configured cap.
- Phase 0/1/2 informational only — `maxFirstLoadKB` is `null`. Cap activates with the Serwist SW PR (Phase 3), where the audit's 40 KB delta budget starts mattering.
- CI workflow step (build + `bundle-budget`) lands with Phase 3 PR.

## Behavior change
- Components can now use `next/image` with Firebase Storage URLs without `unoptimized={true}`.
- No runtime change for users.

## Test plan
- [x] Lint clean.
- [ ] Manual: `npm run build && npm run bundle-budget` locally — confirm largest entrypoint reported.

Refs: `docs/spec/offline-first.md` Phase 2 + audit note N5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)