### PR TITLE
perf(equipment): useEquipment → onSnapshot listeners (drop refetch-per-mutation)

### DIFF
--- a/src/hooks/useEquipment.ts
+++ b/src/hooks/useEquipment.ts
@@ -83,6 +83,8 @@ export function useEquipment(options: UseEquipmentOptions = {}): UseEquipmentRet
     };
   }, [enhancedUser]);
 
+  // Force-resync escape hatch. The listener keeps state current; this exists for
+  // edge cases (e.g. after a forced auth refresh) where callers want to re-prime.
   const refreshEquipment = useCallback(async () => {
     setLoading(true);
     setError(null);
@@ -92,12 +94,10 @@ export function useEquipment(options: UseEquipmentOptions = {}): UseEquipmentRet
         setRawEquipment(result.equipments);
       } else {
         setError(result.error || TEXT_CONSTANTS.FEATURES.EQUIPMENT.ERROR_LOADING);
-        setRawEquipment([]);
       }
     } catch (err) {
       console.error('Error loading equipment:', err);
       setError(TEXT_CONSTANTS.ERRORS.CONNECTION_ERROR);
-      setRawEquipment([]);
     } finally {
       setLoading(false);
     }
@@ -112,12 +112,10 @@ export function useEquipment(options: UseEquipmentOptions = {}): UseEquipmentRet
         setEquipmentTypes(result.equipmentTypes);
       } else {
         setTypesError(result.error || TEXT_CONSTANTS.FEATURES.EQUIPMENT.ERROR_LOADING);
-        setEquipmentTypes([]);
       }
     } catch (err) {
       console.error('Error loading equipment types:', err);
       setTypesError(TEXT_CONSTANTS.ERRORS.CONNECTION_ERROR);
-      setEquipmentTypes([]);
     } finally {
       setTypesLoading(false);
     }
@@ -156,7 +154,7 @@ export function useEquipment(options: UseEquipmentOptions = {}): UseEquipmentRet
         signedBy,
         TEXT_CONSTANTS.FEATURES.EQUIPMENT.INITIAL_SIGN_IN
       );
-      if (result.success) { await refreshEquipment(); return true; }
+      if (result.success) return true;
       setError(result.message);
       return false;
     } catch (err) {
@@ -164,7 +162,7 @@ export function useEquipment(options: UseEquipmentOptions = {}): UseEquipmentRet
       setError(TEXT_CONSTANTS.ERRORS.UNEXPECTED_ERROR);
       return false;
     }
-  }, [refreshEquipment]);
+  }, []);
 
   const transferEquipment = useCallback(async (
     equipmentId: string,
@@ -186,7 +184,7 @@ export function useEquipment(options: UseEquipmentOptions = {}): UseEquipmentRet
         equipmentId, newHolder, newHolderId, updatedBy, updatedByName,
         approvalDetails, newUnit, newLocation, notes
       );
-      if (result.success) { await refreshEquipment(); return true; }
+      if (result.success) return true;
       setError(result.message);
       return false;
     } catch (err) {
@@ -194,7 +192,7 @@ export function useEquipment(options: UseEquipmentOptions = {}): UseEquipmentRet
       setError(TEXT_CONSTANTS.ERRORS.UNEXPECTED_ERROR);
       return false;
     }
-  }, [refreshEquipment]);
+  }, []);
 
   const updateEquipmentStatus = useCallback(async (
     equipmentId: string, newStatus: EquipmentStatus, updatedBy: string, updatedByName: string, notes?: string
@@ -203,7 +201,7 @@ export function useEquipment(options: UseEquipmentOptions = {}): UseEquipmentRet
       const result = await EquipmentService.Items.updateEquipment(
         equipmentId, { status: newStatus }, updatedBy, updatedByName, EquipmentAction.STATUS_UPDATE, notes
       );
-      if (result.success) { await refreshEquipment(); return true; }
+      if (result.success) return true;
       setError(result.message);
       return false;
     } catch (err) {
@@ -211,7 +209,7 @@ export function useEquipment(options: UseEquipmentOptions = {}): UseEquipmentRet
       setError(TEXT_CONSTANTS.ERRORS.UNEXPECTED_ERROR);
       return false;
     }
-  }, [refreshEquipment]);
+  }, []);
 
   const updateEquipmentCondition = useCallback(async (
     equipmentId: string, newCondition: EquipmentCondition, updatedBy: string, updatedByName: string, notes?: string
@@ -220,7 +218,7 @@ export function useEquipment(options: UseEquipmentOptions = {}): UseEquipmentRet
       const result = await EquipmentService.Items.updateEquipment(
         equipmentId, { condition: newCondition }, updatedBy, updatedByName, EquipmentAction.CONDITION_UPDATE, notes
       );
-      if (result.success) { await refreshEquipment(); return true; }
+      if (result.success) return true;
       setError(result.message);
       return false;
     } catch (err) {
@@ -228,7 +226,7 @@ export function useEquipment(options: UseEquipmentOptions = {}): UseEquipmentRet
       setError(TEXT_CONSTANTS.ERRORS.UNEXPECTED_ERROR);
       return false;
     }
-  }, [refreshEquipment]);
+  }, []);
 
   const performDailyCheck = useCallback(async (
     equipmentId: string, checkedBy: string, checkedByName: string, notes?: string
@@ -240,7 +238,7 @@ export function useEquipment(options: UseEquipmentOptions = {}): UseEquipmentRet
         checkedBy, checkedByName, EquipmentAction.DAILY_CHECK_IN,
         notes || TEXT_CONSTANTS.FEATURES.EQUIPMENT.DAILY_CHECK
       );
-      if (result.success) { await refreshEquipment(); return true; }
+      if (result.success) return true;
       setError(result.message);
       return false;
     } catch (err) {
@@ -248,7 +246,7 @@ export function useEquipment(options: UseEquipmentOptions = {}): UseEquipmentRet
       setError(TEXT_CONSTANTS.ERRORS.UNEXPECTED_ERROR);
       return false;
     }
-  }, [refreshEquipment]);
+  }, []);
 
   const reportEquipment = useCallback(async (
     equipmentId: string, photoUrl: string | null, note?: string
@@ -259,7 +257,7 @@ export function useEquipment(options: UseEquipmentOptions = {}): UseEquipmentRet
       const result = await EquipmentService.Items.reportEquipment(
         equipmentId, photoUrl, identity.displayName, note
       );
-      if (result.success) { await refreshEquipment(); return true; }
+      if (result.success) return true;
       setError(result.message);
       return false;
     } catch (err) {
@@ -267,7 +265,7 @@ export function useEquipment(options: UseEquipmentOptions = {}): UseEquipmentRet
       setError(TEXT_CONSTANTS.ERRORS.UNEXPECTED_ERROR);
       return false;
     }
-  }, [refreshEquipment, buildActorIdentity]);
+  }, [buildActorIdentity]);
 
   const retireEquipment = useCallback(async (
     equipmentId: string, reason: string
@@ -279,7 +277,6 @@ export function useEquipment(options: UseEquipmentOptions = {}): UseEquipmentRet
         equipmentId, identity.displayName, reason
       );
       if (result.success) {
-        await refreshEquipment();
         const kind = (result.data as { kind?: 'immediate' | 'request' } | undefined)?.kind;
         return { success: true, kind };
       }
@@ -288,7 +285,7 @@ export function useEquipment(options: UseEquipmentOptions = {}): UseEquipmentRet
       console.error('Error retiring equipment:', err);
       return { success: false, error: TEXT_CONSTANTS.ERRORS.UNEXPECTED_ERROR };
     }
-  }, [refreshEquipment, buildActorIdentity]);
+  }, [buildActorIdentity]);
 
   const createEquipmentBatch = useCallback(async (
     items: Array<Omit<Equipment, 'createdAt' | 'updatedAt' | 'trackingHistory'>>,
@@ -300,7 +297,7 @@ export function useEquipment(options: UseEquipmentOptions = {}): UseEquipmentRet
       const result = await EquipmentService.Items.createEquipmentBatch(
         items, identity.displayName, identity.uid, identity.displayName, identity.uid, notes
       );
-      if (result.success) { await refreshEquipment(); return true; }
+      if (result.success) return true;
       setError(result.message);
       return false;
     } catch (err) {
@@ -308,14 +305,14 @@ export function useEquipment(options: UseEquipmentOptions = {}): UseEquipmentRet
       setError(TEXT_CONSTANTS.ERRORS.UNEXPECTED_ERROR);
       return false;
     }
-  }, [refreshEquipment, buildActorIdentity]);
+  }, [buildActorIdentity]);
 
   const addEquipmentType = useCallback(async (
     equipmentTypeData: Omit<EquipmentType, 'createdAt' | 'updatedAt'>
   ): Promise<boolean> => {
     try {
       const result = await EquipmentService.Types.createEquipmentType(equipmentTypeData);
-      if (result.success) { await refreshEquipmentTypes(); return true; }
+      if (result.success) return true;
       setTypesError(result.message);
       return false;
     } catch (err) {
@@ -323,7 +320,7 @@ export function useEquipment(options: UseEquipmentOptions = {}): UseEquipmentRet
       setTypesError(TEXT_CONSTANTS.ERRORS.UNEXPECTED_ERROR);
       return false;
     }
-  }, [refreshEquipmentTypes]);
+  }, []);
 
   const getEquipmentById = useCallback((equipmentId: string) => equipment.find((i) => i.id === equipmentId), [equipment]);
   const getEquipmentByStatus = useCallback((status: EquipmentStatus) => equipment.filter((i) => i.status === status), [equipment]);
@@ -332,18 +329,53 @@ export function useEquipment(options: UseEquipmentOptions = {}): UseEquipmentRet
   const getEquipmentByTeam = useCallback((teamId: string) => equipment.filter((i) => i.holderTeamId === teamId || i.signerTeamId === teamId), [equipment]);
   const getEquipmentTypeById = useCallback((typeId: string) => equipmentTypes.find((t) => t.id === typeId), [equipmentTypes]);
 
+  // Subscribe to live snapshots while authenticated. Listener pattern replaces
+  // the previous fetch-on-mount + refetch-after-mutation churn: persistent IndexedDB
+  // cache paints initial state synchronously, and server deltas keep it current
+  // across tabs and other writers without per-mutation full-collection scans.
   useEffect(() => {
-    const unsubscribe = auth.onAuthStateChanged((user) => {
-      if (user) {
-        refreshEquipment();
-        refreshEquipmentTypes();
-      } else {
+    let unsubEquipment: (() => void) | null = null;
+    let unsubTypes: (() => void) | null = null;
+
+    const unsubAuth = auth.onAuthStateChanged((user) => {
+      unsubEquipment?.(); unsubTypes?.();
+      unsubEquipment = null; unsubTypes = null;
+
+      if (!user) {
         setRawEquipment([]);
         setEquipmentTypes([]);
+        return;
       }
+
+      setLoading(true);
+      setError(null);
+      unsubEquipment = EquipmentService.Items.subscribeEquipmentList((result) => {
+        if (result.success) {
+          setRawEquipment(result.equipments);
+        } else {
+          setError(result.error || TEXT_CONSTANTS.FEATURES.EQUIPMENT.ERROR_LOADING);
+        }
+        setLoading(false);
+      });
+
+      setTypesLoading(true);
+      setTypesError(null);
+      unsubTypes = EquipmentService.Types.subscribeEquipmentTypes((result) => {
+        if (result.success) {
+          setEquipmentTypes(result.equipmentTypes);
+        } else {
+          setTypesError(result.error || TEXT_CONSTANTS.FEATURES.EQUIPMENT.ERROR_LOADING);
+        }
+        setTypesLoading(false);
+      });
     });
-    return () => unsubscribe();
-  }, [refreshEquipment, refreshEquipmentTypes]);
+
+    return () => {
+      unsubAuth();
+      unsubEquipment?.();
+      unsubTypes?.();
+    };
+  }, []);
 
   return {
     equipment,

--- a/src/lib/equipmentService.ts
+++ b/src/lib/equipmentService.ts
@@ -11,6 +11,7 @@ import {
   doc,
   getDoc,
   getDocs,
+  onSnapshot,
   query,
   where,
   orderBy,
@@ -18,6 +19,7 @@ import {
   serverTimestamp,
   Timestamp,
   writeBatch,
+  type Unsubscribe,
 } from 'firebase/firestore';
 
 import {
@@ -231,8 +233,38 @@ export class EquipmentTypesService {
   }
 
   /**
-   * Update equipment type
+   * Subscribe to equipment types via onSnapshot. Replaces mount-time + post-mutation
+   * refetch pattern. Fires synchronously from local cache when available, then
+   * delivers server deltas. Returns unsubscribe.
    */
+  static subscribeEquipmentTypes(
+    callback: (result: EquipmentTypeListResult) => void,
+    { activeOnly = true, category = null }: { activeOnly?: boolean; category?: string | null } = {}
+  ): Unsubscribe {
+    let q = query(collection(db, EQUIPMENT_TEMPLATES_COLLECTION));
+    if (activeOnly) q = query(q, where('isActive', '==', true));
+    if (category) q = query(q, where('category', '==', category));
+
+    return onSnapshot(
+      q,
+      (snap) => {
+        const equipmentTypes: EquipmentType[] = [];
+        snap.forEach((d) => equipmentTypes.push({ id: d.id, ...d.data() } as EquipmentType));
+        equipmentTypes.sort((a, b) => {
+          const sa = (a as unknown as { sortOrder?: number }).sortOrder ?? Number.MAX_SAFE_INTEGER;
+          const sb = (b as unknown as { sortOrder?: number }).sortOrder ?? Number.MAX_SAFE_INTEGER;
+          if (sa !== sb) return sa - sb;
+          return (a.name ?? '').localeCompare(b.name ?? '');
+        });
+        callback({ success: true, equipmentTypes, totalCount: equipmentTypes.length });
+      },
+      (error) => {
+        console.error('Equipment types snapshot error:', error);
+        callback({ success: false, equipmentTypes: [], totalCount: 0, error: error.message });
+      }
+    );
+  }
+
   /**
    * Update equipment type.
    * Delegates to server API route (firebase-admin) for the write.
@@ -449,6 +481,58 @@ export class EquipmentItemsService {
         error: error instanceof Error ? error.message : 'Unknown error'
       };
     }
+  }
+
+  /**
+   * Subscribe to equipment list via onSnapshot. Replaces refetch-after-mutation pattern.
+   * Filters mirror getEquipmentList for parity. Returns unsubscribe.
+   */
+  static subscribeEquipmentList(
+    callback: (result: EquipmentListResult) => void,
+    filters: {
+      holder?: string;
+      holderId?: string;
+      status?: EquipmentStatus[];
+      category?: string;
+      equipmentType?: string;
+      limitCount?: number;
+    } = {}
+  ): Unsubscribe {
+    let q = query(collection(db, EQUIPMENT_COLLECTION), orderBy('updatedAt', 'desc'));
+
+    if (filters.holderId) {
+      q = query(q, where('currentHolderId', '==', filters.holderId));
+    } else if (filters.holder) {
+      q = query(q, where('currentHolder', '==', filters.holder));
+    }
+    if (filters.status && filters.status.length > 0) q = query(q, where('status', 'in', filters.status));
+    if (filters.category) q = query(q, where('category', '==', filters.category));
+    if (filters.equipmentType) q = query(q, where('equipmentType', '==', filters.equipmentType));
+    if (filters.limitCount) q = query(q, limit(filters.limitCount));
+
+    return onSnapshot(
+      q,
+      (snap) => {
+        const equipments: Equipment[] = [];
+        snap.forEach((d) => equipments.push({ id: d.id, ...d.data() } as Equipment));
+        callback({
+          success: true,
+          equipments,
+          totalCount: equipments.length,
+          hasMore: filters.limitCount ? equipments.length === filters.limitCount : false,
+        });
+      },
+      (error) => {
+        console.error('Equipment list snapshot error:', error);
+        callback({
+          success: false,
+          equipments: [],
+          totalCount: 0,
+          hasMore: false,
+          error: error.message,
+        });
+      }
+    );
   }
 
   /**


### PR DESCRIPTION
## Summary
- Adds \`subscribeEquipmentList\` + \`subscribeEquipmentTypes\` to \`EquipmentService\` (one-shot \`getDocs\` replaced by long-lived \`onSnapshot\`).
- Rewires \`useEquipment\` mount effect to subscribe while authenticated, unsubscribe on signout/unmount.
- Drops every \`await refreshEquipment()\` / \`refreshEquipmentTypes()\` from the 9 mutators — listener fires when the write commits, so we no longer eat a full collection scan per write × N viewers.
- \`refreshEquipment\` / \`refreshEquipmentTypes\` stay exported as force-resync escape hatches (no longer wipe state on transient error).

## Test plan
- [x] \`npm run lint\` clean
- [x] \`npm test\` — 42 suites pass (701/701 active tests)
- [ ] \`npm run dev\` — open equipment page in two tabs, mutate in tab A, confirm tab B updates without refresh
- [ ] Verify list view paints from cache instantly when navigating back to equipment page (no spinner flash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)