### PR TITLE
perf(ammunition): useAmmunitionInventory → onSnapshot (drop refetch-per-mutation)

### DIFF
--- a/src/hooks/useAmmunitionInventory.ts
+++ b/src/hooks/useAmmunitionInventory.ts
@@ -3,6 +3,8 @@
 import { useCallback, useEffect, useState } from 'react';
 import { apiFetch } from '@/lib/apiFetch';
 import {
+  subscribeAmmunitionStock,
+  subscribeSerialAmmunitionItems,
   listAmmunitionStock,
   listSerialAmmunitionItems,
 } from '@/lib/ammunition/inventoryService';
@@ -70,98 +72,110 @@ export interface UseAmmunitionInventoryReturn {
   returnToCentral: (payload: ReturnToCentralPayload) => Promise<boolean>;
 }
 
-// Module-level cache so navigating between pages does not refetch the entire
-// inventory. Stale-while-revalidate: subsequent mounts paint from cache
-// immediately, then refresh in the background. The set of mutators in this
-// hook all call refresh() on success, so the cache is kept current.
-let cachedStock: AmmunitionStock[] | null = null;
-let cachedItems: AmmunitionItem[] | null = null;
-
 export function useAmmunitionInventory(): UseAmmunitionInventoryReturn {
-  const [stock, setStock] = useState<AmmunitionStock[]>(cachedStock ?? []);
-  const [items, setItems] = useState<AmmunitionItem[]>(cachedItems ?? []);
-  const [isLoading, setIsLoading] = useState(cachedStock === null);
+  const [stock, setStock] = useState<AmmunitionStock[]>([]);
+  const [items, setItems] = useState<AmmunitionItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  // Two onSnapshot listeners (stock + serial items). Persistent IndexedDB cache
+  // paints initial state synchronously on cold mount and across navigations;
+  // server deltas keep both lists current without per-mutation refetch.
+  useEffect(() => {
+    let gotStock = false;
+    let gotItems = false;
+    const finish = () => {
+      if (gotStock && gotItems) setIsLoading(false);
+    };
+
+    const unsubStock = subscribeAmmunitionStock(
+      (rows) => {
+        setStock(rows);
+        gotStock = true;
+        finish();
+      },
+      (err) => {
+        setError(err.message || 'שגיאה בטעינת מלאי');
+        gotStock = true;
+        finish();
+      }
+    );
+    const unsubItems = subscribeSerialAmmunitionItems(
+      (rows) => {
+        setItems(rows);
+        gotItems = true;
+        finish();
+      },
+      (err) => {
+        setError(err.message || 'שגיאה בטעינת מלאי');
+        gotItems = true;
+        finish();
+      }
+    );
+
+    return () => {
+      unsubStock();
+      unsubItems();
+    };
+  }, []);
+
+  // Force-resync escape hatch. Listener owns state; this exists for callers
+  // that want an explicit one-shot read (e.g. after a corrupted cache).
   const refresh = useCallback(async () => {
-    if (cachedStock === null) setIsLoading(true);
     setError(null);
     try {
-      const [s, i] = await Promise.all([
-        listAmmunitionStock(),
-        listSerialAmmunitionItems(),
-      ]);
-      cachedStock = s;
-      cachedItems = i;
+      const [s, i] = await Promise.all([listAmmunitionStock(), listSerialAmmunitionItems()]);
       setStock(s);
       setItems(i);
     } catch (e) {
       setError(e instanceof Error ? e.message : 'שגיאה בטעינת מלאי');
-    } finally {
-      setIsLoading(false);
     }
   }, []);
 
-  useEffect(() => {
-    refresh();
-  }, [refresh]);
+  const upsertStock = useCallback(async (payload: UpsertStockPayload) => {
+    try {
+      const res = await apiFetch('/api/ammunition-inventory', {
+        method: 'POST',
+        body: JSON.stringify({ kind: 'stock', payload }),
+      });
+      const json = await res.json();
+      if (!res.ok || !json.success) throw new Error(json.error || 'עדכון מלאי נכשל');
+      return true;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'שגיאה לא צפויה');
+      return false;
+    }
+  }, []);
 
-  const upsertStock = useCallback(
-    async (payload: UpsertStockPayload) => {
-      try {
-        const res = await apiFetch('/api/ammunition-inventory', {
-          method: 'POST',
-          body: JSON.stringify({ kind: 'stock', payload }),
-        });
-        const json = await res.json();
-        if (!res.ok || !json.success) throw new Error(json.error || 'עדכון מלאי נכשל');
-        await refresh();
-        return true;
-      } catch (e) {
-        setError(e instanceof Error ? e.message : 'שגיאה לא צפויה');
-        return false;
-      }
-    },
-    [refresh]
-  );
+  const deleteStock = useCallback(async (id: string) => {
+    try {
+      const res = await apiFetch(`/api/ammunition-inventory/${encodeURIComponent(id)}`, {
+        method: 'DELETE',
+        body: JSON.stringify({ kind: 'stock' }),
+      });
+      const json = await res.json();
+      if (!res.ok || !json.success) throw new Error(json.error || 'מחיקת מלאי נכשלה');
+      return true;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'שגיאה לא צפויה');
+      return false;
+    }
+  }, []);
 
-  const deleteStock = useCallback(
-    async (id: string) => {
-      try {
-        const res = await apiFetch(`/api/ammunition-inventory/${encodeURIComponent(id)}`, {
-          method: 'DELETE',
-          body: JSON.stringify({ kind: 'stock' }),
-        });
-        const json = await res.json();
-        if (!res.ok || !json.success) throw new Error(json.error || 'מחיקת מלאי נכשלה');
-        await refresh();
-        return true;
-      } catch (e) {
-        setError(e instanceof Error ? e.message : 'שגיאה לא צפויה');
-        return false;
-      }
-    },
-    [refresh]
-  );
-
-  const createSerialItem = useCallback(
-    async (payload: CreateSerialItemPayload) => {
-      try {
-        const res = await apiFetch('/api/ammunition-inventory', {
-          method: 'POST',
-          body: JSON.stringify({ kind: 'item', payload }),
-        });
-        const json = await res.json();
-        if (!res.ok || !json.success) throw new Error(json.error || 'יצירת פריט נכשלה');
-        await refresh();
-        return true;
-      } catch (e) {
-        setError(e instanceof Error ? e.message : 'שגיאה לא צפויה');
-        return false;
-      }
-    },
-    [refresh]
-  );
+  const createSerialItem = useCallback(async (payload: CreateSerialItemPayload) => {
+    try {
+      const res = await apiFetch('/api/ammunition-inventory', {
+        method: 'POST',
+        body: JSON.stringify({ kind: 'item', payload }),
+      });
+      const json = await res.json();
+      if (!res.ok || !json.success) throw new Error(json.error || 'יצירת פריט נכשלה');
+      return true;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'שגיאה לא צפויה');
+      return false;
+    }
+  }, []);
 
   const updateSerialItem = useCallback(
     async (serial: string, payload: UpdateSerialItemPayload) => {
@@ -172,91 +186,74 @@ export function useAmmunitionInventory(): UseAmmunitionInventoryReturn {
         });
         const json = await res.json();
         if (!res.ok || !json.success) throw new Error(json.error || 'עדכון פריט נכשל');
-        await refresh();
         return true;
       } catch (e) {
         setError(e instanceof Error ? e.message : 'שגיאה לא צפויה');
         return false;
       }
     },
-    [refresh]
+    []
   );
 
-  const deleteSerialItem = useCallback(
-    async (serial: string) => {
-      try {
-        const res = await apiFetch(`/api/ammunition-inventory/${encodeURIComponent(serial)}`, {
-          method: 'DELETE',
-          body: JSON.stringify({ kind: 'item' }),
-        });
-        const json = await res.json();
-        if (!res.ok || !json.success) throw new Error(json.error || 'מחיקת פריט נכשלה');
-        await refresh();
-        return true;
-      } catch (e) {
-        setError(e instanceof Error ? e.message : 'שגיאה לא צפויה');
-        return false;
-      }
-    },
-    [refresh]
-  );
+  const deleteSerialItem = useCallback(async (serial: string) => {
+    try {
+      const res = await apiFetch(`/api/ammunition-inventory/${encodeURIComponent(serial)}`, {
+        method: 'DELETE',
+        body: JSON.stringify({ kind: 'item' }),
+      });
+      const json = await res.json();
+      if (!res.ok || !json.success) throw new Error(json.error || 'מחיקת פריט נכשלה');
+      return true;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'שגיאה לא צפויה');
+      return false;
+    }
+  }, []);
 
-  const returnSerialItemToMgr = useCallback(
-    async (serial: string) => {
-      try {
-        const res = await apiFetch(`/api/ammunition-inventory/${encodeURIComponent(serial)}`, {
-          method: 'PATCH',
-          body: JSON.stringify({ action: 'return-to-mgr' }),
-        });
-        const json = await res.json();
-        if (!res.ok || !json.success) throw new Error(json.error || 'החזרה לאחראי תחמושת נכשלה');
-        await refresh();
-        return true;
-      } catch (e) {
-        setError(e instanceof Error ? e.message : 'שגיאה לא צפויה');
-        return false;
-      }
-    },
-    [refresh]
-  );
+  const returnSerialItemToMgr = useCallback(async (serial: string) => {
+    try {
+      const res = await apiFetch(`/api/ammunition-inventory/${encodeURIComponent(serial)}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ action: 'return-to-mgr' }),
+      });
+      const json = await res.json();
+      if (!res.ok || !json.success) throw new Error(json.error || 'החזרה לאחראי תחמושת נכשלה');
+      return true;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'שגיאה לא צפויה');
+      return false;
+    }
+  }, []);
 
-  const assignFromCentral = useCallback(
-    async (payload: AssignFromCentralPayload) => {
-      try {
-        const res = await apiFetch('/api/ammunition-inventory', {
-          method: 'POST',
-          body: JSON.stringify({ action: 'assign_from_central', payload }),
-        });
-        const json = await res.json();
-        if (!res.ok || !json.success) throw new Error(json.error || 'הקצאה ממלאי מרכזי נכשלה');
-        await refresh();
-        return true;
-      } catch (e) {
-        setError(e instanceof Error ? e.message : 'שגיאה לא צפויה');
-        return false;
-      }
-    },
-    [refresh]
-  );
+  const assignFromCentral = useCallback(async (payload: AssignFromCentralPayload) => {
+    try {
+      const res = await apiFetch('/api/ammunition-inventory', {
+        method: 'POST',
+        body: JSON.stringify({ action: 'assign_from_central', payload }),
+      });
+      const json = await res.json();
+      if (!res.ok || !json.success) throw new Error(json.error || 'הקצאה ממלאי מרכזי נכשלה');
+      return true;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'שגיאה לא צפויה');
+      return false;
+    }
+  }, []);
 
-  const returnToCentral = useCallback(
-    async (payload: ReturnToCentralPayload) => {
-      try {
-        const res = await apiFetch('/api/ammunition-inventory', {
-          method: 'POST',
-          body: JSON.stringify({ action: 'return_to_central', payload }),
-        });
-        const json = await res.json();
-        if (!res.ok || !json.success) throw new Error(json.error || 'החזרה למלאי מרכזי נכשלה');
-        await refresh();
-        return true;
-      } catch (e) {
-        setError(e instanceof Error ? e.message : 'שגיאה לא צפויה');
-        return false;
-      }
-    },
-    [refresh]
-  );
+  const returnToCentral = useCallback(async (payload: ReturnToCentralPayload) => {
+    try {
+      const res = await apiFetch('/api/ammunition-inventory', {
+        method: 'POST',
+        body: JSON.stringify({ action: 'return_to_central', payload }),
+      });
+      const json = await res.json();
+      if (!res.ok || !json.success) throw new Error(json.error || 'החזרה למלאי מרכזי נכשלה');
+      return true;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'שגיאה לא צפויה');
+      return false;
+    }
+  }, []);
 
   return {
     stock,

--- a/src/lib/ammunition/inventoryService.ts
+++ b/src/lib/ammunition/inventoryService.ts
@@ -6,7 +6,7 @@
  * `/api/ammunition-inventory`.
  */
 import { db } from '@/lib/firebase';
-import { collection, getDocs } from 'firebase/firestore';
+import { collection, getDocs, onSnapshot, type Unsubscribe } from 'firebase/firestore';
 import { COLLECTIONS } from '@/lib/db/collections';
 import type { AmmunitionItem, AmmunitionStock } from '@/types/ammunition';
 
@@ -18,4 +18,40 @@ export async function listAmmunitionStock(): Promise<AmmunitionStock[]> {
 export async function listSerialAmmunitionItems(): Promise<AmmunitionItem[]> {
   const snap = await getDocs(collection(db, COLLECTIONS.AMMUNITION));
   return snap.docs.map((d) => ({ id: d.id, ...d.data() }) as AmmunitionItem);
+}
+
+/**
+ * Subscribe to the BRUCE / LOOSE_COUNT stock collection. Listener-based —
+ * persistent IndexedDB cache paints initial state synchronously and server
+ * deltas keep it current without explicit refetch after each mutation.
+ */
+export function subscribeAmmunitionStock(
+  onData: (rows: AmmunitionStock[]) => void,
+  onError?: (err: Error) => void
+): Unsubscribe {
+  return onSnapshot(
+    collection(db, COLLECTIONS.AMMUNITION_INVENTORY),
+    (snap) => onData(snap.docs.map((d) => ({ id: d.id, ...d.data() }) as AmmunitionStock)),
+    (err) => {
+      console.error('Ammunition stock snapshot error:', err);
+      onError?.(err);
+    }
+  );
+}
+
+/**
+ * Subscribe to the per-serial ammunition items collection.
+ */
+export function subscribeSerialAmmunitionItems(
+  onData: (rows: AmmunitionItem[]) => void,
+  onError?: (err: Error) => void
+): Unsubscribe {
+  return onSnapshot(
+    collection(db, COLLECTIONS.AMMUNITION),
+    (snap) => onData(snap.docs.map((d) => ({ id: d.id, ...d.data() }) as AmmunitionItem)),
+    (err) => {
+      console.error('Serial ammunition items snapshot error:', err);
+      onError?.(err);
+    }
+  );
 }


### PR DESCRIPTION
## Summary
- Adds \`subscribeAmmunitionStock\` + \`subscribeSerialAmmunitionItems\` to \`inventoryService\`.
- Replaces hook's mount-fetch + module-level cache with two onSnapshot listeners (stock + serial items).
- Drops \`await refresh()\` from all 8 mutators — listeners pick up writes automatically, eliminating 8 × (2 full scans) per inventory edit.
- \`refresh()\` retained as force-resync escape hatch.
- Module-level \`cachedStock\`/\`cachedItems\` removed; Firestore's persistent IndexedDB cache is the read-through layer now.

## Test plan
- [x] \`npm run lint\` clean
- [x] \`npm test\` — 42 suites pass (701/701 active)
- [ ] \`npm run dev\` — open ammunition page in two tabs, edit stock/items in tab A, confirm tab B updates without refresh
- [ ] Cold-mount paint from IndexedDB cache feels instant (no spinner flash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)