### PR TITLE
perf(firestore): cleanup stale indexes + add missing composites

### DIFF
--- a/firebase/firestore.indexes.json
+++ b/firebase/firestore.indexes.json
@@ -207,6 +207,39 @@
       ]
     },
     {
+      "collectionGroup": "transferRequests",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "toUserId", "order": "ASCENDING" },
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "transferRequests",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "equipmentDocId", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "transferRequests",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "subcategories",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "parentCategoryId", "order": "ASCENDING" },
+        { "fieldPath": "order", "order": "DESCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "permissionGrants",
       "queryScope": "COLLECTION",
       "fields": [

--- a/scripts/diff-indexes.cjs
+++ b/scripts/diff-indexes.cjs
@@ -1,0 +1,38 @@
+const fs = require('fs');
+const path = require('path');
+
+const tmp = process.env.TEMP || process.env.TMP || '/tmp';
+const server = JSON.parse(fs.readFileSync(path.join(tmp, 'server-indexes.json'), 'utf8'));
+const local = JSON.parse(fs.readFileSync('firebase/firestore.indexes.json', 'utf8'));
+
+function norm(fields) {
+  return fields
+    .filter((f) => f.fieldPath !== '__name__')
+    .map((f) => (f.arrayConfig ? `${f.fieldPath}:CONTAINS` : `${f.fieldPath}:${f.order}`))
+    .join(',');
+}
+
+const serverEntries = server.map((i) => ({
+  collection: i.name.split('collectionGroups/')[1].split('/')[0],
+  key: norm(i.fields),
+}));
+const localEntries = local.indexes.map((i) => ({
+  collection: i.collectionGroup,
+  key: norm(i.fields),
+}));
+
+const fullKey = (e) => `${e.collection}|${e.key}`;
+
+const serverKeys = new Set(serverEntries.map(fullKey));
+const localKeys = new Set(localEntries.map(fullKey));
+
+const stale = serverEntries.filter((e) => !localKeys.has(fullKey(e)));
+const missing = localEntries.filter((e) => !serverKeys.has(fullKey(e)));
+
+console.log('STALE (server only, would be deleted by --force):');
+stale.forEach((s) => console.log(`  [${s.collection}] ${s.key}`));
+console.log('\nMISSING (local only, not yet on server):');
+missing.forEach((m) => console.log(`  [${m.collection}] ${m.key}`));
+console.log(
+  `\ntotals: server=${serverEntries.length}, local=${localEntries.length}, stale=${stale.length}, missing=${missing.length}`
+);


### PR DESCRIPTION
## Summary
Two follow-ups to #133:

**1) Drop 12 stale server-only indexes** (verified via new \`scripts/diff-indexes.cjs\`):
- 3× equipment lastReportUpdate (no caller filters on this field)
- 4× equipments (old collection name; code uses equipmentTemplates)
- 2× notifications recipientId (code uses userId)
- 1× EmailToUser (no such collection)
- 1× permissionGrants status+userId+expiresAtMs (wrong prefix order)
- 1× transferRequests equipmentDocId+status+createdAt (no live query matches)

**2) Add 4 missing composites** uncovered during cleanup audit:
- transferRequests: \`toUserId+status+createdAt DESC\` (getPendingTransferRequestsForUser)
- transferRequests: \`equipmentDocId+createdAt DESC\` (getEquipmentTransferRequests)
- transferRequests: \`status+createdAt DESC\` (getAllPendingTransferRequests)
- subcategories: \`parentCategoryId+order DESC\` (#137 follow-up — activates fast path)

\`scripts/diff-indexes.cjs\` is a diagnostic helper: read-only, dumps gcloud output, diffs against local JSON. Run via \`gcloud firestore indexes composite list --format=json > \$TEMP/server-indexes.json && node scripts/diff-indexes.cjs\`.

## Deploy
\`\`\`
firebase deploy --only firestore:indexes --force
\`\`\`
\`--force\` needed to delete the 12 stale; safety verified via diff.

## Tests
Config-only + diagnostic script — no runtime path introduced. Per \`feedback_tests_with_dev\`, exempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)