### PR TITLE
feat(offline): idempotency infra + 7 routes wrapped (phase 4a)

### DIFF
--- a/docs/codebase/idempotency.md
+++ b/docs/codebase/idempotency.md
@@ -1,0 +1,108 @@
+# Idempotency helper
+
+**File:** `src/lib/db/server/idempotency.ts`
+**Status:** Active (Phase 4a)
+**Spec:** `docs/spec/offline-first.md` Phase 4
+
+## What it does
+
+`withIdempotency(request, actor, rawBody, handler, options?)` dedupes
+duplicate replays of mutating API requests using the
+`Idempotency-Key: <client-uuid>` HTTP header.
+
+Storage: `_idempotency/{uid}_{key}` doc. Rules deny client access; server-only.
+
+## Flow
+
+```
+client → POST /api/foo  (Idempotency-Key: K)
+   │
+   ▼
+withIdempotency:
+   tx.create(_idempotency/{uid}_K, {requestHash, status:'pending', createdAt, expiresAt})
+   │
+   ├─ ok → run handler → ref.update({status:'committed', snapshot})
+   │
+   └─ ALREADY_EXISTS → ref.get()
+         ├─ requestHash differs           → 422 IDEMPOTENCY_KEY_REUSED  (M2)
+         ├─ status:'committed'            → return cached snapshot      (S1)
+         ├─ status:'pending' fresh        → poll up to 5s
+         └─ status:'pending' >30s old     → steal lock, recurse
+```
+
+## Snapshot shape (S1)
+
+```ts
+{
+  status: number;
+  code?: string;
+  resourceId?: string;
+  createdIds?: string[];
+  newUpdatedAt?: string;
+  bodyHint: 'inline' | 'refetch';
+  inlineBody?: unknown;
+}
+```
+
+Default is `{ status:200, bodyHint:'refetch' }`. Pass `options.toSnapshot` to
+return a real ID / version that the client outbox needs for chaining
+(M3 in Phase 5).
+
+The wrapper truncates any inline body that would push the doc past 64 KB
+back to `bodyHint:'refetch'`. Audit decision S1.
+
+## Why not strictly atomic with the data write (M1)
+
+The audit's preferred path threads a Firestore `Transaction` through every
+service so the idempotency record and the data + audit writes commit
+together. Doing so across ~63 mutation routes is a multi-PR refactor.
+
+The lock-based version ships now. External guarantee — no double-write
+under concurrent replay — is identical. The narrow window:
+
+1. Caller A acquires the lock (`pending` written).
+2. Caller A's handler commits the data writes.
+3. Caller A crashes before patching the lock to `committed`.
+
+Stale-pending detection (>30s) steals the lock and re-runs the handler.
+If the handler is re-entrant (most services are by design), the second
+run is a no-op against the already-committed state. Routes that are
+**not** safely re-entrant must opt out and switch to the strictly-atomic
+path before they wrap.
+
+## Wiring on the client
+
+`src/lib/apiFetch.ts` injects `Idempotency-Key: <crypto.randomUUID()>` on
+every POST/PUT/PATCH/DELETE unless the caller supplies one. Phase 5's
+outbox replay loop overrides by setting the original key on retry — that's
+how dedupe stays consistent across reconnect cycles.
+
+## TTL
+
+- Field `expiresAt` is set to `createdAt + 24h`.
+- Firestore TTL purges records past `expiresAt` (config in
+  `firebase/firestore.indexes.json` `fieldOverrides`).
+- `/api/cron/sweep-idempotency` (daily at 04:00 UTC via `vercel.json`)
+  belt-and-braces deletes any record past `expiresAt + 24h` if TTL is
+  misconfigured.
+
+## Index
+
+- `(expiresAt ASC)` on `_idempotency` for the cron sweeper.
+  See `firebase/firestore.indexes.json`.
+
+## Deployment checklist (Phase 4)
+
+Before this PR merges:
+1. `firebase deploy --only firestore:rules` — pushes the deny rule.
+2. `firebase deploy --only firestore:indexes` — pushes the new composite + TTL.
+3. Verify TTL is enabled:
+   `gcloud firestore fields ttls update expiresAt --collection-group=_idempotency --project=sayeret-givati-1983`
+   (or toggle in Firebase Console → Firestore → Indexes → TTL).
+4. `CRON_SECRET` must be set in Vercel; same value already used by the other crons.
+
+## Migration tracking
+
+`docs/spec/idempotency-route-migration.md` is the canonical checklist for
+which mutation routes are wrapped. Phase 5 cannot start until that list
+is fully ✅ or `SKIP — reason`.

--- a/docs/spec/idempotency-route-migration.md
+++ b/docs/spec/idempotency-route-migration.md
@@ -1,0 +1,95 @@
+# Idempotency Route Migration
+
+Tracking checklist for wrapping every mutating API route with
+`withIdempotency` (`src/lib/db/server/idempotency.ts`).
+
+**Why:** Phase 5 of the offline-first migration (outbox + replay) requires
+server-side dedupe on every mutation route. Without it, every reconnect that
+triggers a duplicate send doubles the write. See `docs/spec/offline-first.md`.
+
+**Gate:** Phase 5 PR cannot land until every row below is ✅ or marked
+`SKIP — reason` and that decision is reflected back here.
+
+## Routes
+
+| Route | Method(s) | Wrapped | Notes |
+|-------|-----------|---------|-------|
+| `/api/actions-log` | POST | ⬜ | Append-only log; replay double-writes a row, but rows are timestamped → harmless. Wrap for cleanliness. |
+| `/api/ammunition-inventory` | POST | ⬜ | |
+| `/api/ammunition-inventory/[id]` | PATCH/DELETE | ⬜ | |
+| `/api/ammunition-report-requests` | POST | ⬜ | |
+| `/api/ammunition-reports` | POST | ⬜ | |
+| `/api/ammunition-templates` | POST | ⬜ | |
+| `/api/ammunition-templates/[id]` | PATCH/DELETE | ⬜ | |
+| `/api/auth/audit` | POST | SKIP — server-internal | Audit emitter; no client-driven retry. |
+| `/api/auth/check-email-verified` | POST | SKIP — read-only side-effect | Reads Auth state; no write. |
+| `/api/auth/register` | POST | SKIP — pre-auth | No bearer token. Server-side dedupe via personnel hash. |
+| `/api/auth/verify-military-id` | POST | SKIP — pre-auth | |
+| `/api/authorized-personnel` | POST | ⬜ | |
+| `/api/authorized-personnel/bulk` | POST | ⬜ | Large body; verify 64 KB snapshot cap behavior. |
+| `/api/categories` | POST/PATCH/DELETE | ⬜ | |
+| `/api/categories/subcategories` | POST/PATCH/DELETE | ⬜ | |
+| `/api/cron/*` | POST | SKIP — cron | Vercel cron, single-fire via `CRON_SECRET`. |
+| `/api/equipment` | POST | ⬜ | |
+| `/api/equipment/batch` | POST | ⬜ | |
+| `/api/equipment/report` | POST | ⬜ | |
+| `/api/equipment/retire` | POST | ✅ | Wrapped in P4a. |
+| `/api/equipment/transfer` | POST | ✅ | Wrapped in P4a. |
+| `/api/equipment/[id]/exchange/replace-by-another` | POST | ⬜ | |
+| `/api/equipment/[id]/exchange/request` | POST | ⬜ | |
+| `/api/equipment/[id]/storage/pull` | POST | ✅ | Wrapped in P4a. |
+| `/api/equipment/[id]/storage/send` | POST | ✅ | Wrapped in P4a. |
+| `/api/equipment-drafts` | POST | ⬜ | |
+| `/api/equipment-templates/approve` | POST | ⬜ | |
+| `/api/equipment-templates/propose` | POST | ⬜ | |
+| `/api/equipment-templates/reject` | POST | ⬜ | |
+| `/api/equipment-templates` | POST | ⬜ | |
+| `/api/equipment-templates/[id]` | PATCH/DELETE | ⬜ | |
+| `/api/exchange-requests/[id]/approve` | POST | ⬜ | |
+| `/api/exchange-requests/[id]/reject` | POST | ⬜ | |
+| `/api/force-ops` | POST | ⬜ | Admin-only forced operations; verify replay semantics carefully. |
+| `/api/guard-schedules` | POST | ⬜ | |
+| `/api/guard-schedules/[id]` | PATCH/DELETE | ⬜ | |
+| `/api/guard-schedules/[id]/share` | POST | ⬜ | Clone-on-share; replay must not double-clone. |
+| `/api/logistics-items` | POST/PATCH/DELETE | ⬜ | |
+| `/api/logistics-templates` | POST/PATCH/DELETE | ⬜ | |
+| `/api/notifications` | POST | ⬜ | |
+| `/api/notifications/read` | POST | ⬜ | Idempotent semantically; wrap for cleanliness. |
+| `/api/permission-grants` | POST | ⬜ | |
+| `/api/permission-grants/[id]/revoke` | POST | ⬜ | |
+| `/api/report-requests` | POST | ⬜ | |
+| `/api/report-requests/fulfill` | POST | ⬜ | |
+| `/api/retirement-requests/approve` | POST | ⬜ | |
+| `/api/retirement-requests/reject` | POST | ⬜ | |
+| `/api/soldier-status/[id]` | PUT | ✅ | Wrapped in P4a. |
+| `/api/system-config` | PATCH | ⬜ | |
+| `/api/training-plans` | POST | ⬜ | |
+| `/api/training-plans/[id]` | PATCH/DELETE | ⬜ | |
+| `/api/training-plans/[id]/restock-request` | POST | ⬜ | |
+| `/api/transfer-requests` | POST | ✅ | Wrapped in P4a. |
+| `/api/transfer-requests/approve` | POST | ⬜ | |
+| `/api/transfer-requests/reject` | POST | ⬜ | |
+| `/api/users/account/cancel-delete` | POST | ⬜ | |
+| `/api/users/account/delete` | POST | ⬜ | |
+| `/api/users/phone-change/cancel` | POST | ⬜ | |
+| `/api/users/phone-change/confirm` | POST | ⬜ | Security-sensitive; replay must not consume OTP twice. |
+| `/api/users/phone-change/initiate` | POST | ⬜ | |
+| `/api/users/profile` | PATCH | ✅ | Wrapped in P4a. |
+| `/api/users/sessions/revoke` | POST | ⬜ | |
+
+## Status summary (last updated 2026-05-15 P4a)
+
+- Wrapped: **7** (high-traffic critical paths).
+- Pending: **47**.
+- Skipped: **6** (cron / pre-auth / server-internal).
+
+## Process
+
+Each wrap follows the same template — pull the body once via `request.text()`,
+hand both `actor` and `rawBody` to `withIdempotency`, parse JSON inside the
+closure. See `src/app/api/equipment/transfer/route.ts` for the canonical
+pattern.
+
+When wrapping, also confirm:
+- The inner handler is safe to re-enter (in case a stale `pending` lock is stolen and the handler runs again — see helper docstring).
+- The default snapshot (`status:200, bodyHint:'refetch'`) is acceptable; if the route returns `createdIds` or new `updatedAt` that the client outbox needs to chain (M3), pass `options.toSnapshot` to populate them.

--- a/docs/spec/offline-first.md
+++ b/docs/spec/offline-first.md
@@ -173,6 +173,8 @@ As each phase ships, findings are reflected in:
 - ✅ **Phase 0** — spec + `OFFLINE_REPLAY_CONCURRENCY` flag (PR #121).
 - ✅ **Phase 1** — Firestore persistent cache enabled in `src/lib/firebase.ts` (PR #122).
 - ✅ **Phase 2** — `next.config.ts` Firebase Storage `remotePatterns` + bundle-budget tooling (PR #123).
-- ✅ **Phase 3** — Serwist PWA shell. `src/app/sw.ts` with `skipWaiting:false` + user-driven `SKIP_WAITING` (M5). `ServiceWorkerUpdater` toast wired in `layout.tsx`. `/sw.js` Cache-Control `no-cache` via `next.config.ts` headers (S7). CI `build-and-budget` job + `bundle-budget.json` cap 110 KB. Baseline `/_error` first-load JS = 93.56 KB.
-- ⬜ **Phase 4** — Server-side idempotency: `_idempotency` collection + `withIdempotency` wrap all mutation routes.
-- ⬜ **Phase 5..8** — see table above.
+- ✅ **Phase 3** — Serwist PWA shell (PR #124).
+- 🚧 **Phase 4a** — Infrastructure: `withIdempotency` helper, rules deny `_idempotency`, composite + TTL index, cron sweeper, `apiFetch` injects `Idempotency-Key`. 7 representative routes wrapped (equipment transfer/retire/storage send & pull, soldier-status, transfer-requests, users profile). Full migration tracked in `docs/spec/idempotency-route-migration.md`.
+- ⬜ **Phase 4b** — Wrap remaining 47 mutation routes per checklist.
+- ⬜ **Phase 5** — Outbox + replay. **Gated** on 4b completion.
+- ⬜ **Phase 6..8** — see table above.

--- a/firebase/firestore.indexes.json
+++ b/firebase/firestore.indexes.json
@@ -159,7 +159,24 @@
           "order": "DESCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "_idempotency",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "expiresAt",
+          "order": "ASCENDING"
+        }
+      ]
     }
   ],
-  "fieldOverrides": []
+  "fieldOverrides": [
+    {
+      "collectionGroup": "_idempotency",
+      "fieldPath": "expiresAt",
+      "ttl": true,
+      "indexes": []
+    }
+  ]
 }

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -238,6 +238,14 @@ service cloud.firestore {
       allow write: if false;
     }
 
+    // Idempotency synchronization tokens (Phase 4 of offline-first
+    // migration). Server-only — clients have zero access. Records are
+    // ephemeral; the Firestore TTL on `expiresAt` purges them 24h after
+    // commit. See docs/spec/offline-first.md.
+    match /_idempotency/{recordId} {
+      allow read, write: if false;
+    }
+
     // Deny everything else
     match /{document=**} {
       allow read, write: if false;

--- a/src/app/api/cron/sweep-idempotency/route.ts
+++ b/src/app/api/cron/sweep-idempotency/route.ts
@@ -1,0 +1,94 @@
+/**
+ * POST /api/cron/sweep-idempotency
+ *
+ * Belt-and-braces sweeper for `_idempotency` records. Firestore TTL (set on
+ * the `expiresAt` field via firebase/firestore.indexes.json `fieldOverrides`)
+ * is the primary purge mechanism; this cron deletes anything still around
+ * past `expiresAt + 24h` in case the TTL feature is misconfigured.
+ *
+ * Auth: `Authorization: Bearer ${CRON_SECRET}` — same shared secret used by
+ * the other crons. Production-project gate.
+ *
+ * See docs/spec/offline-first.md Phase 4 (audit note S2).
+ */
+import { NextResponse } from 'next/server';
+import { timingSafeEqual } from 'crypto';
+import { Timestamp } from 'firebase-admin/firestore';
+import { getAdminDb } from '@/lib/db/admin';
+import { COLLECTIONS } from '@/lib/db/collections';
+
+const PROD_PROJECT_ID = 'sayeret-givati-1983';
+const SAFETY_BUFFER_HOURS = 24;
+const DEFAULT_MAX_DELETES = 1000;
+
+function isAuthorized(request: Request): boolean {
+  const expected = process.env.CRON_SECRET;
+  if (!expected) return false;
+  const header = request.headers.get('authorization') ?? '';
+  const presented = header.startsWith('Bearer ') ? header.slice(7) : '';
+  if (!presented) return false;
+  const a = Buffer.from(presented);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) return false;
+  try {
+    return timingSafeEqual(a, b);
+  } catch {
+    return false;
+  }
+}
+
+export async function POST(request: Request) {
+  if (!process.env.CRON_SECRET) {
+    return NextResponse.json(
+      { success: false, error: 'cron_disabled' },
+      { status: 503 },
+    );
+  }
+  if (process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID !== PROD_PROJECT_ID) {
+    return NextResponse.json(
+      { success: false, error: 'wrong_project' },
+      { status: 503 },
+    );
+  }
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ success: false, error: 'unauthorized' }, { status: 401 });
+  }
+
+  const url = new URL(request.url);
+  const dryRun = url.searchParams.get('dryRun') === 'true';
+  const maxDeletesRaw = Number(url.searchParams.get('maxDeletes') ?? DEFAULT_MAX_DELETES);
+  const maxDeletes = Number.isFinite(maxDeletesRaw)
+    ? Math.max(1, Math.min(10_000, Math.trunc(maxDeletesRaw)))
+    : DEFAULT_MAX_DELETES;
+
+  const cutoff = Timestamp.fromMillis(Date.now() - SAFETY_BUFFER_HOURS * 3600 * 1000);
+  const db = getAdminDb();
+  const snap = await db
+    .collection(COLLECTIONS.IDEMPOTENCY)
+    .where('expiresAt', '<', cutoff)
+    .limit(maxDeletes)
+    .get();
+
+  let deleted = 0;
+  if (!dryRun && !snap.empty) {
+    const batch = db.batch();
+    snap.docs.forEach((doc) => batch.delete(doc.ref));
+    await batch.commit();
+    deleted = snap.size;
+  }
+
+  console.log('[cron/sweep-idempotency]', {
+    dryRun,
+    examined: snap.size,
+    deleted,
+    truncated: snap.size === maxDeletes,
+  });
+
+  return NextResponse.json({
+    success: true,
+    dryRun,
+    examined: snap.size,
+    deleted,
+    truncated: snap.size === maxDeletes,
+  });
+}

--- a/src/app/api/equipment/[id]/storage/pull/route.ts
+++ b/src/app/api/equipment/[id]/storage/pull/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { serverPullFromStorage } from '@/lib/db/server/equipmentService';
 import { getActorOrError } from '@/lib/db/server/auth';
+import { withIdempotency } from '@/lib/db/server/idempotency';
 import {
   actorToAuthUser,
   fetchEquipmentForPolicy,
@@ -11,31 +12,35 @@ export async function POST(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  try {
-    const actorOrError = await getActorOrError(request);
-    if (actorOrError instanceof NextResponse) return actorOrError;
-    const actor = actorOrError;
+  const actorOrError = await getActorOrError(request);
+  if (actorOrError instanceof NextResponse) return actorOrError;
+  const actor = actorOrError;
 
-    const { id } = await params;
-    const equipment = await fetchEquipmentForPolicy(id);
-    const authUser = actorToAuthUser(actor);
-    if (!canPullFromStorage({ user: authUser, equipment })) {
-      return NextResponse.json(
-        { success: false, error: 'Only the current holder of a stored item may pull it from storage' },
-        { status: 403 }
-      );
+  const { id } = await params;
+  const rawBody = await request.text();
+
+  return withIdempotency(request, actor, rawBody, async () => {
+    try {
+      const equipment = await fetchEquipmentForPolicy(id);
+      const authUser = actorToAuthUser(actor);
+      if (!canPullFromStorage({ user: authUser, equipment })) {
+        return NextResponse.json(
+          { success: false, error: 'Only the current holder of a stored item may pull it from storage' },
+          { status: 403 }
+        );
+      }
+
+      // SystemConfig.roundOpen gate is re-checked inside the server service.
+      await serverPullFromStorage({
+        equipmentId: id,
+        actorId: actor.uid,
+        actorName: actor.displayName || actor.uid,
+      });
+      return NextResponse.json({ success: true });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error('[API] equipment/[id]/storage/pull POST failed:', message);
+      return NextResponse.json({ success: false, error: message }, { status: 500 });
     }
-
-    // SystemConfig.roundOpen gate is re-checked inside the server service.
-    await serverPullFromStorage({
-      equipmentId: id,
-      actorId: actor.uid,
-      actorName: actor.displayName || actor.uid,
-    });
-    return NextResponse.json({ success: true });
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    console.error('[API] equipment/[id]/storage/pull POST failed:', message);
-    return NextResponse.json({ success: false, error: message }, { status: 500 });
-  }
+  });
 }

--- a/src/app/api/equipment/[id]/storage/send/route.ts
+++ b/src/app/api/equipment/[id]/storage/send/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { serverSendToStorage } from '@/lib/db/server/equipmentService';
 import { getActorOrError } from '@/lib/db/server/auth';
+import { withIdempotency } from '@/lib/db/server/idempotency';
 import {
   actorToAuthUser,
   fetchEquipmentForPolicy,
@@ -11,30 +12,34 @@ export async function POST(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  try {
-    const actorOrError = await getActorOrError(request);
-    if (actorOrError instanceof NextResponse) return actorOrError;
-    const actor = actorOrError;
+  const actorOrError = await getActorOrError(request);
+  if (actorOrError instanceof NextResponse) return actorOrError;
+  const actor = actorOrError;
 
-    const { id } = await params;
-    const equipment = await fetchEquipmentForPolicy(id);
-    const authUser = actorToAuthUser(actor);
-    if (!canSendToStorage({ user: authUser, equipment })) {
-      return NextResponse.json(
-        { success: false, error: 'Only the current holder of an available item may send it to storage' },
-        { status: 403 }
-      );
+  const { id } = await params;
+  const rawBody = await request.text();
+
+  return withIdempotency(request, actor, rawBody, async () => {
+    try {
+      const equipment = await fetchEquipmentForPolicy(id);
+      const authUser = actorToAuthUser(actor);
+      if (!canSendToStorage({ user: authUser, equipment })) {
+        return NextResponse.json(
+          { success: false, error: 'Only the current holder of an available item may send it to storage' },
+          { status: 403 }
+        );
+      }
+
+      await serverSendToStorage({
+        equipmentId: id,
+        actorId: actor.uid,
+        actorName: actor.displayName || actor.uid,
+      });
+      return NextResponse.json({ success: true });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error('[API] equipment/[id]/storage/send POST failed:', message);
+      return NextResponse.json({ success: false, error: message }, { status: 500 });
     }
-
-    await serverSendToStorage({
-      equipmentId: id,
-      actorId: actor.uid,
-      actorName: actor.displayName || actor.uid,
-    });
-    return NextResponse.json({ success: true });
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    console.error('[API] equipment/[id]/storage/send POST failed:', message);
-    return NextResponse.json({ success: false, error: message }, { status: 500 });
-  }
+  });
 }

--- a/src/app/api/equipment/retire/route.ts
+++ b/src/app/api/equipment/retire/route.ts
@@ -5,41 +5,46 @@ import {
   fetchEquipmentForPolicy,
 } from '@/lib/db/server/policyHelpers';
 import { getActorOrError } from '@/lib/db/server/auth';
+import { withIdempotency } from '@/lib/db/server/idempotency';
 import { canRetire } from '@/lib/equipmentPolicy';
 
 export async function POST(request: Request) {
-  try {
-    const actorOrError = await getActorOrError(request);
-    if (actorOrError instanceof NextResponse) return actorOrError;
-    const actor = actorOrError;
-    const input = await request.json();
+  const actorOrError = await getActorOrError(request);
+  if (actorOrError instanceof NextResponse) return actorOrError;
+  const actor = actorOrError;
+  const rawBody = await request.text();
 
-    if (!input.equipmentId) {
-      return NextResponse.json({ success: false, error: 'equipmentId is required' }, { status: 400 });
-    }
-    if (!input.reason) {
-      return NextResponse.json({ success: false, error: 'reason is required' }, { status: 400 });
-    }
+  return withIdempotency(request, actor, rawBody, async () => {
+    try {
+      const input = rawBody ? JSON.parse(rawBody) : {};
 
-    const equipment = await fetchEquipmentForPolicy(input.equipmentId);
-    const authUser = actorToAuthUser(actor);
-    if (!canRetire({ user: authUser, equipment })) {
-      return NextResponse.json(
-        { success: false, error: 'Only the signer may retire this item' },
-        { status: 403 }
-      );
-    }
+      if (!input.equipmentId) {
+        return NextResponse.json({ success: false, error: 'equipmentId is required' }, { status: 400 });
+      }
+      if (!input.reason) {
+        return NextResponse.json({ success: false, error: 'reason is required' }, { status: 400 });
+      }
 
-    const outcome = await serverRetireEquipment({
-      equipmentId: input.equipmentId,
-      actorId: actor.uid,
-      actorName: input.actorName || actor.displayName || actor.uid,
-      reason: input.reason,
-    });
-    return NextResponse.json({ success: true, outcome });
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    console.error('[API] equipment/retire POST failed:', message);
-    return NextResponse.json({ success: false, error: message }, { status: 500 });
-  }
+      const equipment = await fetchEquipmentForPolicy(input.equipmentId);
+      const authUser = actorToAuthUser(actor);
+      if (!canRetire({ user: authUser, equipment })) {
+        return NextResponse.json(
+          { success: false, error: 'Only the signer may retire this item' },
+          { status: 403 }
+        );
+      }
+
+      const outcome = await serverRetireEquipment({
+        equipmentId: input.equipmentId,
+        actorId: actor.uid,
+        actorName: input.actorName || actor.displayName || actor.uid,
+        reason: input.reason,
+      });
+      return NextResponse.json({ success: true, outcome });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error('[API] equipment/retire POST failed:', message);
+      return NextResponse.json({ success: false, error: message }, { status: 500 });
+    }
+  });
 }

--- a/src/app/api/equipment/transfer/route.ts
+++ b/src/app/api/equipment/transfer/route.ts
@@ -1,23 +1,29 @@
 import { NextResponse } from 'next/server';
 import { serverTransferEquipment } from '@/lib/db/server/equipmentService';
 import { getActorOrError } from '@/lib/db/server/auth';
+import { withIdempotency } from '@/lib/db/server/idempotency';
 
 export async function POST(request: Request) {
-  try {
-    const actorOrError = await getActorOrError(request);
-    if (actorOrError instanceof NextResponse) return actorOrError;
-    const input = await request.json();
-    if (!input.equipmentId || !input.newHolder || !input.newHolderId) {
-      return NextResponse.json(
-        { success: false, error: 'equipmentId, newHolder, and newHolderId are required' },
-        { status: 400 }
-      );
+  const actorOrError = await getActorOrError(request);
+  if (actorOrError instanceof NextResponse) return actorOrError;
+  const actor = actorOrError;
+  const rawBody = await request.text();
+
+  return withIdempotency(request, actor, rawBody, async () => {
+    try {
+      const input = rawBody ? JSON.parse(rawBody) : {};
+      if (!input.equipmentId || !input.newHolder || !input.newHolderId) {
+        return NextResponse.json(
+          { success: false, error: 'equipmentId, newHolder, and newHolderId are required' },
+          { status: 400 }
+        );
+      }
+      await serverTransferEquipment(input);
+      return NextResponse.json({ success: true });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error('[API] equipment/transfer POST failed:', message);
+      return NextResponse.json({ success: false, error: message }, { status: 500 });
     }
-    await serverTransferEquipment(input);
-    return NextResponse.json({ success: true });
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    console.error('[API] equipment/transfer POST failed:', message);
-    return NextResponse.json({ success: false, error: message }, { status: 500 });
-  }
+  });
 }

--- a/src/app/api/soldier-status/[id]/route.ts
+++ b/src/app/api/soldier-status/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { getActorOrError } from '@/lib/db/server/auth';
+import { withIdempotency } from '@/lib/db/server/idempotency';
 import {
   SoldierStatusValidationError,
   serverUpdateSoldierStatus,
@@ -25,46 +26,50 @@ export async function PUT(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  try {
-    const actorOrError = await getActorOrError(request);
-    if (actorOrError instanceof NextResponse) return actorOrError;
-    const actor = actorOrError;
+  const actorOrError = await getActorOrError(request);
+  if (actorOrError instanceof NextResponse) return actorOrError;
+  const actor = actorOrError;
 
-    const { id } = await params;
-    if (!id) {
-      return NextResponse.json(
-        { success: false, error: 'id is required in the path' },
-        { status: 400 }
-      );
-    }
-
-    const body = (await request.json()) as PutBody;
-    if (typeof body.status !== 'string') {
-      return NextResponse.json(
-        { success: false, error: 'status is required' },
-        { status: 400 }
-      );
-    }
-
-    await serverUpdateSoldierStatus(
-      id,
-      {
-        status: body.status as SoldierStatus,
-        ...(typeof body.customStatus === 'string' ? { customStatus: body.customStatus } : {}),
-      },
-      { uid: actor.uid, displayName: actor.displayName },
+  const { id } = await params;
+  if (!id) {
+    return NextResponse.json(
+      { success: false, error: 'id is required in the path' },
+      { status: 400 }
     );
-
-    return NextResponse.json({ success: true });
-  } catch (error) {
-    if (error instanceof SoldierStatusValidationError) {
-      return NextResponse.json(
-        { success: false, error: error.message },
-        { status: error.status }
-      );
-    }
-    const message = error instanceof Error ? error.message : String(error);
-    console.error('[API] soldier-status PUT failed:', message);
-    return NextResponse.json({ success: false, error: message }, { status: 500 });
   }
+
+  const rawBody = await request.text();
+
+  return withIdempotency(request, actor, rawBody, async () => {
+    try {
+      const body = (rawBody ? JSON.parse(rawBody) : {}) as PutBody;
+      if (typeof body.status !== 'string') {
+        return NextResponse.json(
+          { success: false, error: 'status is required' },
+          { status: 400 }
+        );
+      }
+
+      await serverUpdateSoldierStatus(
+        id,
+        {
+          status: body.status as SoldierStatus,
+          ...(typeof body.customStatus === 'string' ? { customStatus: body.customStatus } : {}),
+        },
+        { uid: actor.uid, displayName: actor.displayName },
+      );
+
+      return NextResponse.json({ success: true });
+    } catch (error) {
+      if (error instanceof SoldierStatusValidationError) {
+        return NextResponse.json(
+          { success: false, error: error.message },
+          { status: error.status }
+        );
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      console.error('[API] soldier-status PUT failed:', message);
+      return NextResponse.json({ success: false, error: message }, { status: 500 });
+    }
+  });
 }

--- a/src/app/api/transfer-requests/route.ts
+++ b/src/app/api/transfer-requests/route.ts
@@ -1,30 +1,35 @@
 import { NextResponse } from 'next/server';
 import { serverCreateTransferRequest } from '@/lib/db/server/transferRequestService';
 import { getActorOrError } from '@/lib/db/server/auth';
+import { withIdempotency } from '@/lib/db/server/idempotency';
 
 export async function POST(request: Request) {
-  try {
-    const actorOrError = await getActorOrError(request);
-    if (actorOrError instanceof NextResponse) return actorOrError;
-    const actor = actorOrError;
-    const input = await request.json();
-    if (!input.equipmentDocId || !input.toUserId) {
-      return NextResponse.json(
-        { success: false, error: 'equipmentDocId and toUserId are required' },
-        { status: 400 }
-      );
+  const actorOrError = await getActorOrError(request);
+  if (actorOrError instanceof NextResponse) return actorOrError;
+  const actor = actorOrError;
+  const rawBody = await request.text();
+
+  return withIdempotency(request, actor, rawBody, async () => {
+    try {
+      const input = rawBody ? JSON.parse(rawBody) : {};
+      if (!input.equipmentDocId || !input.toUserId) {
+        return NextResponse.json(
+          { success: false, error: 'equipmentDocId and toUserId are required' },
+          { status: 400 }
+        );
+      }
+      if (input.fromUserId && input.fromUserId !== actor.uid) {
+        return NextResponse.json(
+          { success: false, error: 'fromUserId must match the authenticated user' },
+          { status: 403 }
+        );
+      }
+      const id = await serverCreateTransferRequest({ ...input, fromUserId: actor.uid });
+      return NextResponse.json({ success: true, id });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error('[API] transfer-requests POST failed:', message);
+      return NextResponse.json({ success: false, error: message }, { status: 500 });
     }
-    if (input.fromUserId && input.fromUserId !== actor.uid) {
-      return NextResponse.json(
-        { success: false, error: 'fromUserId must match the authenticated user' },
-        { status: 403 }
-      );
-    }
-    const id = await serverCreateTransferRequest({ ...input, fromUserId: actor.uid });
-    return NextResponse.json({ success: true, id });
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    console.error('[API] transfer-requests POST failed:', message);
-    return NextResponse.json({ success: false, error: message }, { status: 500 });
-  }
+  });
 }

--- a/src/app/api/users/profile/route.ts
+++ b/src/app/api/users/profile/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from 'next/server';
 import { serverUpdateUserProfile, InvalidProfileUpdateError } from '@/lib/db/server/userService';
 import { getActorOrError } from '@/lib/db/server/auth';
+import { withIdempotency } from '@/lib/db/server/idempotency';
+import type { ApiActor } from '@/lib/db/server/policyHelpers';
 import { getAdminDb } from '@/lib/db/admin';
 import { COLLECTIONS } from '@/lib/db/collections';
 import { UserType } from '@/types/user';
@@ -19,11 +21,17 @@ import { serverUpsertPhoneBookFromUser } from '@/lib/db/server/phoneBookService'
  * `project_settings_page.md` Council synthesis for the threat model.
  */
 export async function PATCH(request: Request) {
+  const actorOrError = await getActorOrError(request);
+  if (actorOrError instanceof NextResponse) return actorOrError;
+  const actor = actorOrError;
+  const rawBody = await request.text();
+
+  return withIdempotency(request, actor, rawBody, () => handlePatch(actor, rawBody));
+}
+
+async function handlePatch(actor: ApiActor, rawBody: string): Promise<NextResponse> {
   try {
-    const actorOrError = await getActorOrError(request);
-    if (actorOrError instanceof NextResponse) return actorOrError;
-    const actor = actorOrError;
-    const body = await request.json();
+    const body = rawBody ? JSON.parse(rawBody) : {};
     if (!body?.uid || typeof body.uid !== 'string') {
       return NextResponse.json({ success: false, error: 'uid is required' }, { status: 400 });
     }

--- a/src/lib/apiFetch.ts
+++ b/src/lib/apiFetch.ts
@@ -1,11 +1,27 @@
 import { auth } from './firebase';
 
+const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+
+function generateIdempotencyKey(): string {
+  // crypto.randomUUID is available in Node 19+ and all modern browsers.
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID();
+  }
+  // Fallback for older runtimes.
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
 /**
  * Authenticated fetch wrapper. Attaches the current user's Firebase ID token
  * as `Authorization: Bearer <token>`. Use for every call to a protected
  * `/api/...` route. Public auth routes (`/api/auth/register`,
  * `/api/auth/verify-military-id`, `/api/auth/check-email-verified`) use plain
  * `fetch` instead.
+ *
+ * Mutating methods (POST/PUT/PATCH/DELETE) automatically receive an
+ * `Idempotency-Key` header (UUID v4) so server-side `withIdempotency` can
+ * dedupe replays. Callers can override by setting the header themselves
+ * (e.g. the outbox replay loop reuses the original key on retry).
  *
  * Throws `Error('Not authenticated')` if there is no signed-in user.
  */
@@ -22,6 +38,10 @@ export async function apiFetch(
   headers.set('Authorization', `Bearer ${idToken}`);
   if (init.body && !headers.has('Content-Type')) {
     headers.set('Content-Type', 'application/json');
+  }
+  const method = (init.method ?? 'GET').toUpperCase();
+  if (MUTATING_METHODS.has(method) && !headers.has('Idempotency-Key')) {
+    headers.set('Idempotency-Key', generateIdempotencyKey());
   }
   return fetch(input, { ...init, headers });
 }

--- a/src/lib/db/collections.ts
+++ b/src/lib/db/collections.ts
@@ -36,6 +36,7 @@ export const COLLECTIONS = {
   PHONE_CHANGE_RATE_LIMIT: 'phoneChangeRateLimit',
   LOGISTICS_TEMPLATES: 'logisticsTemplates',
   LOGISTICS_ITEMS: 'logisticsItems',
+  IDEMPOTENCY: '_idempotency',
 } as const;
 
 export type CollectionName = typeof COLLECTIONS[keyof typeof COLLECTIONS];

--- a/src/lib/db/server/idempotency.ts
+++ b/src/lib/db/server/idempotency.ts
@@ -1,0 +1,225 @@
+/**
+ * Server-side idempotency helper. Wraps a mutation handler so duplicate
+ * requests with the same `Idempotency-Key` header produce one effect.
+ *
+ * Lock-then-work pattern (M1 simplified):
+ *   1. tx.create(_idempotency/{uid}_{key}, { requestHash, status:'pending', createdAt, expiresAt })
+ *      → only one caller wins.
+ *   2. Run the inner handler.
+ *   3. Patch the record { status:'committed', snapshot }.
+ *
+ * ALREADY_EXISTS path:
+ *   - Read the record.
+ *   - If fingerprint differs → 422 IDEMPOTENCY_KEY_REUSED (M2).
+ *   - If status:'committed' → return cached response (S1 snapshot policy).
+ *   - If status:'pending' and not expired → short poll loop; otherwise steal.
+ *
+ * The exact atomic-with-data-write variant from the audit (M1) requires
+ * threading a Transaction through every service. We ship the lock-based
+ * version now — it has the same external guarantee (no double-write under
+ * concurrent replay) with a tiny window where a crashed caller leaves a
+ * `pending` record. Stale-pending stealing closes that window.
+ *
+ * Reference: docs/spec/offline-first.md Phase 4.
+ */
+
+import { createHash } from 'crypto';
+import { NextResponse } from 'next/server';
+import { FieldValue, Timestamp } from 'firebase-admin/firestore';
+import { getAdminDb } from '../admin';
+import { COLLECTIONS } from '../collections';
+import type { ApiActor } from './policyHelpers';
+
+const TTL_HOURS = 24;
+const PENDING_TIMEOUT_MS = 30_000;
+const PENDING_POLL_INTERVAL_MS = 200;
+const PENDING_POLL_ATTEMPTS = 25;
+
+export type IdempotencySnapshot = {
+  status: number;
+  code?: string;
+  resourceId?: string;
+  createdIds?: string[];
+  newUpdatedAt?: string;
+  bodyHint: 'inline' | 'refetch';
+  inlineBody?: unknown;
+};
+
+type StoredRecord = {
+  requestHash: string;
+  status: 'pending' | 'committed';
+  createdAt: Timestamp;
+  expiresAt: Timestamp;
+  snapshot?: IdempotencySnapshot;
+};
+
+const SNAPSHOT_BYTE_CAP = 64 * 1024;
+
+function sha256Hex(buf: string | Buffer): string {
+  return createHash('sha256').update(buf).digest('hex');
+}
+
+export function fingerprintRequest(method: string, path: string, body: string): string {
+  return sha256Hex(`${method.toUpperCase()}|${path}|${sha256Hex(body)}`);
+}
+
+function nowPlusHoursTimestamp(hours: number): Timestamp {
+  return Timestamp.fromMillis(Date.now() + hours * 3600 * 1000);
+}
+
+function snapshotToResponse(snapshot: IdempotencySnapshot): NextResponse {
+  if (snapshot.bodyHint === 'inline' && snapshot.inlineBody !== undefined) {
+    return NextResponse.json(snapshot.inlineBody, { status: snapshot.status });
+  }
+  // bodyHint:'refetch' — caller should refetch the resource. We still
+  // return success so the client outbox dequeues this entry; the client
+  // will pull fresh data on the next read path.
+  return NextResponse.json(
+    {
+      success: snapshot.status >= 200 && snapshot.status < 300,
+      idempotencyReplay: true,
+      resourceId: snapshot.resourceId,
+      newUpdatedAt: snapshot.newUpdatedAt,
+    },
+    { status: snapshot.status },
+  );
+}
+
+function truncateSnapshot(snapshot: IdempotencySnapshot): IdempotencySnapshot {
+  if (snapshot.bodyHint !== 'inline' || snapshot.inlineBody === undefined) {
+    return snapshot;
+  }
+  const serialized = JSON.stringify(snapshot.inlineBody);
+  if (Buffer.byteLength(serialized, 'utf8') <= SNAPSHOT_BYTE_CAP) return snapshot;
+  return { ...snapshot, bodyHint: 'refetch', inlineBody: undefined };
+}
+
+async function sleep(ms: number) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+type WithIdempotencyOptions = {
+  /**
+   * Build the response snapshot from a successful handler result. Default
+   * stores `{ status: 200, bodyHint: 'refetch' }` — i.e., on duplicate
+   * replay the client gets a success ack and refetches.
+   */
+  toSnapshot?: (result: NextResponse) => Promise<IdempotencySnapshot> | IdempotencySnapshot;
+};
+
+const DEFAULT_SNAPSHOT: IdempotencySnapshot = { status: 200, bodyHint: 'refetch' };
+
+/**
+ * Wrap a mutation route handler with idempotency dedupe.
+ *
+ * Usage in a route:
+ *
+ *   export async function POST(request: Request) {
+ *     const actorOrError = await getActorOrError(request);
+ *     if (actorOrError instanceof NextResponse) return actorOrError;
+ *     const actor = actorOrError;
+ *     const body = await request.text();
+ *     return withIdempotency(request, actor, body, async () => {
+ *       // do the work, return NextResponse
+ *     });
+ *   }
+ *
+ * If the request has no `Idempotency-Key` header, the wrapper skips the
+ * dedupe path entirely — handler runs as before. Server-internal callers
+ * (cron, admin scripts) do not need keys.
+ */
+export async function withIdempotency(
+  request: Request,
+  actor: ApiActor,
+  rawBody: string,
+  handler: () => Promise<NextResponse>,
+  options: WithIdempotencyOptions = {},
+): Promise<NextResponse> {
+  const key = request.headers.get('idempotency-key') ?? request.headers.get('Idempotency-Key');
+  if (!key) return handler();
+
+  if (key.length < 8 || key.length > 200) {
+    return NextResponse.json(
+      { success: false, error: 'Invalid Idempotency-Key length' },
+      { status: 400 },
+    );
+  }
+
+  const url = new URL(request.url);
+  const requestHash = fingerprintRequest(request.method, url.pathname, rawBody);
+
+  const docId = `${actor.uid}_${key}`;
+  const ref = getAdminDb().collection(COLLECTIONS.IDEMPOTENCY).doc(docId);
+
+  // Step 1: try to claim the lock.
+  let acquired = false;
+  try {
+    await ref.create({
+      requestHash,
+      status: 'pending',
+      createdAt: FieldValue.serverTimestamp(),
+      expiresAt: nowPlusHoursTimestamp(TTL_HOURS),
+    } satisfies Omit<StoredRecord, 'createdAt' | 'expiresAt'> & {
+      createdAt: FirebaseFirestore.FieldValue;
+      expiresAt: Timestamp;
+    });
+    acquired = true;
+  } catch (e: unknown) {
+    const code = (e as { code?: number | string })?.code;
+    if (code !== 6 && code !== 'already-exists') throw e;
+  }
+
+  if (acquired) {
+    try {
+      const response = await handler();
+      const snapshot = truncateSnapshot(
+        (await options.toSnapshot?.(response)) ?? DEFAULT_SNAPSHOT,
+      );
+      await ref.update({
+        status: 'committed',
+        snapshot,
+      });
+      return response;
+    } catch (err) {
+      // Handler failed — clear the lock so a retry can re-enter cleanly.
+      await ref.delete().catch(() => {});
+      throw err;
+    }
+  }
+
+  // Did not acquire — record already exists. Inspect.
+  for (let attempt = 0; attempt < PENDING_POLL_ATTEMPTS; attempt++) {
+    const snap = await ref.get();
+    if (!snap.exists) {
+      // Lock was deleted (handler failed). Reattempt by recursing once.
+      return withIdempotency(request, actor, rawBody, handler, options);
+    }
+    const data = snap.data() as StoredRecord;
+    if (data.requestHash !== requestHash) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: 'Idempotency key reused with a different payload',
+          code: 'IDEMPOTENCY_KEY_REUSED',
+        },
+        { status: 422 },
+      );
+    }
+    if (data.status === 'committed' && data.snapshot) {
+      return snapshotToResponse(data.snapshot);
+    }
+    // Pending — check if stale.
+    const createdMs = data.createdAt.toMillis();
+    if (Date.now() - createdMs > PENDING_TIMEOUT_MS) {
+      // Steal: delete and reattempt.
+      await ref.delete().catch(() => {});
+      return withIdempotency(request, actor, rawBody, handler, options);
+    }
+    await sleep(PENDING_POLL_INTERVAL_MS);
+  }
+
+  return NextResponse.json(
+    { success: false, error: 'Idempotency check timed out' },
+    { status: 504 },
+  );
+}

--- a/vercel.json
+++ b/vercel.json
@@ -8,6 +8,10 @@
     {
       "path": "/api/cron/purge-credential-audit-log",
       "schedule": "30 3 * * *"
+    },
+    {
+      "path": "/api/cron/sweep-idempotency",
+      "schedule": "0 4 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Server-side dedupe for replayed mutations — prerequisite for Phase 5 (outbox/replay), gated behind the route-wrap follow-up in `docs/spec/idempotency-route-migration.md`.

### Helper (`src/lib/db/server/idempotency.ts`)
- `withIdempotency(request, actor, rawBody, handler, options?)` wraps any mutation route.
- Lock-then-work pattern via `ref.create({status:'pending'})` as the sync point.
- `ALREADY_EXISTS` → fingerprint check → 422 on mismatch (M2), cached snapshot on match (S1).
- 64 KB snapshot cap with auto-fallback to `bodyHint:'refetch'`.
- Stale-pending stealing (>30s) for crashed callers.
- 24h TTL on `expiresAt`.

### Wiring
- `src/lib/apiFetch.ts` — injects `Idempotency-Key` (UUID) on POST/PUT/PATCH/DELETE.
- `firebase/firestore.rules` — deny `_idempotency` to clients.
- `firebase/firestore.indexes.json` — composite `(expiresAt ASC)` + `fieldOverrides` TTL.
- `vercel.json` + `/api/cron/sweep-idempotency` — belt-and-braces daily sweep.
- `COLLECTIONS.IDEMPOTENCY` constant.

### Routes wrapped (7)
- `/api/equipment/{transfer,retire}`
- `/api/equipment/[id]/storage/{send,pull}`
- `/api/soldier-status/[id]`
- `/api/transfer-requests`
- `/api/users/profile`

Remaining 47 mutating routes listed in `docs/spec/idempotency-route-migration.md` — Phase 4b will wrap them. Phase 5 is gated on that list being fully ✅ or `SKIP`.

## ⚠️ Operator deploy steps (before merge)

1. `firebase deploy --only firestore:rules`
2. `firebase deploy --only firestore:indexes`
3. `gcloud firestore fields ttls update expiresAt --collection-group=_idempotency --project=sayeret-givati-1983`
4. Confirm `CRON_SECRET` is set in Vercel.

## Test plan
- [x] `npm run lint` — clean.
- [x] `npm test` — 701 pass / 36 skipped / 0 failing.
- [x] `npm run build` — OK.
- [x] `npm run bundle-budget` — `/_error` 93.56 KB under 110 KB cap.
- [ ] Post-deploy smoke: send the same write twice with the same `Idempotency-Key` header → second response is the cached snapshot, no duplicate side-effect.
- [ ] Post-deploy smoke: send two writes with the same key but different bodies → second returns 422 `IDEMPOTENCY_KEY_REUSED`.

Refs: `docs/spec/offline-first.md` Phase 4, `docs/codebase/idempotency.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)