### PR TITLE
feat(offline): ConflictCenter for 409 resolution (phase 6)

### DIFF
--- a/docs/codebase/src/components/conflicts/ConflictCenter.md
+++ b/docs/codebase/src/components/conflicts/ConflictCenter.md
@@ -1,0 +1,42 @@
+# ConflictCenter.tsx
+
+**File:** `src/components/conflicts/ConflictCenter.tsx`
+**Status:** Active (Phase 6)
+**Spec:** `docs/spec/offline-first.md` Phase 6 (audit note S4).
+
+## Purpose
+
+One-at-a-time conflict resolution UI for the offline outbox. When a queued
+mutation replays and the server returns 409, the entry transitions to
+`status:'conflict'` in IndexedDB. This component surfaces the head of the
+conflict queue and lets the user resolve it.
+
+## Why not one modal per conflict
+
+Audit S4: a user with 10 conflicting items must not see 10 stacked dialogs.
+The center renders only the head; resolving advances to the next; the badge
+keeps the live count visible the whole time. Conflicts persist in IDB across
+reloads (they're `OutboxEntry` rows), so closing the tab and reopening
+restores the same queue.
+
+## Resolution semantics
+
+- **Keep local** — rewrites `If-Match` to the latest server version pulled
+  from `conflictState.serverData.newUpdatedAt` (or `updatedAt`). Status
+  flips back to `pending` and a drain is triggered. The user's local edit
+  wins.
+- **Discard** — `removeById`. User accepts server state.
+
+Both actions are wired through `OutboxContext.resolveConflict`.
+
+## Mount
+
+Mounted by `SyncStatusIndicator` (the floating badge). Clicking the badge
+when `conflictCount > 0` opens this dialog. Layout-level mount unnecessary.
+
+## Future
+
+Phase 6b ideas (not in this PR):
+- Inline diff between local body and server data.
+- Per-conflict "open the related screen" deep link.
+- Merge resolution for routes that support it (e.g. set unions).

--- a/docs/spec/offline-first.md
+++ b/docs/spec/offline-first.md
@@ -176,6 +176,7 @@ As each phase ships, findings are reflected in:
 - ✅ **Phase 3** — Serwist PWA shell (PR #124).
 - ✅ **Phase 4a** — Idempotency infra + 7 representative routes (PR #125).
 - ✅ **Phase 4b** — Remaining 47 mutation routes wrapped (PR #126).
-- ✅ **Phase 5** — Outbox + replay shipped. IndexedDB store with `DB_VERSION=1` upgrade scaffold (M4). Replay loop: auth-await (M6), concurrency cap 3 (S3), per-batch token cache, chained `If-Match` rewrite (M3), page-thread fallback for iOS (M7). Deny-by-default allowlist (`equipment.transfer/retire/storage`, `soldier-status.update`). `OutboxContext` + `SyncStatusIndicator` mounted globally. Threat model at `docs/spec/offline-threat-model.md` (S10 locked: no app-layer encryption). **Not shipped here:** S9 hooks projection (deferred to P5b), Background Sync registration (deferred to P8).
-- ⬜ **Phase 6** — `ConflictCenter` aggregator + IDB-persistent conflicts.
-- ⬜ **Phase 7..8** — see table above.
+- ✅ **Phase 5** — Outbox + replay shipped (PR #127).
+- ✅ **Phase 6** — `ConflictCenter` aggregator (Headless UI Dialog). One-at-a-time resolution. Keep-local rewrites `If-Match` from server data and re-arms drain; Discard removes the entry. Conflicts persist in IDB across reloads (already part of P5 entry shape). `SyncStatusIndicator` opens the center when `conflictCount > 0`.
+- ⬜ **Phase 7** — SWR-style hooks. `localStorage` migration. Permission revocation cache invalidation.
+- ⬜ **Phase 8** — Telemetry SLOs + `/debug/offline` prod-build exclusion.

--- a/src/components/conflicts/ConflictCenter.tsx
+++ b/src/components/conflicts/ConflictCenter.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { Fragment } from 'react';
+import { Dialog, Transition } from '@headlessui/react';
+import { useOutbox } from '@/contexts/OutboxContext';
+import { TEXT_CONSTANTS } from '@/constants/text';
+
+interface ConflictCenterProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+/**
+ * One-at-a-time conflict resolution UX. Audit S4: do not surface ten modals
+ * when ten entries conflict. The dialog shows the head of the queue and the
+ * remaining count; resolving advances to the next.
+ *
+ * Conflicts persist in IndexedDB across reloads — they live as
+ * `OutboxEntry.status === 'conflict'` rows. Opening the dialog never
+ * mutates the store; only the explicit Keep/Discard buttons do.
+ */
+export default function ConflictCenter({ open, onClose }: ConflictCenterProps) {
+  const { entries, resolveConflict } = useOutbox();
+  const conflicts = entries.filter((e) => e.status === 'conflict');
+  const current = conflicts[0];
+
+  if (!current) {
+    if (open) onClose();
+    return null;
+  }
+
+  const handle = async (resolution: 'keep' | 'discard') => {
+    if (current.id === undefined) return;
+    await resolveConflict(current.id, resolution);
+    if (conflicts.length <= 1) onClose();
+  };
+
+  return (
+    <Transition show={open} as={Fragment}>
+      <Dialog onClose={onClose} className="relative z-[10001]">
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-150"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-100"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-black/50" aria-hidden="true" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 flex items-center justify-center p-4">
+          <Transition.Child
+            as={Fragment}
+            enter="ease-out duration-150"
+            enterFrom="opacity-0 scale-95"
+            enterTo="opacity-100 scale-100"
+            leave="ease-in duration-100"
+            leaveFrom="opacity-100 scale-100"
+            leaveTo="opacity-0 scale-95"
+          >
+            <Dialog.Panel className="bg-white rounded-2xl shadow-medium max-w-md w-full p-6">
+              <Dialog.Title className="text-lg font-semibold text-neutral-900">
+                {TEXT_CONSTANTS.PWA.CONFLICT_TITLE}
+              </Dialog.Title>
+              <Dialog.Description className="mt-2 text-sm text-neutral-600">
+                {TEXT_CONSTANTS.PWA.CONFLICT_BODY}
+              </Dialog.Description>
+
+              <div className="mt-4 rounded-lg bg-neutral-50 p-3 text-xs text-neutral-700 space-y-1">
+                <div>
+                  <span className="font-medium">
+                    {TEXT_CONSTANTS.PWA.CONFLICT_ROUTE_LABEL}:
+                  </span>{' '}
+                  <span className="font-mono">{current.routeName}</span>
+                </div>
+                <div className="font-mono text-neutral-500">
+                  {current.method} {current.url}
+                </div>
+                {current.lastError && (
+                  <div className="text-danger-600 font-mono">{current.lastError}</div>
+                )}
+                {conflicts.length > 1 && (
+                  <div className="text-neutral-500">
+                    {conflicts.length - 1} {TEXT_CONSTANTS.PWA.CONFLICT_QUEUE_COUNT}
+                  </div>
+                )}
+              </div>
+
+              <div className="mt-6 flex justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={() => { void handle('discard'); }}
+                  className="btn-ghost text-sm"
+                >
+                  {TEXT_CONSTANTS.PWA.CONFLICT_DISCARD}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => { void handle('keep'); }}
+                  className="btn-primary text-sm"
+                >
+                  {TEXT_CONSTANTS.PWA.CONFLICT_KEEP_LOCAL}
+                </button>
+              </div>
+            </Dialog.Panel>
+          </Transition.Child>
+        </div>
+      </Dialog>
+    </Transition>
+  );
+}

--- a/src/components/pwa/SyncStatusIndicator.tsx
+++ b/src/components/pwa/SyncStatusIndicator.tsx
@@ -1,21 +1,24 @@
 'use client';
 
+import { useState } from 'react';
 import { useOutbox } from '@/contexts/OutboxContext';
+import ConflictCenter from '@/components/conflicts/ConflictCenter';
 
 /**
  * Compact pending-queue indicator. Renders nothing when the queue is empty.
  *
- * Surfaces three counts:
- *  - pending (offline-queued or actively replaying)
- *  - conflicts (P6 surfaces them via ConflictCenter; here we just show a number)
- *  - stuck/poisoned (manual inspection required)
+ * Click behavior:
+ *  - If there are conflicts, opens the `ConflictCenter` dialog.
+ *  - Otherwise triggers a manual drain (useful when a stuck retry is queued).
  *
  * Phase 8 will replace this with a dedicated Settings → Offline diagnostics
- * page; for now it's a passive badge. Clicking it triggers a manual drain.
+ * page. For now it's a passive badge.
  */
 export default function SyncStatusIndicator() {
   const { pendingCount, conflictCount, stuckCount, drain } = useOutbox();
+  const [conflictsOpen, setConflictsOpen] = useState(false);
   const total = pendingCount + conflictCount + stuckCount;
+
   if (total === 0) return null;
 
   const tone =
@@ -23,19 +26,30 @@ export default function SyncStatusIndicator() {
       ? 'bg-warning-500 text-neutral-900'
       : 'bg-neutral-900 text-white';
 
+  const onClick = () => {
+    if (conflictCount > 0) {
+      setConflictsOpen(true);
+      return;
+    }
+    void drain();
+  };
+
   return (
-    <button
-      type="button"
-      onClick={() => { void drain(); }}
-      className={`fixed bottom-6 end-6 z-[9990] rounded-full shadow-medium px-3 py-1.5 text-xs font-medium ${tone}`}
-      aria-label={`Offline queue: ${total} items`}
-      title={
-        `pending: ${pendingCount}` +
-        (conflictCount ? `, conflicts: ${conflictCount}` : '') +
-        (stuckCount ? `, stuck: ${stuckCount}` : '')
-      }
-    >
-      ⇅ {total}
-    </button>
+    <>
+      <button
+        type="button"
+        onClick={onClick}
+        className={`fixed bottom-6 end-6 z-[9990] rounded-full shadow-medium px-3 py-1.5 text-xs font-medium ${tone}`}
+        aria-label={`Offline queue: ${total} items`}
+        title={
+          `pending: ${pendingCount}` +
+          (conflictCount ? `, conflicts: ${conflictCount}` : '') +
+          (stuckCount ? `, stuck: ${stuckCount}` : '')
+        }
+      >
+        ⇅ {total}
+      </button>
+      <ConflictCenter open={conflictsOpen} onClose={() => setConflictsOpen(false)} />
+    </>
   );
 }

--- a/src/constants/text.en.ts
+++ b/src/constants/text.en.ts
@@ -190,6 +190,12 @@ export const TEXT_EN = {
     UPDATE_AVAILABLE_BODY: 'An update is ready. The page will reload.',
     UPDATE_NOW: 'Update now',
     UPDATE_LATER: 'Later',
+    CONFLICT_TITLE: 'Sync conflict',
+    CONFLICT_BODY: 'The action tried to update an item that changed on the server after you went offline.',
+    CONFLICT_KEEP_LOCAL: 'Force overwrite',
+    CONFLICT_DISCARD: 'Discard action',
+    CONFLICT_QUEUE_COUNT: 'remaining',
+    CONFLICT_ROUTE_LABEL: 'Action',
   },
   PROFILE: {
     PHONE_NUMBER_LABEL: 'Phone number',

--- a/src/constants/text.ts
+++ b/src/constants/text.ts
@@ -2127,7 +2127,13 @@ export const TEXT_CONSTANTS = {
     UPDATE_AVAILABLE_TITLE: 'גרסה חדשה זמינה',
     UPDATE_AVAILABLE_BODY: 'עדכון מוכן להתקנה. המסך ייטען מחדש.',
     UPDATE_NOW: 'עדכן עכשיו',
-    UPDATE_LATER: 'אחר כך'
+    UPDATE_LATER: 'אחר כך',
+    CONFLICT_TITLE: 'התנגשות בעדכון',
+    CONFLICT_BODY: 'הפעולה ניסתה לעדכן פריט שהשתנה בשרת מאז שעבדת במצב לא־מקוון.',
+    CONFLICT_KEEP_LOCAL: 'דרוס את השרת',
+    CONFLICT_DISCARD: 'בטל את הפעולה',
+    CONFLICT_QUEUE_COUNT: 'נותרו',
+    CONFLICT_ROUTE_LABEL: 'פעולה'
   }
 } as const;
 

--- a/src/contexts/OutboxContext.tsx
+++ b/src/contexts/OutboxContext.tsx
@@ -12,10 +12,14 @@ import { auth } from '@/lib/firebase';
 import { onAuthStateChanged } from 'firebase/auth';
 import {
   listForUid,
+  removeById,
   subscribe as subscribeOutbox,
+  updateById,
   type OutboxEntry,
 } from '@/lib/offline/outbox';
 import { drainOutbox, installAutoDrain } from '@/lib/offline/replay';
+
+export type ConflictResolution = 'keep' | 'discard';
 
 interface OutboxContextValue {
   entries: OutboxEntry[];
@@ -24,6 +28,14 @@ interface OutboxContextValue {
   stuckCount: number;
   /** Manually trigger a drain pass — useful for "retry now" buttons. */
   drain: () => Promise<void>;
+  /**
+   * Resolve a queued conflict.
+   *  - `keep`: rewrite `If-Match` to the latest server version (from
+   *    conflictState.serverData) and set status back to pending so the
+   *    replay loop sends it again on the next tick.
+   *  - `discard`: remove the entry; user accepts the server state.
+   */
+  resolveConflict: (id: number, resolution: ConflictResolution) => Promise<void>;
 }
 
 const OutboxContext = createContext<OutboxContextValue | undefined>(undefined);
@@ -74,6 +86,29 @@ export function OutboxProvider({ children }: { children: ReactNode }) {
       conflictCount,
       stuckCount,
       drain: async () => { await drainOutbox(); },
+      resolveConflict: async (id, resolution) => {
+        if (resolution === 'discard') {
+          await removeById(id);
+          return;
+        }
+        // keep — reset to pending; if the server's 409 body carried an
+        // updatedAt-like field, lift it into If-Match so the next send
+        // wins.
+        const target = entries.find((e) => e.id === id);
+        const headers = { ...(target?.headers ?? {}) };
+        const sd = (target?.conflictState?.serverData ?? null) as
+          | { newUpdatedAt?: string; updatedAt?: string }
+          | null;
+        const newIfMatch = sd?.newUpdatedAt ?? sd?.updatedAt;
+        if (newIfMatch) headers['If-Match'] = newIfMatch;
+        await updateById(id, {
+          status: 'pending',
+          headers,
+          conflictState: undefined,
+          nextAttemptAt: Date.now(),
+        });
+        void drainOutbox();
+      },
     };
   }, [entries]);
 
@@ -84,7 +119,14 @@ export function useOutbox(): OutboxContextValue {
   const ctx = useContext(OutboxContext);
   if (!ctx) {
     // Return a safe empty value when used outside the provider (e.g. SSR before mount).
-    return { entries: [], pendingCount: 0, conflictCount: 0, stuckCount: 0, drain: async () => {} };
+    return {
+      entries: [],
+      pendingCount: 0,
+      conflictCount: 0,
+      stuckCount: 0,
+      drain: async () => {},
+      resolveConflict: async () => {},
+    };
   }
   return ctx;
 }


### PR DESCRIPTION
## Summary
Audit S4: aggregate queued 409 conflicts into one Headless UI dialog rather than stacking modals.

- `src/components/conflicts/ConflictCenter.tsx` — head-of-queue resolver. Keep-local / Discard buttons.
- `src/contexts/OutboxContext.tsx` — `resolveConflict(id, 'keep'|'discard')`. Keep rewrites `If-Match` from server data and re-drains; Discard removes the entry.
- `SyncStatusIndicator` opens the center when `conflictCount > 0` (vs. drain otherwise).
- bilingual `PWA.CONFLICT_*` strings (he+en).

Conflicts persist across reloads automatically — they're already IDB rows with `status:'conflict'` since P5.

## Test plan
- [x] Lint clean.
- [x] 701 tests pass.
- [ ] Manual: force two offline edits to the same item with stale `If-Match` → both conflict on replay → dialog opens, shows head + "1 remaining" → Keep-local resolves both with server's latest `updatedAt`.

Refs: `docs/spec/offline-first.md` Phase 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)