### PR TITLE
chore(soldier-status): drop dead legacy-cache branches in useSoldierStatus

### DIFF
--- a/docs/codebase/src/hooks/useSoldierStatus.md
+++ b/docs/codebase/src/hooks/useSoldierStatus.md
@@ -1,0 +1,46 @@
+# useSoldierStatus.ts
+
+**File:** `src/hooks/useSoldierStatus.ts`
+**Status:** Active
+
+## Purpose
+
+Loads + mutates the soldier-status roster against `/api/soldier-status`. Roster
+is the join of `users` ∪ `authorized_personnel` plus the optional status overlay.
+
+## Return Shape
+
+```typescript
+{
+  soldiers: Soldier[];
+  setSoldiers: (s: Soldier[]) => void;
+  originalSoldiers: Soldier[];
+  loading: boolean;
+  error: string | null;
+  lastUpdated: Date | null;
+  isRefreshing: boolean;
+  isUpdatingChanges: boolean;
+  fetchSoldiers: (forceRefresh?: boolean) => Promise<void>;
+  pushChangedStatuses: (changed: Soldier[]) => Promise<void>;
+}
+```
+
+## Caching
+
+The Service Worker runtime cache (offline-first Phase 3) covers
+`/api/soldier-status` for offline / fast paint. The legacy in-hook localStorage
+cache was retired in Phase 7 (PR #129); the SW + Firestore persistent cache
+layers are now authoritative. Do not reintroduce a hook-level TTL — that
+duplicates work the SW already does and reopens the staleness window
+deliberately closed by the migration.
+
+## Mutation
+
+`pushChangedStatuses` PUTs each changed soldier individually to
+`/api/soldier-status/[id]`. Small roster, low traffic — no batch endpoint.
+
+## Tests
+
+`src/hooks/__tests__/useSoldierStatus.test.tsx` covers mount-fetch, error
+surface, no-cache-between-mounts (regression guard for the dropped legacy
+cache branch), and `forceRefresh` flow.

--- a/src/hooks/__tests__/useSoldierStatus.test.tsx
+++ b/src/hooks/__tests__/useSoldierStatus.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * @jest-environment jsdom
+ */
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useSoldierStatus } from '../useSoldierStatus';
+import { apiFetch } from '@/lib/apiFetch';
+
+jest.mock('@/lib/apiFetch', () => ({
+  apiFetch: jest.fn(),
+}));
+
+const apiFetchMock = apiFetch as jest.MockedFunction<typeof apiFetch>;
+
+function jsonResponse(body: unknown, init: { ok?: boolean; status?: number } = {}) {
+  const ok = init.ok ?? true;
+  const status = init.status ?? (ok ? 200 : 500);
+  return {
+    ok,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+describe('useSoldierStatus', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('fetches the roster on mount and exposes mapped soldiers', async () => {
+    apiFetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        success: true,
+        soldiers: [
+          {
+            id: 'u1',
+            firstName: 'דוד',
+            lastName: 'לוי',
+            platoon: 'מסייעת',
+            status: 'בית',
+            isRegistered: true,
+            phoneNumber: '+972500000001',
+          },
+        ],
+      }),
+    );
+
+    const { result } = renderHook(() => useSoldierStatus());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(apiFetchMock).toHaveBeenCalledWith('/api/soldier-status');
+    expect(result.current.error).toBeNull();
+    expect(result.current.soldiers).toHaveLength(1);
+    expect(result.current.soldiers[0]).toMatchObject({
+      id: 'u1',
+      firstName: 'דוד',
+      lastName: 'לוי',
+      name: 'דוד לוי',
+      platoon: 'מסייעת',
+      status: 'בית',
+      isRegistered: true,
+      phoneNumber: '+972500000001',
+      isSelected: false,
+    });
+    expect(result.current.lastUpdated).toBeInstanceOf(Date);
+    expect(result.current.originalSoldiers).toEqual(result.current.soldiers);
+  });
+
+  it('falls back to platoon "מסייעת" when entry has no platoon', async () => {
+    apiFetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        success: true,
+        soldiers: [
+          { id: 'u2', firstName: 'אבי', lastName: 'כהן', status: 'משמר' },
+        ],
+      }),
+    );
+
+    const { result } = renderHook(() => useSoldierStatus());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.soldiers[0].platoon).toBe('מסייעת');
+  });
+
+  it('surfaces the server error on non-ok response and leaves soldiers empty', async () => {
+    apiFetchMock.mockResolvedValueOnce(
+      jsonResponse({ success: false, error: 'boom' }, { ok: false, status: 500 }),
+    );
+
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { result } = renderHook(() => useSoldierStatus());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error).toBe('boom');
+    expect(result.current.soldiers).toEqual([]);
+
+    consoleSpy.mockRestore();
+  });
+
+  it('does not consult any local cache between mounts — each mount hits the API', async () => {
+    apiFetchMock.mockResolvedValue(
+      jsonResponse({ success: true, soldiers: [] }),
+    );
+
+    const first = renderHook(() => useSoldierStatus());
+    await waitFor(() => expect(first.result.current.loading).toBe(false));
+    first.unmount();
+
+    const second = renderHook(() => useSoldierStatus());
+    await waitFor(() => expect(second.result.current.loading).toBe(false));
+
+    expect(apiFetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('forceRefresh flips isRefreshing on then off', async () => {
+    apiFetchMock.mockResolvedValueOnce(
+      jsonResponse({ success: true, soldiers: [] }),
+    );
+    const { result } = renderHook(() => useSoldierStatus());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    apiFetchMock.mockResolvedValueOnce(
+      jsonResponse({ success: true, soldiers: [] }),
+    );
+
+    await act(async () => {
+      await result.current.fetchSoldiers(true);
+    });
+
+    expect(result.current.isRefreshing).toBe(false);
+    expect(apiFetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/hooks/useSoldierStatus.ts
+++ b/src/hooks/useSoldierStatus.ts
@@ -2,8 +2,6 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { apiFetch } from '@/lib/apiFetch';
-import { getCachedData, setCachedData } from '@/lib/cache';
-import { formatCacheErrorDate } from '@/lib/dateUtils';
 import type { Soldier } from '@/app/types';
 import type { RosterEntry, SoldierStatus } from '@/types/soldierStatus';
 
@@ -33,9 +31,12 @@ function rosterToSoldier(entry: RosterEntry): Soldier {
  * Loads + mutates the soldier-status roster against `/api/soldier-status`.
  *
  * Roster is the join of `users` ∪ `authorized_personnel` plus the optional
- * status overlay; adding a soldier happens in the admin panel, not here. The
- * hook caches via the existing localStorage cache layer for offline / fast
- * paint and invalidates on every successful PUT.
+ * status overlay; adding a soldier happens in the admin panel, not here.
+ *
+ * Caching: the Service Worker runtime cache (offline-first Phase 3) covers
+ * `/api/soldier-status` for offline / fast paint. The legacy in-hook
+ * localStorage cache was retired in Phase 7 (PR #129); the SW + Firestore
+ * persistent cache layers are now authoritative.
  */
 export function useSoldierStatus() {
   const [soldiers, setSoldiers] = useState<Soldier[]>([]);
@@ -52,17 +53,6 @@ export function useSoldierStatus() {
       setError(null);
       if (forceRefresh) setIsRefreshing(true);
 
-      if (!forceRefresh) {
-        const cached = getCachedData();
-        if (cached) {
-          setSoldiers(cached.data);
-          setOriginalSoldiers(JSON.parse(JSON.stringify(cached.data)));
-          setLastUpdated(new Date(cached.timestamp));
-          setLoading(false);
-          return;
-        }
-      }
-
       const response = await apiFetch('/api/soldier-status');
       const result: ApiResponse = await response.json().catch(() => ({ success: false }));
       if (!response.ok || !result.success || !Array.isArray(result.soldiers)) {
@@ -70,28 +60,17 @@ export function useSoldierStatus() {
       }
 
       const soldiersData = result.soldiers.map(rosterToSoldier);
-      const now = Date.now();
-      setCachedData(soldiersData, now);
-      setLastUpdated(new Date(now));
+      setLastUpdated(new Date());
       setSoldiers(soldiersData);
       setOriginalSoldiers(JSON.parse(JSON.stringify(soldiersData)));
     } catch (err) {
       console.error('Error fetching soldiers:', err);
-      const cached = getCachedData();
-      if (cached && soldiers.length === 0) {
-        setSoldiers(cached.data);
-        setLastUpdated(new Date(cached.timestamp));
-        setError(
-          `שגיאה בטעינת נתונים חדשים. מציג נתונים שמורים מ-${formatCacheErrorDate(cached.timestamp)}`
-        );
-      } else {
-        setError(err instanceof Error ? err.message : 'שגיאה לא צפויה בטעינת הנתונים');
-      }
+      setError(err instanceof Error ? err.message : 'שגיאה לא צפויה בטעינת הנתונים');
     } finally {
       setLoading(false);
       if (forceRefresh) setIsRefreshing(false);
     }
-  }, [soldiers.length]);
+  }, []);
 
   useEffect(() => {
     fetchSoldiers();


### PR DESCRIPTION
## Summary
\`src/lib/cache.ts\` was deprecated in offline-first Phase 7 (PR #129): \`getCachedData\` always returns null, \`setCachedData\` is a no-op. The calls in \`useSoldierStatus.ts\` therefore exercised dead branches:

- \`fetchSoldiers\`: the \`if (!forceRefresh) { ... cached } \` early-return branch never fired.
- error path: the "fall back to cache + format-stale-banner" branch never fired either.

Dropped both branches + imports. SW runtime cache + Firestore persistent cache are now the only caching layers, as intended by the migration.

Originally a "TTL audit" follow-up from the Firestore read-reduction sweep. Turned out the cache it would TTL had already been gutted — change is hygiene, not perf.

## Tests
New \`src/hooks/__tests__/useSoldierStatus.test.tsx\` (5 tests):
- Mount-fetch happy path + mapped soldier shape
- Platoon fallback (\"מסייעת\")
- Server error surface
- **Regression guard**: no local cache consulted between mounts (each mount hits API)
- \`forceRefresh\` flow + \`isRefreshing\` state

42 → 43 suites, 701 → 706 tests, all pass. \`npm run build\` clean.

## Docs
New \`docs/codebase/src/hooks/useSoldierStatus.md\` — documents caching layers + warns against reintroducing a hook-level TTL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)