### PR TITLE
feat(offline): pendingResourceKeys + usePendingSync (phase 5b / S9 partial)

### DIFF
--- a/docs/codebase/outbox.md
+++ b/docs/codebase/outbox.md
@@ -111,12 +111,16 @@ Cap is `OFFLINE_REPLAY_CONCURRENCY` (default 3). One bearer token is fetched
 per drain pass and reused across the batch. 429 from server triggers backoff
 on the **batch**, not just the failing item.
 
-## What's NOT shipped in P5
+## Phase 5b — partial S9 (shipped)
 
-- **S9 — hooks projection from `(server, outbox)`.** Hooks like
-  `useEquipment` still read server data only. Optimistic overlay lives in
-  the next iteration; current outbox surfaces queue depth but doesn't blend
-  pending mutations into list rendering. Phase 5b follow-up.
+`OutboxContext.pendingResourceKeys: Set<string>` exposes resource keys with
+uncommitted entries (status pending / replaying / awaiting_auth / conflict).
+`src/hooks/usePendingSync.ts` is the narrow selector. List components query
+it and flag rows as "syncing" without local optimistic state.
+
+Full projection of pending mutations onto server data (e.g. showing the
+post-transfer holder before the server confirms) is deferred to Phase 5c
+once a projection helper proves out across more than one domain.
 - **P6 — `ConflictCenter`.** 409s land in `conflictState` and bump the
   badge, but a per-conflict modal / aggregator UI is its own phase.
 - **Background Sync registration.** Page-thread drain is the only path.

--- a/docs/codebase/src/hooks/usePendingSync.md
+++ b/docs/codebase/src/hooks/usePendingSync.md
@@ -1,0 +1,51 @@
+# usePendingSync.ts
+
+**File:** `src/hooks/usePendingSync.ts`
+**Status:** Active (Phase 5b — audit S9 partial)
+**Spec:** `docs/spec/offline-first.md` Phase 5b.
+
+## Purpose
+
+Selector over `OutboxContext.pendingResourceKeys`. Lets list components
+flag rows as "syncing" without each maintaining local optimistic state.
+
+## Signature
+
+```ts
+usePendingSync(keys?: readonly string[]): (key: string) => boolean
+```
+
+- Pass the resource keys you render (e.g. `equipment:EQ-1234`).
+- Returns a lookup function. `true` means an uncommitted outbox entry
+  exists for that key.
+
+No-arg form: returns a function that accepts any key (less efficient — full
+context Set lookup per call).
+
+## Resource key convention
+
+`<domain>:<id>`. Same shape `src/lib/offline/allowlist.ts` uses when it
+builds `resourceKey` for queued entries. Examples:
+
+- `equipment:${equipmentId}`
+- `soldierStatus:${militaryPersonalNumberHash}`
+
+If `allowlist.ts` doesn't set a `resourceKey` for a route, queued entries
+for that route are not surfaced by this hook (intentional — those routes
+don't have a single resource to mark).
+
+## When to use
+
+- Equipment list, status board, ammunition rosters — anything that
+  renders rows of resources that can be mutated offline.
+
+## When NOT to use
+
+- Single-resource detail pages — they can read `entries` directly from
+  `useOutbox()` and project the pending mutation onto the displayed state.
+  Phase 5c (not shipped) will add a higher-level projection helper.
+
+## Related
+
+- `src/contexts/OutboxContext.tsx` — source of truth.
+- `src/lib/offline/allowlist.ts` — where resource keys are minted.

--- a/src/contexts/OutboxContext.tsx
+++ b/src/contexts/OutboxContext.tsx
@@ -26,6 +26,15 @@ interface OutboxContextValue {
   pendingCount: number;
   conflictCount: number;
   stuckCount: number;
+  /**
+   * Set of resource keys currently in-flight or queued. Audit S9: lets
+   * list components flag rows as "syncing" without each maintaining local
+   * optimistic state. Entry shape: `<domain>:<id>` (e.g.
+   * `equipment:EQ-1234`). Built from entries whose status is pending,
+   * replaying, awaiting_auth, or conflict (anything not yet committed
+   * server-side).
+   */
+  pendingResourceKeys: Set<string>;
   /** Manually trigger a drain pass — useful for "retry now" buttons. */
   drain: () => Promise<void>;
   /**
@@ -37,6 +46,13 @@ interface OutboxContextValue {
    */
   resolveConflict: (id: number, resolution: ConflictResolution) => Promise<void>;
 }
+
+const UNCOMMITTED_STATUSES = new Set<OutboxEntry['status']>([
+  'pending',
+  'replaying',
+  'awaiting_auth',
+  'conflict',
+]);
 
 const OutboxContext = createContext<OutboxContextValue | undefined>(undefined);
 
@@ -80,11 +96,18 @@ export function OutboxProvider({ children }: { children: ReactNode }) {
     const pendingCount = entries.filter((e) => e.status === 'pending' || e.status === 'awaiting_auth' || e.status === 'replaying').length;
     const conflictCount = entries.filter((e) => e.status === 'conflict').length;
     const stuckCount = entries.filter((e) => e.status === 'stuck' || e.status === 'poisoned').length;
+    const pendingResourceKeys = new Set<string>();
+    for (const e of entries) {
+      if (e.resourceKey && UNCOMMITTED_STATUSES.has(e.status)) {
+        pendingResourceKeys.add(e.resourceKey);
+      }
+    }
     return {
       entries,
       pendingCount,
       conflictCount,
       stuckCount,
+      pendingResourceKeys,
       drain: async () => { await drainOutbox(); },
       resolveConflict: async (id, resolution) => {
         if (resolution === 'discard') {
@@ -124,6 +147,7 @@ export function useOutbox(): OutboxContextValue {
       pendingCount: 0,
       conflictCount: 0,
       stuckCount: 0,
+      pendingResourceKeys: new Set<string>(),
       drain: async () => {},
       resolveConflict: async () => {},
     };

--- a/src/hooks/usePendingSync.ts
+++ b/src/hooks/usePendingSync.ts
@@ -1,0 +1,40 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useOutbox } from '@/contexts/OutboxContext';
+
+/**
+ * Narrow selector over `OutboxContext.pendingResourceKeys`. Returns whether
+ * each provided resource key has an uncommitted outbox entry.
+ *
+ * Pattern (audit S9): list components own server data and don't want to
+ * track local optimistic state per row. They pass the resource keys they
+ * render through this hook and get back a `(key) => boolean` lookup.
+ *
+ * Example:
+ * ```ts
+ * const isPending = usePendingSync(equipment.map((e) => `equipment:${e.id}`));
+ * // ...
+ * {equipment.map((row) => (
+ *   <li>{row.name} {isPending(`equipment:${row.id}`) && <SyncingBadge />}</li>
+ * ))}
+ * ```
+ *
+ * No-arg form returns a function that accepts any key — useful when the
+ * caller can't enumerate keys up front.
+ */
+export function usePendingSync(keys?: readonly string[]): (key: string) => boolean {
+  const { pendingResourceKeys } = useOutbox();
+  return useMemo(() => {
+    if (keys && keys.length > 0) {
+      // Materialize a filtered Set so consumers don't pay the full-context
+      // re-render on unrelated entries (resourceKeys for other domains).
+      const filtered = new Set<string>();
+      for (const k of keys) {
+        if (pendingResourceKeys.has(k)) filtered.add(k);
+      }
+      return (key: string) => filtered.has(key);
+    }
+    return (key: string) => pendingResourceKeys.has(key);
+  }, [keys, pendingResourceKeys]);
+}


### PR DESCRIPTION
## Summary

Audit S9 partial — list components can now flag rows as syncing without each tracking local optimistic state.

- `OutboxContext.pendingResourceKeys: Set<string>` — derived from entries with status pending / replaying / awaiting_auth / conflict.
- `src/hooks/usePendingSync.ts` — narrow selector. Pass the resource keys you render; get back a `(key) => boolean` lookup.

## Usage

```tsx
const isPending = usePendingSync(equipment.map((e) => \`equipment:\${e.id}\`));

equipment.map((row) => (
  <li>
    {row.name}
    {isPending(\`equipment:\${row.id}\`) && <SyncingBadge />}
  </li>
));
```

## Deferred

Full mutation projection (e.g. show post-transfer holder before server confirms) is Phase 5c. Will land when one projection helper has proved out across more than one domain.

## Test plan
- [x] Lint clean.
- [x] 701 tests pass.

Refs: `docs/spec/offline-first.md`, `docs/codebase/outbox.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)