### PR TITLE
fix(users-tab): show users.teamId instead of role-bucket fallback

### DIFF
--- a/docs/codebase/src/hooks/useUsersAndPersonnel.md
+++ b/docs/codebase/src/hooks/useUsersAndPersonnel.md
@@ -33,7 +33,13 @@ Each `UserWithRegistration` field uses `users` first, falling back to `authorize
 | `status` | `users.status` → `authorized_personnel.status` → `'active'` |
 | `registered` | `users` doc present AND `authorized_personnel.registered !== false` |
 
-`roleDisplay` and `team` are derived from `role` via the in-file lookup tables. The team mapping is a placeholder (matches the prior `useUsers` behavior) until team resolution is wired through `FirestoreUserProfile.teamId`.
+`roleDisplay` is derived from `role` via the `ROLE_DISPLAY` lookup table.
+
+`team` resolves through `resolveTeam(teamId, role)`:
+1. If the joined `users.teamId` is set and non-blank, that value is used verbatim (matches `systemConfig/main.teams`).
+2. Otherwise — including every unregistered personnel row, since `authorized_personnel` docs don't carry a team field today — falls back to a role-bucket via `TEAM_FROM_ROLE` (e.g. SOLDIER → `כללי`, TEAM_LEADER → `מפקדי צוות`).
+
+Regression coverage in `src/hooks/__tests__/useUsersAndPersonnel.test.tsx`. The bug fixed there: the original implementation called `teamFromRole(role)` unconditionally, so every soldier with a real `teamId` rendered as `כללי` in the management UsersTab.
 
 ## Sort
 

--- a/src/hooks/__tests__/useUsersAndPersonnel.test.tsx
+++ b/src/hooks/__tests__/useUsersAndPersonnel.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Regression guard: the management UsersTab `team` column showed "כללי"
+ * (general — the SOLDIER role-bucket fallback) for every soldier even when
+ * the underlying `users.teamId` was populated. Root cause was a blind call
+ * to `teamFromRole(role)` that ignored the real Firestore field. This hook
+ * now prefers `userDoc.teamId` / `data.teamId` and only falls back to the
+ * role bucket when the field is missing/blank.
+ */
+import { renderHook, waitFor } from '@testing-library/react';
+import { useUsersAndPersonnel } from '../useUsersAndPersonnel';
+import { UserRole } from '@/types/equipment';
+
+const mockGetDocs = jest.fn();
+
+jest.mock('firebase/firestore', () => ({
+  collection: jest.fn(() => ({ id: 'col' })),
+  query: jest.fn((c) => c),
+  getDocs: (...args: unknown[]) => mockGetDocs(...args),
+}));
+
+jest.mock('@/lib/firebase', () => ({
+  db: {},
+}));
+
+function fakeSnapshot(docs: Array<{ id: string; data: Record<string, unknown> }>) {
+  return {
+    docs: docs.map((d) => ({ id: d.id, data: () => d.data })),
+  };
+}
+
+describe('useUsersAndPersonnel — team resolution', () => {
+  beforeEach(() => {
+    mockGetDocs.mockReset();
+  });
+
+  it('uses users.teamId when present (registered user)', async () => {
+    const usersSnap = fakeSnapshot([
+      {
+        id: 'u1',
+        data: {
+          uid: 'u1',
+          email: 'a@b.com',
+          firstName: 'דנה',
+          lastName: 'כהן',
+          phoneNumber: '+972500000001',
+          rank: 'רב טוראי',
+          role: UserRole.SOLDIER,
+          militaryPersonalNumberHash: 'h1',
+          teamId: 'מסייעת א',
+          status: 'active',
+        },
+      },
+    ]);
+    const personnelSnap = fakeSnapshot([
+      {
+        id: 'h1',
+        data: {
+          firstName: 'דנה',
+          lastName: 'כהן',
+          militaryPersonalNumberHash: 'h1',
+          approvedRole: UserRole.SOLDIER,
+          registered: true,
+          status: 'active',
+        },
+      },
+    ]);
+    mockGetDocs.mockResolvedValueOnce(usersSnap).mockResolvedValueOnce(personnelSnap);
+
+    const { result } = renderHook(() => useUsersAndPersonnel());
+    await waitFor(() => expect(result.current.rows).toHaveLength(1));
+
+    expect(result.current.rows[0].team).toBe('מסייעת א');
+  });
+
+  it('falls back to the role-bucket when teamId is empty', async () => {
+    const usersSnap = fakeSnapshot([
+      {
+        id: 'u2',
+        data: {
+          uid: 'u2',
+          email: 'b@c.com',
+          firstName: 'נועה',
+          lastName: 'לוי',
+          phoneNumber: '+972500000002',
+          rank: 'טוראי',
+          role: UserRole.SOLDIER,
+          militaryPersonalNumberHash: 'h2',
+          teamId: '   ', // blank → fallback
+          status: 'active',
+        },
+      },
+    ]);
+    const personnelSnap = fakeSnapshot([
+      {
+        id: 'h2',
+        data: {
+          firstName: 'נועה',
+          lastName: 'לוי',
+          militaryPersonalNumberHash: 'h2',
+          approvedRole: UserRole.SOLDIER,
+          registered: true,
+          status: 'active',
+        },
+      },
+    ]);
+    mockGetDocs.mockResolvedValueOnce(usersSnap).mockResolvedValueOnce(personnelSnap);
+
+    const { result } = renderHook(() => useUsersAndPersonnel());
+    await waitFor(() => expect(result.current.rows).toHaveLength(1));
+
+    expect(result.current.rows[0].team).toBe('כללי');
+  });
+
+  it('unregistered personnel row falls back to role-bucket (no teamId on personnel docs)', async () => {
+    const usersSnap = fakeSnapshot([]);
+    const personnelSnap = fakeSnapshot([
+      {
+        id: 'h3',
+        data: {
+          firstName: 'יואב',
+          lastName: 'מזרחי',
+          militaryPersonalNumberHash: 'h3',
+          approvedRole: UserRole.TEAM_LEADER,
+          registered: false,
+          status: 'active',
+        },
+      },
+    ]);
+    mockGetDocs.mockResolvedValueOnce(usersSnap).mockResolvedValueOnce(personnelSnap);
+
+    const { result } = renderHook(() => useUsersAndPersonnel());
+    await waitFor(() => expect(result.current.rows).toHaveLength(1));
+
+    expect(result.current.rows[0].team).toBe('מפקדי צוות');
+    expect(result.current.rows[0].registered).toBe(false);
+  });
+});

--- a/src/hooks/useUsersAndPersonnel.ts
+++ b/src/hooks/useUsersAndPersonnel.ts
@@ -60,6 +60,10 @@ const ROLE_DISPLAY: Record<UserRole, string> = {
   [UserRole.EQUIPMENT_MANAGER]: 'מנהל ציוד',
 };
 
+// Role-bucket fallback used when a user has no `teamId` set on their Firestore
+// doc. Real team assignments live in `users.teamId` and are sourced from
+// `systemConfig/main.teams`. Personnel docs (`authorized_personnel`) have no
+// team field today, so unregistered rows always fall back to this bucket.
 const TEAM_FROM_ROLE: Record<UserRole, string> = {
   [UserRole.SOLDIER]: 'כללי',
   [UserRole.TEAM_LEADER]: 'מפקדי צוות',
@@ -78,6 +82,12 @@ function roleDisplay(role: UserRole | undefined): string {
 function teamFromRole(role: UserRole | undefined): string {
   if (!role) return TEAM_FROM_ROLE[UserRole.SOLDIER];
   return TEAM_FROM_ROLE[role] ?? 'כללי';
+}
+
+function resolveTeam(teamId: string | undefined | null, role: UserRole | undefined): string {
+  const trimmed = (teamId ?? '').trim();
+  if (trimmed) return trimmed;
+  return teamFromRole(role);
 }
 
 export function useUsersAndPersonnel(): UseUsersAndPersonnelReturn {
@@ -130,7 +140,7 @@ export function useUsersAndPersonnel(): UseUsersAndPersonnelReturn {
           rank: userDoc?.rank || personnel.rank || 'לא מוגדר',
           role,
           roleDisplay: roleDisplay(role),
-          team: teamFromRole(role),
+          team: resolveTeam(userDoc?.teamId, role),
           status: userDoc?.status ?? personnel.status ?? 'active',
           registered,
         });
@@ -152,7 +162,7 @@ export function useUsersAndPersonnel(): UseUsersAndPersonnelReturn {
           rank: data.rank || 'לא מוגדר',
           role,
           roleDisplay: roleDisplay(role),
-          team: teamFromRole(role),
+          team: resolveTeam(data.teamId, role),
           status: data.status ?? 'active',
           registered: true,
         });


### PR DESCRIPTION
## Symptom

In *Management → Users*, every soldier rendered with team **"כללי"** (general — the SOLDIER role-bucket label). Same false bucketing for every other role: TEAM_LEADER → \"מפקדי צוות\", OFFICER → \"מטה\", etc. — regardless of the actual `teamId` stored on each user's Firestore doc.

## Root cause

`useUsersAndPersonnel` populated the `team` field with `teamFromRole(role)` unconditionally. The canonical team value (`FirestoreUserProfile.teamId`, sourced from `systemConfig/main.teams` and written during registration via `WelcomeModal`) was never read.

## Fix

New `resolveTeam(teamId, role)` helper:
1. If `users.teamId` is set and non-blank, use it verbatim.
2. Otherwise fall back to the role-bucket (the prior behavior). This still applies to every unregistered personnel row, since `authorized_personnel` docs don't carry a team field today.

Both code paths in the hook (the personnel-snap join and the users-only orphan branch) now go through `resolveTeam`.

## Scope

`useUsers.ts` deliberately **not touched** — its `getTeamFromRole` serves `EmailTab` / `CustomUserSelectionModal` / ammunition consumers where `team` is really a role-group bucket for email blasts, not the soldier's actual team. Renaming or merging that semantic is a separate cleanup.

## Test plan

- [x] `npm run lint` clean.
- [x] `npm test` — 46 suites / 728 tests pass, including new `src/hooks/__tests__/useUsersAndPersonnel.test.tsx` covering all three branches (real `teamId`, blank `teamId` fallback, unregistered personnel fallback).
- [ ] Manual: open *Management → Users*, expand a soldier card, confirm the team field shows their real team (matches what `WelcomeModal` would have written), not \"כללי\".

🤖 Generated with [Claude Code](https://claude.com/claude-code)