### PR TITLE
fix(sw-updater): toast no longer clips off the left edge on mobile in RTL

### DIFF
--- a/docs/codebase/src/components/pwa/ServiceWorkerUpdater.md
+++ b/docs/codebase/src/components/pwa/ServiceWorkerUpdater.md
@@ -39,3 +39,15 @@ claim policy. Regression test:
 
 - `src/components/pwa/__tests__/ServiceWorkerUpdater.test.tsx` — covers the regression: after SKIP_WAITING, reload fires only when the waiting worker reaches `'activated'`, and no global `controllerchange` listener is registered.
 - Manual end-to-end flow documented in `docs/codebase/pwa-shell.md`.
+
+## Positioning
+
+Container: `fixed bottom-6 inset-x-4 mx-auto max-w-md ...`. The earlier
+`start-1/2 -translate-x-1/2 w-[calc(100%-2rem)]` combination clipped the
+toast off the left edge on mobile in `dir="rtl"`: `start-1/2` resolves to
+`right: 50%`, then `-translate-x-1/2` is direction-neutral (`translateX(-50%)`),
+so the element's center landed *left* of viewport center and a nearly-full
+viewport width spilled off the left edge — hiding the "Update now" button.
+The `inset-x-4 mx-auto max-w-md` pattern anchors both sides with a 16px
+gutter and centers between them, so the layout is symmetric in RTL and LTR
+and bounded on mobile.

--- a/src/components/pwa/ServiceWorkerUpdater.tsx
+++ b/src/components/pwa/ServiceWorkerUpdater.tsx
@@ -84,7 +84,7 @@ export default function ServiceWorkerUpdater() {
           transition={{ duration: 0.2 }}
           role="status"
           aria-live="polite"
-          className="fixed bottom-6 start-1/2 -translate-x-1/2 z-[10000] max-w-md w-[calc(100%-2rem)] bg-neutral-900 text-white rounded-2xl shadow-medium p-4 flex items-start gap-3"
+          className="fixed bottom-6 inset-x-4 mx-auto max-w-md z-[10000] bg-neutral-900 text-white rounded-2xl shadow-medium p-4 flex items-start gap-3"
         >
           <div className="flex-1">
             <div className="font-semibold text-sm">


### PR DESCRIPTION
## Symptom

On mobile in Hebrew (`dir=\"rtl\"`), the *new version available* update banner clipped off the left side of the viewport. The "Update now" button sat outside the screen and could not be tapped. Desktop rendered fine — the toast was narrow enough that the mis-centered position still fit.

## Root cause

```
fixed bottom-6 start-1/2 -translate-x-1/2 w-[calc(100%-2rem)]
```

- `start-1/2` is RTL-aware → resolves to `right: 50%` under `dir=\"rtl\"`.
- `-translate-x-1/2` is **not** RTL-aware → always `transform: translateX(-50%)`.
- Net: right edge at horizontal 50%, shifted left by half the toast's width → center lands *left* of viewport center.
- With `w-[calc(100%-2rem)]` (nearly full viewport width), the left portion of the toast spilled past the viewport edge, hiding the action buttons.

## Fix

```
fixed bottom-6 inset-x-4 mx-auto max-w-md
```

- `inset-x-4` anchors both edges 16px from the viewport (direction-neutral).
- `max-w-md` caps the toast at 28rem on desktop.
- `mx-auto` centers between the gutters.

Symmetric in RTL + LTR, bounded on mobile, no `translateX` math needed.

## Test plan

- [x] `npm run lint` clean.
- [ ] Mobile RTL: banner visible end-to-end, both buttons tappable.
- [ ] Desktop RTL/LTR: banner stays centered + capped at `max-w-md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)