### PR TITLE
fix(rtl): drop text-end on registration inputs (same bug class as login modal / SW toast)

### DIFF
--- a/src/components/registration/AccountDetailsStep.tsx
+++ b/src/components/registration/AccountDetailsStep.tsx
@@ -97,8 +97,8 @@ export default function AccountDetailsStep({
                 spellCheck={false}
                 value={formData.email}
                 onChange={(e) => handleInputChange('email', e.target.value)}
-                className={`w-full px-4 py-2.5 border-2 rounded-xl focus:ring-2 outline-none transition-all
-                         text-end text-neutral-800 bg-neutral-50 focus:bg-white placeholder-neutral-500 ps-12 ${
+                className={`w-full ps-11 pe-4 py-2.5 border-2 rounded-xl focus:ring-2 outline-none transition-all
+                         text-neutral-800 bg-neutral-50 focus:bg-white placeholder-neutral-500 ${
                   validationErrors.email && formData.email
                     ? 'border-danger-500 focus:border-danger-500 focus:ring-danger-500'
                     : 'border-neutral-200 focus:border-info-500 focus:ring-info-500'
@@ -106,7 +106,7 @@ export default function AccountDetailsStep({
                 placeholder={TEXT_CONSTANTS.AUTH.EMAIL_PLACEHOLDER_REGISTRATION}
                 data-testid="email-input"
               />
-              <div className="absolute start-3 top-1/2 transform -translate-y-1/2">
+              <div className="pointer-events-none absolute start-3 top-1/2 transform -translate-y-1/2">
                 <svg className="w-5 h-5 text-neutral-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
                         d="M16 12a4 4 0 10-8 0 4 4 0 008 0zm0 0v1.5a2.5 2.5 0 005 0V12a9 9 0 10-9 9m4.5-1.206a8.959 8.959 0 01-4.5 1.207" />
@@ -116,7 +116,7 @@ export default function AccountDetailsStep({
             
             {/* Email Error Message */}
             {validationErrors.email && formData.email && (
-              <p className="text-xs text-danger-600 text-end px-1" data-testid="email-error">
+              <p className="text-xs text-danger-600 px-1" data-testid="email-error">
                 {validationErrors.email}
               </p>
             )}
@@ -132,8 +132,8 @@ export default function AccountDetailsStep({
                 spellCheck={false}
                 value={formData.password}
                 onChange={(e) => handleInputChange('password', e.target.value)}
-                className={`w-full px-4 py-2.5 border-2 rounded-xl focus:ring-2 outline-none transition-all
-                         text-end text-neutral-800 bg-neutral-50 focus:bg-white placeholder-neutral-500 pe-12 ps-12 ${
+                className={`w-full ps-12 pe-12 py-2.5 border-2 rounded-xl focus:ring-2 outline-none transition-all
+                         text-neutral-800 bg-neutral-50 focus:bg-white placeholder-neutral-500 ${
                   validationErrors.password && formData.password
                     ? 'border-danger-500 focus:border-danger-500 focus:ring-danger-500'
                     : 'border-neutral-200 focus:border-info-500 focus:ring-info-500'
@@ -181,7 +181,7 @@ export default function AccountDetailsStep({
                   {showPasswordTooltip && (
                     <div className="absolute bottom-full start-0 mb-2 w-64 bg-neutral-800 text-white text-xs rounded-lg p-3 z-10 shadow-lg">
                       <div className="text-center font-semibold mb-2">דרישות סיסמה:</div>
-                      <ul className="text-end space-y-1">
+                      <ul className="space-y-1">
                         <li>• לפחות 8 תווים</li>
                         <li>• אות גדולה (A-Z)</li>
                         <li>• אות קטנה (a-z)</li>
@@ -198,7 +198,7 @@ export default function AccountDetailsStep({
             
             {/* Password Error Message */}
             {validationErrors.password && formData.password && (
-              <p className="text-xs text-danger-600 text-end px-1" data-testid="password-error">
+              <p className="text-xs text-danger-600 px-1" data-testid="password-error">
                 {validationErrors.password}
               </p>
             )}
@@ -220,7 +220,7 @@ export default function AccountDetailsStep({
                 
                 data-testid="consent-checkbox"
               />
-              <label htmlFor="consent" className="text-sm text-neutral-700 text-end leading-5">
+              <label htmlFor="consent" className="text-sm text-neutral-700 leading-5">
                 * אני מסכים/ה ל
                 <button
                   type="button"
@@ -236,7 +236,7 @@ export default function AccountDetailsStep({
           {/* Submission error from parent (linkEmailPassword / register API) */}
           {submitError && !isSubmitting && (
             <p
-              className="text-xs text-danger-600 text-end px-1"
+              className="text-xs text-danger-600 px-1"
               data-testid="account-submit-error"
               role="alert"
             >

--- a/src/components/registration/PersonalDetailsStep.tsx
+++ b/src/components/registration/PersonalDetailsStep.tsx
@@ -93,7 +93,7 @@ export default function PersonalDetailsStep({
               value={formData.firstName}
               onChange={(e) => handleInputChange('firstName', e.target.value)}
               className={`w-full h-10 px-3 py-0 border-2 rounded-lg focus:ring-2 outline-none transition-all
-                       text-end text-neutral-800 bg-white text-sm ${
+                       text-neutral-800 bg-white text-sm ${
                 validationErrors.firstName && formData.firstName
                   ? 'border-danger-500 focus:border-danger-500 focus:ring-danger-500'
                   : 'border-neutral-200 focus:border-info-500 focus:ring-info-500'
@@ -104,7 +104,7 @@ export default function PersonalDetailsStep({
             
             {/* First Name Error Message */}
             {validationErrors.firstName && formData.firstName && (
-              <p className="text-xs text-danger-600 text-end px-1" data-testid="first-name-error">
+              <p className="text-xs text-danger-600 px-1" data-testid="first-name-error">
                 {validationErrors.firstName}
               </p>
             )}
@@ -117,7 +117,7 @@ export default function PersonalDetailsStep({
               value={formData.lastName}
               onChange={(e) => handleInputChange('lastName', e.target.value)}
               className={`w-full h-10 px-3 py-0 border-2 rounded-lg focus:ring-2 outline-none transition-all
-                       text-end text-neutral-800 bg-white text-sm ${
+                       text-neutral-800 bg-white text-sm ${
                 validationErrors.lastName && formData.lastName
                   ? 'border-danger-500 focus:border-danger-500 focus:ring-danger-500'
                   : 'border-neutral-200 focus:border-info-500 focus:ring-info-500'
@@ -128,7 +128,7 @@ export default function PersonalDetailsStep({
             
             {/* Last Name Error Message */}
             {validationErrors.lastName && formData.lastName && (
-              <p className="text-xs text-danger-600 text-end px-1" data-testid="last-name-error">
+              <p className="text-xs text-danger-600 px-1" data-testid="last-name-error">
                 {validationErrors.lastName}
               </p>
             )}
@@ -161,7 +161,7 @@ export default function PersonalDetailsStep({
                 className="!h-10 !px-3 !py-0 !rounded-lg !text-sm !border-2 !border-neutral-200"
               />
               {validationErrors.gender && formData.gender && (
-                <p className="text-xs text-danger-600 text-end px-1" data-testid="gender-error">
+                <p className="text-xs text-danger-600 px-1" data-testid="gender-error">
                   {validationErrors.gender}
                 </p>
               )}
@@ -191,7 +191,7 @@ export default function PersonalDetailsStep({
                 data-testid="birthdate-input"
               />
               {validationErrors.birthdate && formData.birthdate && (
-                <p className="text-xs text-danger-600 text-end px-1" data-testid="birthdate-error">
+                <p className="text-xs text-danger-600 px-1" data-testid="birthdate-error">
                   {validationErrors.birthdate}
                 </p>
               )}

--- a/src/components/registration/RegistrationDetailsStep.tsx
+++ b/src/components/registration/RegistrationDetailsStep.tsx
@@ -135,7 +135,7 @@ export default function RegistrationDetailsStep({
                 value={firstName}
                 readOnly
                 className="w-full px-4 py-3 border-2 border-neutral-200 rounded-xl bg-neutral-100
-                         text-end text-neutral-600 cursor-not-allowed"
+                         text-neutral-600 cursor-not-allowed"
                 data-testid="first-name-readonly"
               />
             </div>
@@ -150,7 +150,7 @@ export default function RegistrationDetailsStep({
                 value={lastName}
                 readOnly
                 className="w-full px-4 py-3 border-2 border-neutral-200 rounded-xl bg-neutral-100
-                         text-end text-neutral-600 cursor-not-allowed"
+                         text-neutral-600 cursor-not-allowed"
                 data-testid="last-name-readonly"
               />
             </div>
@@ -168,8 +168,8 @@ export default function RegistrationDetailsStep({
                 type="email"
                 value={formData.email}
                 onChange={(e) => handleInputChange('email', e.target.value)}
-                className={`w-full px-4 py-3.5 border-2 rounded-xl focus:ring-2 outline-none transition-all
-                         text-end text-neutral-800 bg-neutral-50 focus:bg-white placeholder-neutral-500 ${
+                className={`w-full ps-4 pe-11 py-3.5 border-2 rounded-xl focus:ring-2 outline-none transition-all
+                         text-neutral-800 bg-neutral-50 focus:bg-white placeholder-neutral-500 ${
                   validationErrors.email && formData.email
                     ? 'border-danger-500 focus:border-danger-500 focus:ring-danger-500'
                     : 'border-neutral-200 focus:border-info-500 focus:ring-info-500'
@@ -177,7 +177,7 @@ export default function RegistrationDetailsStep({
                 placeholder={TEXT_CONSTANTS.AUTH.EMAIL_PLACEHOLDER_REGISTRATION}
                 data-testid="email-input"
               />
-              <div className="absolute end-3 top-1/2 transform -translate-y-1/2">
+              <div className="pointer-events-none absolute end-3 top-1/2 transform -translate-y-1/2">
                 <svg className="w-5 h-5 text-neutral-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
                         d="M16 12a4 4 0 10-8 0 4 4 0 008 0zm0 0v1.5a2.5 2.5 0 005 0V12a9 9 0 10-9 9m4.5-1.206a8.959 8.959 0 01-4.5 1.207" />
@@ -185,7 +185,7 @@ export default function RegistrationDetailsStep({
               </div>
             </div>
             {validationErrors.email && formData.email && (
-              <p className="text-sm text-danger-600 text-end px-1" data-testid="email-error">
+              <p className="text-sm text-danger-600 px-1" data-testid="email-error">
                 {validationErrors.email}
               </p>
             )}
@@ -201,8 +201,8 @@ export default function RegistrationDetailsStep({
                 type={showPassword ? 'text' : 'password'}
                 value={formData.password}
                 onChange={(e) => handleInputChange('password', e.target.value)}
-                className={`w-full px-4 py-3.5 border-2 rounded-xl focus:ring-2 outline-none transition-all
-                         text-end text-neutral-800 bg-neutral-50 focus:bg-white pe-12 placeholder-neutral-500 ${
+                className={`w-full ps-4 pe-12 py-3.5 border-2 rounded-xl focus:ring-2 outline-none transition-all
+                         text-neutral-800 bg-neutral-50 focus:bg-white placeholder-neutral-500 ${
                   validationErrors.password && formData.password
                     ? 'border-danger-500 focus:border-danger-500 focus:ring-danger-500'
                     : 'border-neutral-200 focus:border-info-500 focus:ring-info-500'
@@ -233,7 +233,7 @@ export default function RegistrationDetailsStep({
               </button>
             </div>
             {validationErrors.password && formData.password && (
-              <p className="text-sm text-danger-600 text-end px-1" data-testid="password-error">
+              <p className="text-sm text-danger-600 px-1" data-testid="password-error">
                 {validationErrors.password}
               </p>
             )}
@@ -257,7 +257,7 @@ export default function RegistrationDetailsStep({
               ariaLabel={TEXT_CONSTANTS.AUTH.GENDER}
             />
             {validationErrors.gender && (
-              <p className="text-sm text-danger-600 text-end px-1" data-testid="gender-error">
+              <p className="text-sm text-danger-600 px-1" data-testid="gender-error">
                 {validationErrors.gender}
               </p>
             )}
@@ -273,7 +273,7 @@ export default function RegistrationDetailsStep({
               value={formData.birthdate}
               onChange={(e) => handleInputChange('birthdate', e.target.value)}
               className={`w-full px-4 py-3.5 border-2 rounded-xl focus:ring-2 outline-none transition-all
-                       text-end text-neutral-800 bg-neutral-50 focus:bg-white ${
+                       text-neutral-800 bg-neutral-50 focus:bg-white ${
                 validationErrors.birthdate && formData.birthdate
                   ? 'border-danger-500 focus:border-danger-500 focus:ring-danger-500'
                   : 'border-neutral-200 focus:border-info-500 focus:ring-info-500'
@@ -281,7 +281,7 @@ export default function RegistrationDetailsStep({
               data-testid="birthdate-input"
             />
             {validationErrors.birthdate && formData.birthdate && (
-              <p className="text-sm text-danger-600 text-end px-1" data-testid="birthdate-error">
+              <p className="text-sm text-danger-600 px-1" data-testid="birthdate-error">
                 {validationErrors.birthdate}
               </p>
             )}
@@ -310,7 +310,7 @@ export default function RegistrationDetailsStep({
               </span>
             </label>
             {validationErrors.consent && (
-              <p className="text-sm text-danger-600 text-end px-1" data-testid="consent-error">
+              <p className="text-sm text-danger-600 px-1" data-testid="consent-error">
                 {validationErrors.consent}
               </p>
             )}

--- a/src/components/registration/RegistrationForm.tsx
+++ b/src/components/registration/RegistrationForm.tsx
@@ -310,8 +310,8 @@ export default function RegistrationForm({ personalNumber, setPersonalNumber, on
                 autoComplete="off"
                 value={personalNumber}
                 onChange={handleInputChange}
-                className={`w-full px-4 py-3.5 border-2 rounded-xl focus:ring-2 outline-none transition-all
-                         text-end text-neutral-800 bg-neutral-50 focus:bg-white placeholder-neutral-500 ${
+                className={`w-full ps-4 pe-11 py-3.5 border-2 rounded-xl focus:ring-2 outline-none transition-all
+                         text-neutral-800 bg-neutral-50 focus:bg-white placeholder-neutral-500 ${
                   validationError && personalNumber
                     ? 'border-danger-500 focus:border-danger-500 focus:ring-danger-500'
                     : 'border-neutral-200 focus:border-primary-500 focus:ring-primary-500'
@@ -320,7 +320,7 @@ export default function RegistrationForm({ personalNumber, setPersonalNumber, on
                 maxLength={7}
                 data-testid="personal-number-input"
               />
-              <div className="absolute end-3 top-1/2 transform -translate-y-1/2">
+              <div className="pointer-events-none absolute end-3 top-1/2 transform -translate-y-1/2">
                 <svg className="w-5 h-5 text-neutral-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
                         d="M10 6H5a2 2 0 00-2 2v9a2 2 0 002 2h14a2 2 0 002-2V8a2 2 0 00-2-2h-5m-4 0V4a2 2 0 114 0v2m-4 0a2 2 0 104 0m-5 8a2 2 0 100-4 2 2 0 000 4zm0 0c1.306 0 2.417.835 2.83 2M9 14a3.001 3.001 0 00-2.83 2M15 11h3m-3 4h2" />
@@ -330,7 +330,7 @@ export default function RegistrationForm({ personalNumber, setPersonalNumber, on
 
             {validationError && personalNumber && (
               <p
-                className="text-sm text-danger-600 text-end px-1"
+                className="text-sm text-danger-600 px-1"
                 data-testid="personal-number-error"
               >
                 {validationError}


### PR DESCRIPTION
## Why

The SW-toast cutoff (PR #147) and login-modal icon collision (PR #145) were both the same RTL bug class. User asked to sweep the rest of the webapp for similar offenders. This PR is the result.

## Audit summary

| Pattern | Scope | Result |
|---|---|---|
| `start-*`/`end-*` + `-translate-x-*` centering | All `src/` | **Clean** — every other centering hit uses physical `left-1/2 -translate-x-1/2`, which is symmetric (translateX is direction-neutral). SW toast was the only outlier, fixed in #147. |
| `text-end` + icon pinned to END side on input | `src/components/registration/*` | **5 files / 8 inputs offending** |
| `text-end` on Hebrew-content input with no icon | `PersonalDetailsStep.tsx` | Alignment hygiene — Hebrew typed text landed on LEFT instead of natural RIGHT |
| Settings / OTP modals | Use `input-base` (no `text-end`) or `text-center` | Safe |

## Files

- **`RegistrationForm.tsx`** — personal-number input.
- **`RegistrationDetailsStep.tsx`** — email + password + birthdate + 2 read-only Hebrew name fields + every error span.
- **`AccountDetailsStep.tsx`** — email + password + password-requirements list + consent label + submit-error span.
- **`PersonalDetailsStep.tsx`** — firstName + lastName + every error span.

## Pattern applied (canonical, matches #145)

1. Drop `text-end` from inputs — default `text-align: start` puts text on the logical-start side (RIGHT in RTL), away from the end-pinned icon.
2. Replace symmetric `px-4` with explicit `ps-4 pe-N` (or `ps-N pe-4` where the icon sits on START, e.g. `AccountDetailsStep` email). Padding reserves the icon column so typed text never reaches it.
3. Add `pointer-events-none` to static (non-button) icon wrappers so a near-edge click falls through to the input.
4. Drop `text-end` from error spans + the consent label + the password-requirements list so they align with the now-right-aligned inputs.

## Scope notes

- `AccountDetailsStep` keeps its icons on `start-3` (RIGHT in RTL) instead of mirroring `LoginModal`. A layout flip would expand this PR meaningfully and the current layout works once `text-end` is dropped.
- `<input type=\"date\">` keeps its existing `dir=\"ltr\"` exemption (segments break in RTL — documented inline).
- Dead-codey `RegistrationDetailsStep.tsx` (only imported by its own test) still fixed — it's shipped, may get surfaced, no cost to be thorough.

## Memory updated

`project_rtl_audit.md` now logs both regression classes (icon collision + centering drift) and the canonical pattern for new code.

## Test plan

- [x] `npm run lint` clean.
- [x] `npx jest src/components/registration` — 9 suites / 181 tests pass.
- [ ] Manual RTL: open registration flow on mobile, confirm placeholder + icon don't overlap on any input, error messages align right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)