### PR TITLE
fix(pwa,equipment): SW update toast reloads reliably + equipment list spacing

### DIFF
--- a/docs/codebase/src/app/equipment/page.md
+++ b/docs/codebase/src/app/equipment/page.md
@@ -11,9 +11,15 @@ AuthGuard
   EquipmentErrorBoundary
     AppShell (mounts WelcomeModal if profile missing teamId/unitId)
       EquipmentPageContent
-        ├ PageHeader  (+ הוסף ציוד button → opens AddEquipmentWizard)
-        ├ EquipmentTabs (Self / Team / All — All gated by manager+)
-        ├ FilterBar    (search + status filter + category filter)
+        ├ PageHeader   (+ הוסף ציוד button → opens AddEquipmentWizard)
+        ├ EquipmentTabs (Self / Team / All — All gated by manager+; rounded card)
+        ├ ViewToggle    (active / archive — bug #25; sits *between* the tabs and
+        │                the filter card, separated by `mt-4 mb-2` for breathing
+        │                room. EquipmentTabs + FilterBar are independent cards,
+        │                NOT a glued top/bottom unit anymore — that was the
+        │                pre-#25 layout before ViewToggle was inserted between
+        │                them.)
+        ├ FilterBar     (search + status filter + category filter; rounded card)
         ├ EquipmentTable (or loading / error / empty state)
         └ BulkActionBar (sticky, surfaces when rows selected)
 ```

--- a/docs/codebase/src/components/equipment/EquipmentTabs.md
+++ b/docs/codebase/src/components/equipment/EquipmentTabs.md
@@ -12,3 +12,7 @@ Three-tab selector for the `/equipment` page: **Self / Team / All**.
 ## Why three tabs and not a filter
 
 Scope is a primary axis of the page (it changes both the data set the user expects and which actions make sense), so it sits on a tab strip rather than a dropdown. Status / search filters live separately so users can drill into a scope, not switch context.
+
+## Visual unit
+
+Container is a self-contained rounded card (`border border-neutral-200 bg-white rounded-xl`). It used to be `rounded-t-xl` (top-rounded only) so that `FilterBar` directly underneath could close the bottom with `rounded-b-xl`. After bug #25 inserted the active/archive `ViewToggle` between the two, the glued-card visual no longer made sense — both `EquipmentTabs` and `FilterBar` are now independent cards, separated by the ViewToggle row.

--- a/docs/codebase/src/components/pwa/ServiceWorkerUpdater.md
+++ b/docs/codebase/src/components/pwa/ServiceWorkerUpdater.md
@@ -14,9 +14,22 @@ installed and waiting. User-driven activation only — audit note M5.
 1. Mounts → `navigator.serviceWorker.register('/sw.js')`.
 2. Reads existing `reg.waiting`; subscribes to `updatefound` for future installs.
 3. When a waiting worker is present, renders an action banner.
-4. "Update now" → posts `{ type: 'SKIP_WAITING' }` to the waiting worker.
-5. `controllerchange` fires after the worker activates → page reloads.
+4. "Update now" → attaches a `statechange` listener to the waiting worker, then posts `{ type: 'SKIP_WAITING' }`.
+5. The listener fires when the worker reaches `'activated'` → page reloads.
 6. "Later" hides the banner locally; next page load picks up the waiting worker again.
+
+### Why `statechange` and not `controllerchange`
+
+`src/app/sw.ts` sets `clientsClaim: false` so the activated SW does NOT take
+over the currently-loaded document — `navigator.serviceWorker.controller`
+stays pointing at the old worker, so `controllerchange` never fires for this
+page. The previous implementation relied on `controllerchange` and the toast
+appeared to "never disappear after reload": the user clicked Update Now, no
+reload happened (because the event never fired), and a manual F5 re-read
+`reg.waiting` and re-rendered the toast. Listening to the waiting worker's
+own `statechange` is the canonical signal across browsers regardless of the
+claim policy. Regression test:
+`src/components/pwa/__tests__/ServiceWorkerUpdater.test.tsx`.
 
 ## Where it mounts
 
@@ -24,4 +37,5 @@ installed and waiting. User-driven activation only — audit note M5.
 
 ## Tests
 
-Manual flow documented in `docs/codebase/pwa-shell.md`. Automated Playwright coverage lands in Phase 5/8.
+- `src/components/pwa/__tests__/ServiceWorkerUpdater.test.tsx` — covers the regression: after SKIP_WAITING, reload fires only when the waiting worker reaches `'activated'`, and no global `controllerchange` listener is registered.
+- Manual end-to-end flow documented in `docs/codebase/pwa-shell.md`.

--- a/src/app/equipment/page.tsx
+++ b/src/app/equipment/page.tsx
@@ -237,6 +237,7 @@ function EquipmentPageContent() {
           setSelectedIds(new Set());
         }}
         archiveCount={archivedEquipment.length}
+        className="mt-4 mb-2"
       />
 
       <FilterBar
@@ -450,7 +451,7 @@ function FilterBar({
   // empty result if a user selects e.g. AVAILABLE while viewing the archive.
   const showStatusFilter = view === 'active';
   return (
-    <div className="bg-white rounded-b-xl border-x border-b border-neutral-200 p-3 mb-4 space-y-2">
+    <div className="bg-white rounded-xl border border-neutral-200 p-3 mb-4 space-y-2">
       <div className="relative">
         <Search className="absolute start-3 top-1/2 -translate-y-1/2 w-4 h-4 text-neutral-400" />
         <input
@@ -495,14 +496,20 @@ function ViewToggle({
   view,
   onChange,
   archiveCount,
+  className,
 }: {
   view: 'active' | 'archive';
   onChange: (v: 'active' | 'archive') => void;
   archiveCount: number;
+  className?: string;
 }) {
   const labels = TEXT_CONSTANTS.FEATURES.EQUIPMENT.ARCHIVE;
   return (
-    <div className="flex gap-2 mb-2" role="tablist" aria-label="equipment view">
+    <div
+      className={cn('flex gap-2', className ?? 'mb-2')}
+      role="tablist"
+      aria-label="equipment view"
+    >
       <button
         type="button"
         role="tab"

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -232,4 +232,15 @@
   select {
     font-size: 16px !important;
   }
+  /* iOS Safari decides auto-zoom from the *input's* font-size, not the
+     placeholder's. Pin placeholders to `text-sm` (0.875rem / 14px) so the
+     hint text matches the design language of non-input controls (e.g. the
+     Headless UI `Listbox` placeholder in `src/components/ui/Select.tsx`,
+     which renders inside a `<button>` and stays at 14px). Without this
+     override the placeholder inherits the 16px floor above and visually
+     dominates the form. */
+  input::placeholder,
+  textarea::placeholder {
+    font-size: 0.875rem !important;
+  }
 }

--- a/src/components/equipment/EquipmentTabs.tsx
+++ b/src/components/equipment/EquipmentTabs.tsx
@@ -24,7 +24,7 @@ export default function EquipmentTabs({ scope, onChange, user, counts }: Equipme
   if (showAll) tabs.push({ id: 'all', label: labels.ALL });
 
   return (
-    <div className="border-b border-neutral-200 bg-white rounded-t-xl">
+    <div className="border border-neutral-200 bg-white rounded-xl">
       <nav className="flex" role="tablist" aria-label="Equipment scope">
         {tabs.map((t) => {
           const active = t.id === scope;

--- a/src/components/pwa/ServiceWorkerUpdater.tsx
+++ b/src/components/pwa/ServiceWorkerUpdater.tsx
@@ -7,9 +7,19 @@ import { TEXT_CONSTANTS } from '@/constants/text';
 /**
  * Mounts the service worker registration and surfaces an update banner when a
  * new SW is installed and waiting. The SW (src/app/sw.ts) is built with
- * `skipWaiting: false`, so the waiting worker only activates after the user
- * accepts. We post `{ type: 'SKIP_WAITING' }` to the waiting worker, then
- * reload on `controllerchange`.
+ * `skipWaiting: false` AND `clientsClaim: false`, so the waiting worker only
+ * activates after the user accepts AND it does not auto-claim already-open
+ * tabs. We post `{ type: 'SKIP_WAITING' }`, listen for the worker's own
+ * `statechange` to `'activated'`, and reload from there.
+ *
+ * Why not `controllerchange`: with `clientsClaim: false`, after SKIP_WAITING
+ * the new SW activates but does NOT take over the current document's
+ * controller. `navigator.serviceWorker.controller` stays pointed at the old
+ * SW, so `controllerchange` never fires for this page and the original
+ * implementation left the toast pinned forever (the user reloaded, but the
+ * waiting worker was still waiting because `controllerchange` only signals a
+ * controller swap — not activation). The waiting worker's `statechange`
+ * fires reliably across browsers and is the canonical signal here.
  *
  * Audit note M5 (docs/spec/offline-first.md). Never auto-activate the new SW
  * — open tabs with in-flight optimistic state would be taken over mid-session.
@@ -44,20 +54,22 @@ export default function ServiceWorkerUpdater() {
         console.warn('[sw] registration failed', err);
       });
 
-    const onControllerChange = () => {
-      window.location.reload();
-    };
-    navigator.serviceWorker.addEventListener('controllerchange', onControllerChange);
-
     return () => {
       cleanup?.();
-      navigator.serviceWorker.removeEventListener('controllerchange', onControllerChange);
     };
   }, []);
 
   const onUpdateNow = () => {
     if (!waitingWorker) return;
-    waitingWorker.postMessage({ type: 'SKIP_WAITING' });
+    const worker = waitingWorker;
+    const onState = () => {
+      if (worker.state === 'activated') {
+        worker.removeEventListener('statechange', onState);
+        window.location.reload();
+      }
+    };
+    worker.addEventListener('statechange', onState);
+    worker.postMessage({ type: 'SKIP_WAITING' });
   };
 
   const onDismiss = () => setWaitingWorker(null);

--- a/src/components/pwa/__tests__/ServiceWorkerUpdater.test.tsx
+++ b/src/components/pwa/__tests__/ServiceWorkerUpdater.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * Regression coverage for the bug where the update toast never disappeared
+ * after the user clicked "Update Now": the original implementation listened
+ * to `controllerchange` to trigger the reload, but with `clientsClaim: false`
+ * (set in `src/app/sw.ts`) the new SW activates without claiming the current
+ * document, so `controllerchange` never fires for this page and the reload
+ * never happens. Fix: listen to the waiting worker's own `statechange` for
+ * `'activated'` and reload from there.
+ */
+import React from 'react';
+import { act, render, screen } from '@testing-library/react';
+import ServiceWorkerUpdater from '../ServiceWorkerUpdater';
+
+type Listener = (this: unknown, ev: Event) => unknown;
+
+class FakeWorker extends EventTarget {
+  state: 'installing' | 'installed' | 'activating' | 'activated' = 'installed';
+  postMessage = jest.fn<void, [unknown]>();
+
+  transitionTo(state: FakeWorker['state']) {
+    this.state = state;
+    this.dispatchEvent(new Event('statechange'));
+  }
+}
+
+class FakeRegistration extends EventTarget {
+  installing: FakeWorker | null = null;
+  waiting: FakeWorker | null;
+  active: FakeWorker | null = null;
+
+  constructor(opts: { waiting?: FakeWorker | null } = {}) {
+    super();
+    this.waiting = opts.waiting ?? null;
+  }
+}
+
+describe('ServiceWorkerUpdater', () => {
+  const originalServiceWorker = navigator.serviceWorker;
+  const originalLocation = window.location;
+  let reload: jest.Mock;
+  let registration: FakeRegistration;
+  let swListeners: Map<string, Listener[]>;
+
+  beforeEach(() => {
+    reload = jest.fn();
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: { ...originalLocation, reload },
+    });
+
+    registration = new FakeRegistration();
+    swListeners = new Map();
+
+    Object.defineProperty(navigator, 'serviceWorker', {
+      configurable: true,
+      value: {
+        register: jest.fn().mockResolvedValue(registration),
+        addEventListener: (event: string, listener: Listener) => {
+          const list = swListeners.get(event) ?? [];
+          list.push(listener);
+          swListeners.set(event, list);
+        },
+        removeEventListener: (event: string, listener: Listener) => {
+          const list = swListeners.get(event) ?? [];
+          swListeners.set(event, list.filter((l) => l !== listener));
+        },
+        controller: null,
+      },
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(navigator, 'serviceWorker', {
+      configurable: true,
+      value: originalServiceWorker,
+    });
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: originalLocation,
+    });
+    jest.clearAllMocks();
+  });
+
+  async function flushPromises() {
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
+
+  it('reloads when the waiting worker transitions to activated after SKIP_WAITING', async () => {
+    const waiting = new FakeWorker();
+    waiting.state = 'installed';
+    registration.waiting = waiting;
+
+    render(<ServiceWorkerUpdater />);
+    await flushPromises();
+
+    // Toast is up.
+    const updateBtn = await screen.findByRole('button', { name: /עדכן עכשיו/ });
+
+    await act(async () => {
+      updateBtn.click();
+    });
+
+    expect(waiting.postMessage).toHaveBeenCalledWith({ type: 'SKIP_WAITING' });
+    expect(reload).not.toHaveBeenCalled();
+
+    // Simulate the browser activating the new SW. Without the fix, no reload
+    // would happen here because `controllerchange` never fires for the
+    // current document under `clientsClaim: false`.
+    await act(async () => {
+      waiting.transitionTo('activating');
+    });
+    expect(reload).not.toHaveBeenCalled();
+
+    await act(async () => {
+      waiting.transitionTo('activated');
+    });
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT register a global controllerchange listener (relies on statechange instead)', async () => {
+    render(<ServiceWorkerUpdater />);
+    await flushPromises();
+    expect(swListeners.get('controllerchange')?.length ?? 0).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Two unrelated UI bugs, bundled per `feedback_bug_workflow`.

### 1) PWA update toast never disappeared

- **Symptom:** user saw a black toast saying *"new version available — the page will reload"*. Clicking *Update Now* did nothing visible, and a manual F5 brought the same toast back.
- **Root cause:** `src/app/sw.ts` is `clientsClaim: false`, so after `SKIP_WAITING` the activated SW does NOT claim the current document — `navigator.serviceWorker.controller` stays on the old worker and `controllerchange` never fires. The original implementation relied solely on that event for reload, so reload never happened.
- **Fix:** after posting `SKIP_WAITING`, listen to the waiting worker's own `statechange` for `'activated'` and reload from there. The global `controllerchange` listener is removed — it was never the right primitive.
- **Bonus:** docs (`docs/codebase/src/components/pwa/ServiceWorkerUpdater.md`) now explain *why* `statechange` and not `controllerchange`.

### 2) Equipment page spacing

- **Symptom:** the active/archive `ViewToggle` (added by bug #25) sat flush against `EquipmentTabs` above it and `FilterBar` below it; no visual breathing room. The search input's placeholder rendered ~16px on mobile (inherited from the bug #23 anti-iOS-zoom floor), much bigger than the 14px `text-sm` placeholder in the filter dropdowns next to it.
- **Fixes:**
  - `EquipmentTabs` container `rounded-t-xl` → `rounded-xl` + full border (was a half-card glued to FilterBar's `rounded-b-xl` — that pairing made no sense once ViewToggle was wedged between them).
  - `FilterBar` container likewise becomes a full rounded card.
  - `ViewToggle` accepts an optional `className`; the page passes `mt-4 mb-2` so it sits between the two cards with clear vertical space.
  - `globals.css`: scope `::placeholder` font-size back to `0.875rem` on touch viewports. iOS Safari decides auto-zoom from the *input's* font-size, NOT the placeholder's, so the 16px floor on the input stays — bug #23 remains fixed.

## Test plan

- [x] `npm run lint` — clean.
- [x] `npx tsc --noEmit` — no new errors (pre-existing TS errors in unrelated test files only).
- [x] `npm test` — 45 suites / 725 tests pass.
- [x] New unit suite `src/components/pwa/__tests__/ServiceWorkerUpdater.test.tsx` covers the regression: reload fires only when the waiting worker reaches `'activated'`, and no global `controllerchange` listener is registered.
- [ ] Manual QA on mobile + desktop: trigger a SW update (or stub one in dev tools), confirm toast disappears after *Update Now* and the page reloads. Confirm Equipment page padding looks right on phone + laptop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)