### PR TITLE
fix(offline): drop single-field _idempotency composite index

### DIFF
--- a/docs/codebase/idempotency.md
+++ b/docs/codebase/idempotency.md
@@ -88,18 +88,37 @@ how dedupe stays consistent across reconnect cycles.
 
 ## Index
 
-- `(expiresAt ASC)` on `_idempotency` for the cron sweeper.
-  See `firebase/firestore.indexes.json`.
+Firestore auto-creates the single-field ascending index for `expiresAt`
+once the `fieldOverrides[].ttl` entry is deployed. No manual composite
+index needed — single-field indexes are rejected by the composite API
+("this index is not necessary, configure using single field index
+controls"). See `firebase/firestore.indexes.json` `fieldOverrides`.
 
 ## Deployment checklist (Phase 4)
 
-Before this PR merges:
-1. `firebase deploy --only firestore:rules` — pushes the deny rule.
-2. `firebase deploy --only firestore:indexes` — pushes the new composite + TTL.
-3. Verify TTL is enabled:
-   `gcloud firestore fields ttls update expiresAt --collection-group=_idempotency --project=sayeret-givati-1983`
-   (or toggle in Firebase Console → Firestore → Indexes → TTL).
-4. `CRON_SECRET` must be set in Vercel; same value already used by the other crons.
+Before users hit the new routes:
+
+```bash
+firebase deploy --only firestore:rules
+firebase deploy --only firestore:indexes
+```
+
+`firebase deploy --only firestore:indexes` reads `fieldOverrides` and
+enables TTL on `_idempotency.expiresAt`. If for some reason that path
+fails, fall back to the gcloud command:
+
+```bash
+gcloud firestore fields ttls update expiresAt \
+  --collection-group=_idempotency \
+  --enable-ttl \
+  --project=sayeret-givati-1983
+```
+
+(`--enable-ttl` is required — gcloud needs exactly one of
+`--enable-ttl` / `--disable-ttl`.)
+
+Confirm `CRON_SECRET` is set in Vercel; same value already used by the
+other crons.
 
 ## Migration tracking
 

--- a/firebase/firestore.indexes.json
+++ b/firebase/firestore.indexes.json
@@ -159,16 +159,6 @@
           "order": "DESCENDING"
         }
       ]
-    },
-    {
-      "collectionGroup": "_idempotency",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "expiresAt",
-          "order": "ASCENDING"
-        }
-      ]
     }
   ],
   "fieldOverrides": [


### PR DESCRIPTION
## Issue

`firebase deploy --only firestore:indexes` failed:

> Error: this index is not necessary, configure using single field index controls

The composite index entry for `_idempotency (expiresAt ASC)` is a single-field index — Firestore rejects those via the composite API. They must come from `fieldOverrides` (or Firestore's automatic single-field indexing).

The `fieldOverrides[].ttl:true` entry already triggers Firestore to auto-create the ascending index for `expiresAt`, so the composite entry was both redundant and blocking the deploy.

## Fix
- Remove the redundant composite index entry.
- `fieldOverrides` keeps TTL enablement.
- Doc updated: `gcloud firestore fields ttls update` needs `--enable-ttl` explicitly. Marked as fallback path; `firebase deploy --only firestore:indexes` now does both index + TTL.

## Operator next steps
After merge:
```bash
firebase deploy --only firestore:indexes
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)