### PR TITLE
perf: convert template/report/training-plan hooks to onSnapshot

### DIFF
--- a/src/hooks/useAmmunitionReports.ts
+++ b/src/hooks/useAmmunitionReports.ts
@@ -1,9 +1,10 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { apiFetch } from '@/lib/apiFetch';
 import {
   listAmmunitionReports,
+  subscribeAmmunitionReports,
   type ListReportsFilter,
 } from '@/lib/ammunition/reportsService';
 import type { AmmunitionReport, BruceState } from '@/types/ammunition';
@@ -33,44 +34,51 @@ export function useAmmunitionReports(): UseAmmunitionReportsReturn {
   const [reports, setReports] = useState<AmmunitionReport[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const filterRef = useRef<ListReportsFilter>({});
+
+  useEffect(() => {
+    setIsLoading(true);
+    setError(null);
+    const unsub = subscribeAmmunitionReports(
+      filterRef.current,
+      (rows) => {
+        setReports(rows);
+        setIsLoading(false);
+      },
+      (e) => {
+        setError(e.message || 'שגיאה בטעינת דיווחים');
+        setIsLoading(false);
+      }
+    );
+    return () => unsub();
+  }, []);
 
   const refresh = useCallback(async (filter: ListReportsFilter = {}) => {
-    setIsLoading(true);
     setError(null);
     try {
       const list = await listAmmunitionReports(filter);
       setReports(list);
     } catch (e) {
       setError(e instanceof Error ? e.message : 'שגיאה בטעינת דיווחים');
-    } finally {
-      setIsLoading(false);
     }
   }, []);
 
-  useEffect(() => {
-    refresh();
-  }, [refresh]);
-
-  const submit = useCallback(
-    async (payload: SubmitReportPayload) => {
-      try {
-        const res = await apiFetch('/api/ammunition-reports', {
-          method: 'POST',
-          body: JSON.stringify({ payload }),
-        });
-        const json = await res.json();
-        if (!res.ok || !json.success) {
-          throw new Error(json.error || 'שליחת דיווח נכשלה');
-        }
-        await refresh();
-        return { ok: true, reportId: json.reportId as string };
-      } catch (e) {
-        setError(e instanceof Error ? e.message : 'שגיאה לא צפויה');
-        return { ok: false };
+  const submit = useCallback(async (payload: SubmitReportPayload) => {
+    try {
+      const res = await apiFetch('/api/ammunition-reports', {
+        method: 'POST',
+        body: JSON.stringify({ payload }),
+      });
+      const json = await res.json();
+      if (!res.ok || !json.success) {
+        throw new Error(json.error || 'שליחת דיווח נכשלה');
       }
-    },
-    [refresh]
-  );
+      return { ok: true, reportId: json.reportId as string };
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'שגיאה לא צפויה');
+      return { ok: false };
+    }
+  }, []);
 
   return { reports, isLoading, error, refresh, submit };
 }

--- a/src/hooks/useAmmunitionTemplates.ts
+++ b/src/hooks/useAmmunitionTemplates.ts
@@ -2,6 +2,10 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { apiFetch } from '@/lib/apiFetch';
+import {
+  listAmmunitionTemplates,
+  subscribeAmmunitionTemplates,
+} from '@/lib/ammunition/templatesService';
 import type { AmmunitionType } from '@/types/ammunition';
 
 export interface CreateAmmunitionTemplatePayload {
@@ -33,89 +37,83 @@ export function useAmmunitionTemplates(): UseAmmunitionTemplatesReturn {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  // Direct client-SDK listener replaces the previous API-route refetch
+  // pattern. Rules allow authenticated read of `ammunitionTemplates`, so we
+  // skip the server hop entirely — persistent cache + delta sync only.
+  useEffect(() => {
+    const unsub = subscribeAmmunitionTemplates(
+      (rows) => {
+        setTemplates(rows);
+        setIsLoading(false);
+      },
+      (e) => {
+        setError(e.message || 'שגיאה בטעינת תבניות תחמושת');
+        setIsLoading(false);
+      }
+    );
+    return () => unsub();
+  }, []);
+
   const refresh = useCallback(async () => {
-    setIsLoading(true);
     setError(null);
     try {
-      const res = await apiFetch('/api/ammunition-templates');
-      const json = await res.json();
-      if (!res.ok || !json.success) {
-        throw new Error(json.error || 'שגיאה בטעינת תבניות תחמושת');
-      }
-      setTemplates(json.templates || []);
+      const rows = await listAmmunitionTemplates();
+      setTemplates(rows);
     } catch (e) {
       setError(e instanceof Error ? e.message : 'שגיאה לא צפויה');
-    } finally {
-      setIsLoading(false);
     }
   }, []);
 
-  useEffect(() => {
-    refresh();
-  }, [refresh]);
-
-  const create = useCallback(
-    async (payload: CreateAmmunitionTemplatePayload) => {
-      try {
-        const res = await apiFetch('/api/ammunition-templates', {
-          method: 'POST',
-          body: JSON.stringify({ payload }),
-        });
-        const json = await res.json();
-        if (!res.ok || !json.success) {
-          throw new Error(json.error || 'יצירת תבנית נכשלה');
-        }
-        await refresh();
-        return true;
-      } catch (e) {
-        setError(e instanceof Error ? e.message : 'שגיאה לא צפויה');
-        return false;
+  const create = useCallback(async (payload: CreateAmmunitionTemplatePayload) => {
+    try {
+      const res = await apiFetch('/api/ammunition-templates', {
+        method: 'POST',
+        body: JSON.stringify({ payload }),
+      });
+      const json = await res.json();
+      if (!res.ok || !json.success) {
+        throw new Error(json.error || 'יצירת תבנית נכשלה');
       }
-    },
-    [refresh]
-  );
+      return true;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'שגיאה לא צפויה');
+      return false;
+    }
+  }, []);
 
-  const update = useCallback(
-    async (id: string, payload: CreateAmmunitionTemplatePayload) => {
-      try {
-        const res = await apiFetch(`/api/ammunition-templates/${id}`, {
-          method: 'PUT',
-          body: JSON.stringify({ payload }),
-        });
-        const json = await res.json();
-        if (!res.ok || !json.success) {
-          throw new Error(json.error || 'עדכון תבנית נכשל');
-        }
-        await refresh();
-        return true;
-      } catch (e) {
-        setError(e instanceof Error ? e.message : 'שגיאה לא צפויה');
-        return false;
+  const update = useCallback(async (id: string, payload: CreateAmmunitionTemplatePayload) => {
+    try {
+      const res = await apiFetch(`/api/ammunition-templates/${id}`, {
+        method: 'PUT',
+        body: JSON.stringify({ payload }),
+      });
+      const json = await res.json();
+      if (!res.ok || !json.success) {
+        throw new Error(json.error || 'עדכון תבנית נכשל');
       }
-    },
-    [refresh]
-  );
+      return true;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'שגיאה לא צפויה');
+      return false;
+    }
+  }, []);
 
-  const remove = useCallback(
-    async (id: string) => {
-      try {
-        const res = await apiFetch(`/api/ammunition-templates/${id}`, {
-          method: 'DELETE',
-          body: JSON.stringify({}),
-        });
-        const json = await res.json();
-        if (!res.ok || !json.success) {
-          throw new Error(json.error || 'מחיקת תבנית נכשלה');
-        }
-        await refresh();
-        return true;
-      } catch (e) {
-        setError(e instanceof Error ? e.message : 'שגיאה לא צפויה');
-        return false;
+  const remove = useCallback(async (id: string) => {
+    try {
+      const res = await apiFetch(`/api/ammunition-templates/${id}`, {
+        method: 'DELETE',
+        body: JSON.stringify({}),
+      });
+      const json = await res.json();
+      if (!res.ok || !json.success) {
+        throw new Error(json.error || 'מחיקת תבנית נכשלה');
       }
-    },
-    [refresh]
-  );
+      return true;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'שגיאה לא צפויה');
+      return false;
+    }
+  }, []);
 
   return { templates, isLoading, error, refresh, create, update, remove };
 }

--- a/src/hooks/useTrainingPlans.ts
+++ b/src/hooks/useTrainingPlans.ts
@@ -1,10 +1,11 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import { apiFetch } from '@/lib/apiFetch';
 import {
   listTrainingPlans,
+  subscribeTrainingPlans,
   type ListTrainingPlansFilter,
 } from '@/lib/training/trainingPlansService';
 import type {
@@ -47,23 +48,38 @@ export function useTrainingPlans(): UseTrainingPlansReturn {
   const [plans, setPlans] = useState<TrainingPlan[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const filterRef = useRef<ListTrainingPlansFilter>({});
 
-  const refresh = useCallback(async (filter: ListTrainingPlansFilter = {}) => {
+  // Listener-based mount. Persistent IndexedDB cache paints initial state
+  // synchronously; server deltas keep it current without per-mutation refetch.
+  useEffect(() => {
     setIsLoading(true);
+    setError(null);
+    const unsub = subscribeTrainingPlans(
+      filterRef.current,
+      (list) => {
+        setPlans(list);
+        setIsLoading(false);
+      },
+      (e) => {
+        setError(e.message || 'שגיאה בטעינת תכנוני אימונים');
+        setIsLoading(false);
+      }
+    );
+    return () => unsub();
+  }, []);
+
+  // Force-resync escape hatch; supports an ad-hoc filter swap for callers
+  // that need a one-shot read with different scope.
+  const refresh = useCallback(async (filter: ListTrainingPlansFilter = {}) => {
     setError(null);
     try {
       const list = await listTrainingPlans(filter);
       setPlans(list);
     } catch (e) {
       setError(e instanceof Error ? e.message : 'שגיאה בטעינת תכנוני אימונים');
-    } finally {
-      setIsLoading(false);
     }
   }, []);
-
-  useEffect(() => {
-    refresh();
-  }, [refresh]);
 
   const create = useCallback(
     async (payload: CreateTrainingPlanInput) => {
@@ -77,14 +93,13 @@ export function useTrainingPlans(): UseTrainingPlansReturn {
         });
         const json = await res.json();
         if (!res.ok || !json.success) throw new Error(json.error || 'יצירת תכנון נכשלה');
-        await refresh();
         return { ok: true, id: json.id as string };
       } catch (e) {
         setError(e instanceof Error ? e.message : 'שגיאה לא צפויה');
         return { ok: false };
       }
     },
-    [enhancedUser, refresh]
+    [enhancedUser]
   );
 
   const transition = useCallback(
@@ -100,14 +115,13 @@ export function useTrainingPlans(): UseTrainingPlansReturn {
         });
         const json = await res.json();
         if (!res.ok || !json.success) throw new Error(json.error || 'הפעולה נכשלה');
-        await refresh();
         return true;
       } catch (e) {
         setError(e instanceof Error ? e.message : 'שגיאה לא צפויה');
         return false;
       }
     },
-    [enhancedUser, refresh]
+    [enhancedUser]
   );
 
   const approve = useCallback((planId: string) => transition(planId, 'approve'), [transition]);

--- a/src/lib/ammunition/reportsService.ts
+++ b/src/lib/ammunition/reportsService.ts
@@ -5,10 +5,12 @@ import { db } from '@/lib/firebase';
 import {
   collection,
   getDocs,
+  onSnapshot,
   orderBy,
   query,
   where,
   Timestamp,
+  type Unsubscribe,
 } from 'firebase/firestore';
 import { COLLECTIONS } from '@/lib/db/collections';
 import type { AmmunitionReport } from '@/types/ammunition';
@@ -21,9 +23,7 @@ export interface ListReportsFilter {
   templateId?: string;
 }
 
-export async function listAmmunitionReports(
-  filter: ListReportsFilter = {}
-): Promise<AmmunitionReport[]> {
+function buildReportsQuery(filter: ListReportsFilter) {
   const constraints = [];
   if (filter.teamId) constraints.push(where('teamId', '==', filter.teamId));
   if (filter.reporterId) constraints.push(where('reporterId', '==', filter.reporterId));
@@ -34,7 +34,31 @@ export async function listAmmunitionReports(
   if (filter.toMs !== undefined) {
     constraints.push(where('usedAt', '<=', Timestamp.fromDate(new Date(filter.toMs))));
   }
-  const q = query(collection(db, COLLECTIONS.AMMUNITION_REPORTS), ...constraints, orderBy('usedAt', 'desc'));
-  const snap = await getDocs(q);
+  return query(
+    collection(db, COLLECTIONS.AMMUNITION_REPORTS),
+    ...constraints,
+    orderBy('usedAt', 'desc')
+  );
+}
+
+export async function listAmmunitionReports(
+  filter: ListReportsFilter = {}
+): Promise<AmmunitionReport[]> {
+  const snap = await getDocs(buildReportsQuery(filter));
   return snap.docs.map((d) => ({ id: d.id, ...d.data() }) as AmmunitionReport);
+}
+
+export function subscribeAmmunitionReports(
+  filter: ListReportsFilter,
+  onData: (rows: AmmunitionReport[]) => void,
+  onError?: (err: Error) => void
+): Unsubscribe {
+  return onSnapshot(
+    buildReportsQuery(filter),
+    (snap) => onData(snap.docs.map((d) => ({ id: d.id, ...d.data() }) as AmmunitionReport)),
+    (err) => {
+      console.error('Ammunition reports snapshot error:', err);
+      onError?.(err);
+    }
+  );
 }

--- a/src/lib/ammunition/templatesService.ts
+++ b/src/lib/ammunition/templatesService.ts
@@ -5,11 +5,25 @@
  * the server API (`/api/ammunition-templates`).
  */
 import { db } from '@/lib/firebase';
-import { collection, getDocs } from 'firebase/firestore';
+import { collection, getDocs, onSnapshot, type Unsubscribe } from 'firebase/firestore';
 import { COLLECTIONS } from '@/lib/db/collections';
 import type { AmmunitionType } from '@/types/ammunition';
 
 export async function listAmmunitionTemplates(): Promise<AmmunitionType[]> {
   const snap = await getDocs(collection(db, COLLECTIONS.AMMUNITION_TEMPLATES));
   return snap.docs.map((d) => ({ id: d.id, ...d.data() }) as AmmunitionType);
+}
+
+export function subscribeAmmunitionTemplates(
+  onData: (rows: AmmunitionType[]) => void,
+  onError?: (err: Error) => void
+): Unsubscribe {
+  return onSnapshot(
+    collection(db, COLLECTIONS.AMMUNITION_TEMPLATES),
+    (snap) => onData(snap.docs.map((d) => ({ id: d.id, ...d.data() }) as AmmunitionType)),
+    (err) => {
+      console.error('Ammunition templates snapshot error:', err);
+      onError?.(err);
+    }
+  );
 }

--- a/src/lib/training/trainingPlansService.ts
+++ b/src/lib/training/trainingPlansService.ts
@@ -6,10 +6,12 @@ import { db } from '@/lib/firebase';
 import {
   collection,
   getDocs,
+  onSnapshot,
   orderBy,
   query,
   where,
   Timestamp,
+  type Unsubscribe,
 } from 'firebase/firestore';
 import { COLLECTIONS } from '@/lib/db/collections';
 import type { TrainingPlan, TrainingPlanStatus } from '@/types/training';
@@ -21,9 +23,7 @@ export interface ListTrainingPlansFilter {
   toMs?: number;
 }
 
-export async function listTrainingPlans(
-  filter: ListTrainingPlansFilter = {}
-): Promise<TrainingPlan[]> {
+function buildTrainingPlansQuery(filter: ListTrainingPlansFilter) {
   const constraints = [];
   if (filter.teamId) constraints.push(where('teamId', '==', filter.teamId));
   if (filter.status) constraints.push(where('status', '==', filter.status));
@@ -33,11 +33,31 @@ export async function listTrainingPlans(
   if (filter.toMs !== undefined) {
     constraints.push(where('startAt', '<=', Timestamp.fromDate(new Date(filter.toMs))));
   }
-  const q = query(
+  return query(
     collection(db, COLLECTIONS.TRAINING_PLANS),
     ...constraints,
     orderBy('startAt', 'desc')
   );
-  const snap = await getDocs(q);
+}
+
+export async function listTrainingPlans(
+  filter: ListTrainingPlansFilter = {}
+): Promise<TrainingPlan[]> {
+  const snap = await getDocs(buildTrainingPlansQuery(filter));
   return snap.docs.map((d) => ({ id: d.id, ...d.data() }) as TrainingPlan);
+}
+
+export function subscribeTrainingPlans(
+  filter: ListTrainingPlansFilter,
+  onData: (plans: TrainingPlan[]) => void,
+  onError?: (err: Error) => void
+): Unsubscribe {
+  return onSnapshot(
+    buildTrainingPlansQuery(filter),
+    (snap) => onData(snap.docs.map((d) => ({ id: d.id, ...d.data() }) as TrainingPlan)),
+    (err) => {
+      console.error('Training plans snapshot error:', err);
+      onError?.(err);
+    }
+  );
 }


### PR DESCRIPTION
## Summary
- \`useAmmunitionTemplates\`, \`useAmmunitionReports\`, \`useTrainingPlans\` now use direct client-SDK \`onSnapshot\` listeners instead of API-route refetch-per-mutation. Rules already allow authenticated read of these collections.
- Adds \`subscribeAmmunitionTemplates\`, \`subscribeAmmunitionReports(filter)\`, \`subscribeTrainingPlans(filter)\` to their respective services. Shared \`buildXQuery\` helper between list + subscribe paths.
- All mutators drop \`await refresh()\` — listener picks up writes automatically.
- \`refresh()\` retained as force-resync escape hatch on each hook.
- **Skipped**: \`usePermissionGrants\` (admin UI lists all grants but rules restrict client reads to own grants) and \`useAmmunitionReportRequests\` (API route applies server-side filtering).

## Test plan
- [x] \`npm run lint\` clean
- [x] \`npm test\` — 42 suites pass (701/701)
- [ ] \`npm run dev\` — ammunition templates/reports pages and training-plans page: mutate in tab A, confirm tab B updates without refresh
- [ ] Cold-mount paint from IndexedDB cache feels instant

🤖 Generated with [Claude Code](https://claude.com/claude-code)