### PR TITLE
perf(reads): fix category-order cost bomb, useUsers → onSnapshot

### DIFF
--- a/src/hooks/useUsers.ts
+++ b/src/hooks/useUsers.ts
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { db } from '@/lib/firebase';
-import { collection, getDocs, query } from 'firebase/firestore';
+import { collection, getDocs, onSnapshot } from 'firebase/firestore';
 import { FirestoreUserProfile } from '@/types/user';
 import { UserRole } from '@/types/equipment';
 import { ADMIN_CONFIG } from '@/constants/admin';
@@ -26,82 +26,79 @@ export interface UseUsersReturn {
   fetchUsers: (forceRefresh?: boolean) => Promise<void>;
 }
 
+function mapAndFilter(docs: Array<{ data(): FirestoreUserProfile }>): UserForEmail[] {
+  return docs
+    .map((d) => {
+      const data = d.data() as FirestoreUserProfile;
+      return {
+        uid: data.uid,
+        email: data.email,
+        fullName: `${data.firstName} ${data.lastName}`.trim(),
+        firstName: data.firstName,
+        lastName: data.lastName,
+        team: getTeamFromRole(data.role),
+        role: getRoleDisplayName(data.role),
+        rank: data.rank || 'לא מוגדר',
+        status: data.status || 'active',
+      } as UserForEmail;
+    })
+    .filter((user) => user.status === 'active')
+    .sort((a, b) => {
+      const lastNameCompare = a.lastName.localeCompare(b.lastName, 'he');
+      if (lastNameCompare !== 0) return lastNameCompare;
+      return a.firstName.localeCompare(b.firstName, 'he');
+    });
+}
+
 export function useUsers(): UseUsersReturn {
   const [users, setUsers] = useState<UserForEmail[]>([]);
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const fetchUsers = useCallback(async (forceRefresh: boolean = false) => {
-    // Skip fetch if we already have users and not forcing refresh
-    if (!forceRefresh && users.length > 0) {
-      console.log('🔍 Using cached users data...');
-      return;
-    }
-
+  // Listener-based. The previous hook had naive `users.length > 0` caching
+  // that broke after deletes. With onSnapshot the list stays correct under
+  // adds/removes/updates without explicit refetch, and persistent IndexedDB
+  // cache paints the initial state synchronously.
+  useEffect(() => {
     setLoading(true);
     setError(null);
+    const unsub = onSnapshot(
+      collection(db, ADMIN_CONFIG.FIRESTORE_USERS_COLLECTION),
+      (snap) => {
+        setUsers(mapAndFilter(snap.docs));
+        setLoading(false);
+      },
+      (err) => {
+        console.error('Users snapshot error:', err);
+        setError('שגיאה בטעינת רשימת המשתמשים');
+        setLoading(false);
+      }
+    );
+    return () => unsub();
+  }, []);
 
+  // Force-resync escape hatch — kept for API parity. Listener owns state in
+  // normal flow.
+  const fetchUsers = useCallback(async (_forceRefresh: boolean = false) => {
+    void _forceRefresh;
     try {
-      console.log('🔍 Fetching users from Firestore...');
-      
-      const usersCollection = collection(db, ADMIN_CONFIG.FIRESTORE_USERS_COLLECTION);
-      // Remove orderBy to avoid requiring composite index - we'll sort on frontend
-      const q = query(usersCollection);
-      
-      const querySnapshot = await getDocs(q);
-      
-      const fetchedUsers: UserForEmail[] = querySnapshot.docs
-        .map(doc => {
-          const data = doc.data() as FirestoreUserProfile;
-          
-          // Map the data to our simplified interface
-          return {
-            uid: data.uid,
-            email: data.email,
-            fullName: `${data.firstName} ${data.lastName}`.trim(),
-            firstName: data.firstName,
-            lastName: data.lastName,
-            team: getTeamFromRole(data.role), // Map role to team display
-            role: getRoleDisplayName(data.role),
-            rank: data.rank || 'לא מוגדר',
-            status: data.status || 'active'
-          };
-        })
-        .filter(user => user.status === 'active') // Only show active users
-        .sort((a, b) => {
-          // Sort by lastName first, then firstName (Hebrew locale)
-          const lastNameCompare = a.lastName.localeCompare(b.lastName, 'he');
-          if (lastNameCompare !== 0) return lastNameCompare;
-          return a.firstName.localeCompare(b.firstName, 'he');
-        });
-      
-      console.log(`✅ Fetched ${fetchedUsers.length} active users`);
-      setUsers(fetchedUsers);
-      
+      const snapshot = await getDocs(collection(db, ADMIN_CONFIG.FIRESTORE_USERS_COLLECTION));
+      setUsers(mapAndFilter(snapshot.docs));
     } catch (err) {
-      console.error('❌ Error fetching users:', err);
+      console.error('Error fetching users:', err);
       setError('שגיאה בטעינת רשימת המשתמשים');
-    } finally {
-      setLoading(false);
     }
-  }, [users.length]);
-
-  useEffect(() => {
-    fetchUsers();
-  }, [fetchUsers]);
+  }, []);
 
   return {
     users,
     loading,
     error,
-    fetchUsers
+    fetchUsers,
   };
 }
 
-// Helper function to map role to team display
 function getTeamFromRole(role: UserRole): string {
-  // For now, we'll derive team from role - this can be enhanced later
-  // to include actual team assignments from user profile
   switch (role) {
     case UserRole.COMMANDER:
     case UserRole.OFFICER:
@@ -119,7 +116,6 @@ function getTeamFromRole(role: UserRole): string {
   }
 }
 
-// Helper function to get role display name
 function getRoleDisplayName(role: UserRole): string {
   const roleDisplayMap: Record<UserRole, string> = {
     [UserRole.SOLDIER]: 'חייל',
@@ -128,8 +124,8 @@ function getRoleDisplayName(role: UserRole): string {
     [UserRole.SERGEANT]: 'סמל',
     [UserRole.OFFICER]: 'קצין',
     [UserRole.COMMANDER]: 'מפקד',
-    [UserRole.EQUIPMENT_MANAGER]: 'מנהל ציוד'
+    [UserRole.EQUIPMENT_MANAGER]: 'מנהל ציוד',
   };
-  
+
   return roleDisplayMap[role] || role.toString();
 }

--- a/src/lib/categories/repository.ts
+++ b/src/lib/categories/repository.ts
@@ -7,6 +7,8 @@ import {
   doc,
   getDocs,
   getDoc,
+  limit,
+  orderBy,
   query,
   where
 } from 'firebase/firestore';
@@ -278,32 +280,59 @@ export class CategoriesRepository {
   }
 
   /**
-   * Get next order number for categories (client SDK read)
+   * Get next order number for categories.
+   * Reads max(order)+1 via orderBy+limit(1) instead of scanning the whole
+   * collection. Safer than `snapshot.size` (which produces duplicate orders
+   * after deletes) and cheaper (1 doc read vs N).
    */
   static async getNextCategoryOrder(): Promise<number> {
     try {
-      const snapshot = await getDocs(collection(db, COLLECTIONS.CATEGORIES));
-      return snapshot.size;
+      const q = query(collection(db, COLLECTIONS.CATEGORIES), orderBy('order', 'desc'), limit(1));
+      const snapshot = await getDocs(q);
+      if (snapshot.empty) return 0;
+      const top = snapshot.docs[0].data() as { order?: number };
+      return (top.order ?? 0) + 1;
     } catch (error) {
-      console.log('Error getting category count, assuming 0:', error);
+      console.log('Error getting max category order, assuming 0:', error);
       return 0;
     }
   }
 
   /**
-   * Get next order number for subcategories in a category (client SDK read)
+   * Get next order number for subcategories in a category.
+   * Needs a composite index (parentCategoryId ASC, order DESC) to use the
+   * limited path; falls back to scanning the parent's subcategories if the
+   * index is missing.
    */
   static async getNextSubcategoryOrder(parentCategoryId: string): Promise<number> {
     try {
       const q = query(
         collection(db, COLLECTIONS.SUBCATEGORIES),
-        where('parentCategoryId', '==', parentCategoryId)
+        where('parentCategoryId', '==', parentCategoryId),
+        orderBy('order', 'desc'),
+        limit(1)
       );
       const snapshot = await getDocs(q);
-      return snapshot.size;
+      if (snapshot.empty) return 0;
+      const top = snapshot.docs[0].data() as { order?: number };
+      return (top.order ?? 0) + 1;
     } catch (error) {
-      console.log('Error getting subcategory count, assuming 0:', error);
-      return 0;
+      console.log('Error getting max subcategory order, falling back:', error);
+      try {
+        const q = query(
+          collection(db, COLLECTIONS.SUBCATEGORIES),
+          where('parentCategoryId', '==', parentCategoryId)
+        );
+        const snapshot = await getDocs(q);
+        let max = -1;
+        snapshot.forEach((d) => {
+          const o = (d.data() as { order?: number }).order ?? -1;
+          if (o > max) max = o;
+        });
+        return max + 1;
+      } catch {
+        return 0;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- \`CategoriesRepository.getNextCategoryOrder()\` was scanning the entire categories collection and returning \`snapshot.size\` (O(N) and broken after deletes). Replaced with \`orderBy('order','desc') + limit(1)\` — 1 doc read, correct under deletes.
- Same fix applied to \`getNextSubcategoryOrder()\` with a fallback path that only scans the parent's subcategories if the composite index \`(parentCategoryId ASC + order DESC)\` isn't yet built. Add that index to firestore.indexes.json in a follow-up after #133 lands.
- \`useUsers\` had naive \`users.length > 0\` caching that broke after user deletes (stale list silently survives). Converted to onSnapshot listener — persistent cache paints initial state, server deltas keep it current. Legacy \`fetchUsers()\` retained as escape hatch.

## Test plan
- [x] \`npm run lint\` clean
- [x] \`npm test\` — 42 suites pass (701/701)
- [ ] Create a category, delete it, create another — verify the second one gets a non-duplicate order
- [ ] User admin page: confirm list reflects deletes/role changes without manual refresh

## Follow-up
- Add \`subcategories: parentCategoryId ASC + order DESC\` composite index to firestore.indexes.json after #133 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)