### PR TITLE
fix(useUsers): type mapAndFilter param as QueryDocumentSnapshot[]

### DIFF
--- a/src/hooks/useUsers.ts
+++ b/src/hooks/useUsers.ts
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { db } from '@/lib/firebase';
-import { collection, getDocs, onSnapshot } from 'firebase/firestore';
+import { collection, getDocs, onSnapshot, type QueryDocumentSnapshot } from 'firebase/firestore';
 import { FirestoreUserProfile } from '@/types/user';
 import { UserRole } from '@/types/equipment';
 import { ADMIN_CONFIG } from '@/constants/admin';
@@ -26,7 +26,7 @@ export interface UseUsersReturn {
   fetchUsers: (forceRefresh?: boolean) => Promise<void>;
 }
 
-function mapAndFilter(docs: Array<{ data(): FirestoreUserProfile }>): UserForEmail[] {
+function mapAndFilter(docs: QueryDocumentSnapshot[]): UserForEmail[] {
   return docs
     .map((d) => {
       const data = d.data() as FirestoreUserProfile;


### PR DESCRIPTION
## Summary
Type-only hotfix for #137. \`mapAndFilter\` was typed against a structural shape that didn't match \`snap.docs\` (\`QueryDocumentSnapshot<DocumentData>[]\`). Lint passed but \`tsc\` (and thus \`next build\`) failed:

\`\`\`
Type 'QueryDocumentSnapshot<DocumentData, DocumentData>' is not assignable to type '{ data(): FirestoreUserProfile; }'.
\`\`\`

Param retyped to \`QueryDocumentSnapshot[]\`. Existing \`d.data() as FirestoreUserProfile\` cast inside preserves runtime behavior. No functional change.

## Test plan
- [x] \`npm run build\` clean
- [x] \`npm run lint\` clean
- [x] \`npm test\` — 42 suites pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)