### PR TITLE
feat(equipment): ? info-bubble for disabled row actions

### DIFF
--- a/docs/codebase/src/components/equipment/EquipmentRowActions.md
+++ b/docs/codebase/src/components/equipment/EquipmentRowActions.md
@@ -7,12 +7,42 @@ Per-row action dropdown for the equipment table. Items in the menu are gated thr
 | Item | Gate |
 |------|------|
 | Report | `canReport` |
-| Transfer | `canTransfer` (only the current holder can request) |
-| Return | `canRetire` (only the signer) — rendered with danger styling |
+| Transfer | `isHolder(ctx) && equipment.status !== RETIRED` (inline — see "Disabled rows + info bubbles" below) |
+| Request exchange / Approve exchange / Replace by another | `canRequestExchange` / `canApproveExchange` / `canReplaceByAnother` |
+| Send to storage | `canSendToStorage` |
+| Pull from storage | `canPullFromStorage` |
 | History | always visible |
+| Reject exchange | `canApproveExchange` (danger) |
+| Return | `canRetire` — danger styling |
 
 The gating decides menu visibility; the page still controls dispatch (the component just emits `onAction(kind)`). No mutation lives here.
 
 ## Layout
 
-Built on Headless UI `Menu` + `MenuItems` with `anchor="bottom end"`. `anchor` portals the panel through Floating UI, so it escapes the parent row's `overflow-hidden` (bug #17). Items split into two groups: safe (`report`, `transfer`, `history`) on top, destructive (`return`) on the bottom. A `border-t` divider renders between them when both groups are non-empty.
+Built on Headless UI `Menu` + `MenuItems` with `anchor="bottom end"`. `anchor` portals the panel through Floating UI, so it escapes the parent row's `overflow-hidden` (bug #17). Items split into two groups: safe on top, destructive on the bottom. A `border-t` divider renders between them when both groups are non-empty.
+
+## Disabled rows + info bubbles
+
+Some rows render in a disabled state with a `?` info bubble (`InfoPopover`) that explains why. The bubble lives inside the same `MenuItem` flex row, immediately after the label, with `pe-2` spacing.
+
+| Row | Disabled when | Bubble text |
+|---|---|---|
+| Transfer | `equipment.status === STORED` | `STORAGE.TRANSFER_BLOCKED_STORED_TOOLTIP` |
+| Pull from storage | `!roundOpen` (parent reads `SystemConfig.roundOpen`) | `STORAGE.ROUND_CLOSED_TOOLTIP` |
+
+Transfer visibility is intentionally inline (`isHolder(ctx) && status !== RETIRED`) and does NOT call `equipmentPolicy.canTransfer`. The server still uses `canTransfer`, which hides STORED items, but the UI wants a visible affordance with a bubble explaining the path forward ("pull from storage first"). Server-side enforcement is unchanged.
+
+## ActionItem shape
+
+```ts
+interface ActionItem {
+  id: EquipmentRowAction;
+  label: string;
+  show: boolean;
+  disabled?: boolean;
+  infoBubble?: string; // rendered via <InfoPopover content={...} /> when disabled
+  tone?: 'danger';
+}
+```
+
+The legacy `title?: string` field is gone — disabled-row reasoning is communicated through `infoBubble` only (visible on both desktop and mobile via the popover).

--- a/docs/codebase/src/components/ui/InfoPopover.md
+++ b/docs/codebase/src/components/ui/InfoPopover.md
@@ -1,0 +1,37 @@
+# InfoPopover
+
+**File:** `src/components/ui/InfoPopover.tsx`
+**Status:** Active
+
+## Purpose
+
+Reusable `?` icon that reveals a tooltip-style bubble explaining additional context — primarily used next to disabled menu rows so the user understands why an action is unavailable. Built on Headless UI `Popover`.
+
+## Interactions
+
+- **Desktop:** hover opens the panel (pointermove handler triggers the button); a click toggles it open/closed. Outside-click and Escape close it.
+- **Mobile / touch:** tap toggles. The hover handler is gated to `pointerType === 'mouse'`, so it's a no-op on touch.
+
+The trigger calls `e.stopPropagation()` on click so the surrounding `MenuItem` button does not also fire (which would dispatch the disabled-action handler).
+
+## Props
+
+| Prop | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `content` | `string` | yes | — | Text rendered inside the bubble. Caller supplies the i18n'd string from `TEXT_CONSTANTS`. |
+| `ariaLabel` | `string` | no | `TEXT_CONSTANTS.FEATURES.EQUIPMENT.STORAGE.INFO_BUBBLE_LABEL` | Accessible name for the icon button. |
+| `className` | `string` | no | — | Extra classes on the trigger wrapper. |
+
+The trigger also exposes `data-info-content={content}` for tests that need to assert the bubble's content without opening the panel (Headless UI's `Popover` anchor positioning needs `floating-ui` measurements that are flaky in jsdom).
+
+## Styling
+
+- Trigger: `HelpCircle` from `lucide-react` at `w-3.5 h-3.5`, neutral-500 default / neutral-700 on hover, focus-visible primary-500 ring.
+- Panel: `bg-neutral-900 text-white text-xs rounded-md px-2 py-1 shadow-lg max-w-[220px]`, anchored above with `z-60` (the `Menu`/`Listbox` panel stack sits at `z-50`).
+
+## When to use
+
+- Next to a disabled control where the disabled-reason is non-obvious.
+- For inline help on form fields where a full description doesn't justify a separate label.
+
+For verbose copy or rich content, use a real popover/modal instead — this component caps content at 220px wide and renders plain text only.

--- a/src/components/equipment/EquipmentRowActions.tsx
+++ b/src/components/equipment/EquipmentRowActions.tsx
@@ -3,20 +3,21 @@
 import React from 'react';
 import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/react';
 import { MoreVertical } from 'lucide-react';
-import type { Equipment } from '@/types/equipment';
+import { Equipment, EquipmentStatus } from '@/types/equipment';
 import type { EnhancedAuthUser } from '@/types/user';
 import {
   canReport,
   canRetire,
-  canTransfer,
   canRequestExchange,
   canApproveExchange,
   canReplaceByAnother,
   canSendToStorage,
   canPullFromStorage,
+  isHolder,
 } from '@/lib/equipmentPolicy';
 import { TEXT_CONSTANTS } from '@/constants/text';
 import { cn } from '@/lib/cn';
+import InfoPopover from '@/components/ui/InfoPopover';
 
 export type EquipmentRowAction =
   | 'report'
@@ -34,7 +35,8 @@ interface EquipmentRowActionsProps {
   equipment: Equipment;
   user: EnhancedAuthUser;
   /**
-   * When true, the pull-from-storage action is rendered disabled with a tooltip.
+   * When true, the pull-from-storage action is rendered enabled. When false,
+   * the row is disabled and an info-bubble explains why.
    * Set by the parent via SystemConfig.roundOpen.
    */
   roundOpen?: boolean;
@@ -46,7 +48,8 @@ interface ActionItem {
   label: string;
   show: boolean;
   disabled?: boolean;
-  title?: string;
+  /** Explanatory text rendered in an InfoPopover when the row is disabled. */
+  infoBubble?: string;
   tone?: 'danger';
 }
 
@@ -56,9 +59,22 @@ export default function EquipmentRowActions({ equipment, user, roundOpen, onActi
 
   const ctx = { user, equipment };
 
+  // Transfer visibility intentionally inline (does NOT call canTransfer):
+  // the policy hides STORED items, but we want to render the row disabled
+  // with a bubble explaining "pull from storage first". Server-side
+  // canTransfer is unchanged and still enforces the policy.
+  const transferVisible = isHolder(ctx) && equipment.status !== EquipmentStatus.RETIRED;
+  const transferDisabledByStorage = equipment.status === EquipmentStatus.STORED;
+
   const safeItems: ActionItem[] = ([
     { id: 'report', label: labels.REPORT, show: canReport(ctx) },
-    { id: 'transfer', label: labels.TRANSFER, show: canTransfer(ctx) },
+    {
+      id: 'transfer',
+      label: labels.TRANSFER,
+      show: transferVisible,
+      disabled: transferDisabledByStorage,
+      infoBubble: transferDisabledByStorage ? storageText.TRANSFER_BLOCKED_STORED_TOOLTIP : undefined,
+    },
     { id: 'request-exchange', label: labels.REQUEST_EXCHANGE, show: canRequestExchange(ctx) },
     { id: 'approve-exchange', label: labels.APPROVE_EXCHANGE, show: canApproveExchange(ctx) },
     { id: 'replace-by-another', label: labels.REPLACE_BY_ANOTHER, show: canReplaceByAnother(ctx) },
@@ -68,7 +84,7 @@ export default function EquipmentRowActions({ equipment, user, roundOpen, onActi
       label: labels.PULL_FROM_STORAGE,
       show: canPullFromStorage(ctx),
       disabled: !roundOpen,
-      title: !roundOpen ? storageText.ROUND_CLOSED_TOOLTIP : undefined,
+      infoBubble: !roundOpen ? storageText.ROUND_CLOSED_TOOLTIP : undefined,
     },
     { id: 'history', label: labels.HISTORY, show: true },
   ] as ActionItem[]).filter((i) => i.show);
@@ -90,22 +106,29 @@ export default function EquipmentRowActions({ equipment, user, roundOpen, onActi
         anchor="bottom end"
         className="w-52 mt-1 bg-white border border-neutral-200 rounded-lg shadow-lg py-1 z-50 focus:outline-none"
       >
-        {safeItems.map((item) => (
-          <MenuItem key={item.id} disabled={item.disabled}>
-            <button
-              type="button"
-              onClick={() => !item.disabled && onAction(item.id)}
-              title={item.title}
-              className={cn(
-                'w-full text-start px-3 py-2 text-sm transition-colors text-neutral-700',
-                'data-[focus]:bg-neutral-50',
-                item.disabled && 'opacity-40 cursor-not-allowed',
-              )}
-            >
-              {item.label}
-            </button>
-          </MenuItem>
-        ))}
+        {safeItems.map((item) => {
+          const showBubble = !!item.disabled && !!item.infoBubble;
+          return (
+            <MenuItem key={item.id} disabled={item.disabled}>
+              <div className="flex items-center justify-between gap-1 pe-2">
+                <button
+                  type="button"
+                  onClick={() => !item.disabled && onAction(item.id)}
+                  className={cn(
+                    'flex-1 text-start px-3 py-2 text-sm transition-colors text-neutral-700',
+                    'data-[focus]:bg-neutral-50',
+                    item.disabled && 'opacity-40 cursor-not-allowed',
+                  )}
+                >
+                  {item.label}
+                </button>
+                {showBubble && (
+                  <InfoPopover content={item.infoBubble!} />
+                )}
+              </div>
+            </MenuItem>
+          );
+        })}
         {safeItems.length > 0 && dangerItems.length > 0 && (
           <div className="my-1 border-t border-neutral-200" role="separator" />
         )}

--- a/src/components/equipment/__tests__/EquipmentRowActions.test.tsx
+++ b/src/components/equipment/__tests__/EquipmentRowActions.test.tsx
@@ -1,0 +1,172 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import EquipmentRowActions from '../EquipmentRowActions';
+import { EquipmentStatus, EquipmentCondition, type Equipment } from '@/types/equipment';
+import { UserType, type EnhancedAuthUser } from '@/types/user';
+
+jest.mock('@/constants/text', () => ({
+  TEXT_CONSTANTS: {
+    FEATURES: {
+      EQUIPMENT: {
+        ROW_ACTIONS: {
+          MORE: 'More',
+          REPORT: 'Report',
+          TRANSFER: 'Transfer',
+          REQUEST_EXCHANGE: 'Request exchange',
+          APPROVE_EXCHANGE: 'Approve exchange',
+          REPLACE_BY_ANOTHER: 'Replace by another',
+          SEND_TO_STORAGE: 'Send to storage',
+          PULL_FROM_STORAGE: 'Pull from storage',
+          HISTORY: 'History',
+          REJECT_EXCHANGE: 'Reject exchange',
+          RETURN: 'Return',
+        },
+        STORAGE: {
+          ROUND_CLOSED_TOOLTIP: 'Round is closed',
+          TRANSFER_BLOCKED_STORED_TOOLTIP: 'Item is in storage — pull first',
+          INFO_BUBBLE_LABEL: 'Info',
+        },
+      },
+    },
+  },
+}));
+
+const HOLDER_UID = 'holder-uid';
+
+function makeUser(): EnhancedAuthUser {
+  return {
+    uid: HOLDER_UID,
+    userType: UserType.USER,
+    displayName: 'Test Holder',
+  };
+}
+
+function makeEquipment(overrides: Partial<Equipment> = {}): Equipment {
+  // jsdom only — we just need enough shape for visibility/disabled logic.
+  return {
+    id: 'eq-1',
+    equipmentType: 'rifle_m4',
+    productName: 'Rifle',
+    category: 'weapons',
+    signedBy: 'Signer',
+    signedById: 'signer-uid',
+    currentHolder: 'Holder',
+    currentHolderId: HOLDER_UID,
+    status: EquipmentStatus.AVAILABLE,
+    location: 'base',
+    condition: EquipmentCondition.GOOD,
+    trackingHistory: [],
+    // Timestamps are not exercised by these tests; cast through unknown to
+    // satisfy the Equipment interface without dragging in firebase types.
+    acquisitionDate: {} as Equipment['acquisitionDate'],
+    dateSigned: {} as Equipment['dateSigned'],
+    lastSeen: {} as Equipment['lastSeen'],
+    lastReportUpdate: {} as Equipment['lastReportUpdate'],
+    createdAt: {} as Equipment['createdAt'],
+    updatedAt: {} as Equipment['updatedAt'],
+    ...overrides,
+  };
+}
+
+describe('EquipmentRowActions', () => {
+  function openMenu() {
+    fireEvent.click(screen.getByRole('button', { name: 'More' }));
+  }
+
+  it('renders the transfer row disabled with an info bubble when status is STORED', () => {
+    const user = makeUser();
+    const equipment = makeEquipment({ status: EquipmentStatus.STORED });
+
+    render(
+      <EquipmentRowActions
+        equipment={equipment}
+        user={user}
+        roundOpen={true}
+        onAction={jest.fn()}
+      />,
+    );
+
+    openMenu();
+
+    const transferRow = screen.getByText('Transfer').closest('button');
+    expect(transferRow).toHaveClass('cursor-not-allowed');
+
+    // Exactly one info bubble is rendered (next to the disabled transfer row).
+    // Round is open, so pull-from-storage is enabled and has no bubble.
+    const infoButtons = screen.getAllByRole('button', { name: 'Info' });
+    expect(infoButtons).toHaveLength(1);
+    expect(infoButtons[0]).toHaveAttribute(
+      'data-info-content',
+      'Item is in storage — pull first',
+    );
+  });
+
+  it('disables pull-from-storage and shows an info bubble when round is closed', () => {
+    const user = makeUser();
+    const equipment = makeEquipment({ status: EquipmentStatus.STORED });
+
+    render(
+      <EquipmentRowActions
+        equipment={equipment}
+        user={user}
+        roundOpen={false}
+        onAction={jest.fn()}
+      />,
+    );
+
+    openMenu();
+
+    const pullRow = screen.getByText('Pull from storage').closest('button');
+    expect(pullRow).toHaveClass('cursor-not-allowed');
+
+    // STORED + roundOpen=false yields TWO disabled rows with bubbles:
+    // transfer (STORED → "pull first") and pull-from-storage (round closed).
+    const infoButtons = screen.getAllByRole('button', { name: 'Info' });
+    const contents = infoButtons.map((b) => b.getAttribute('data-info-content'));
+    expect(contents).toEqual(
+      expect.arrayContaining([
+        'Item is in storage — pull first',
+        'Round is closed',
+      ]),
+    );
+    expect(contents).toHaveLength(2);
+  });
+
+  it('does NOT render any info bubble when the row is enabled', () => {
+    const user = makeUser();
+    const equipment = makeEquipment({ status: EquipmentStatus.AVAILABLE });
+
+    render(
+      <EquipmentRowActions
+        equipment={equipment}
+        user={user}
+        roundOpen={true}
+        onAction={jest.fn()}
+      />,
+    );
+
+    openMenu();
+
+    expect(screen.queryByRole('button', { name: 'Info' })).not.toBeInTheDocument();
+  });
+
+  it('calls onAction when the user clicks an enabled row', () => {
+    const onAction = jest.fn();
+    const user = makeUser();
+    const equipment = makeEquipment({ status: EquipmentStatus.AVAILABLE });
+
+    render(
+      <EquipmentRowActions
+        equipment={equipment}
+        user={user}
+        roundOpen={true}
+        onAction={onAction}
+      />,
+    );
+
+    openMenu();
+    fireEvent.click(screen.getByText('Transfer'));
+    expect(onAction).toHaveBeenCalledWith('transfer');
+  });
+});

--- a/src/components/ui/InfoPopover.tsx
+++ b/src/components/ui/InfoPopover.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import React from 'react';
+import { Popover, PopoverButton, PopoverPanel } from '@headlessui/react';
+import { HelpCircle } from 'lucide-react';
+import { TEXT_CONSTANTS } from '@/constants/text';
+import { cn } from '@/lib/cn';
+
+export interface InfoPopoverProps {
+  /**
+   * Short explanatory text to render inside the bubble. Plain string only —
+   * upstream is responsible for i18n via `TEXT_CONSTANTS`.
+   */
+  content: string;
+  /**
+   * Optional accessible name for the trigger button. Falls back to the
+   * `INFO_BUBBLE_LABEL` text constant.
+   */
+  ariaLabel?: string;
+  /**
+   * Extra classes for the trigger wrapper (icon button).
+   */
+  className?: string;
+}
+
+/**
+ * Small "?" icon that reveals a tooltip-style bubble.
+ *
+ * Built on Headless UI `Popover`:
+ *   - Desktop: hover OR click opens the panel (close on outside click / Escape).
+ *   - Mobile: tap toggles.
+ *
+ * Sits at `z-60` so it floats above the surrounding `MenuItems` panel (z-50).
+ */
+export default function InfoPopover({ content, ariaLabel, className }: InfoPopoverProps) {
+  const label = ariaLabel ?? TEXT_CONSTANTS.FEATURES.EQUIPMENT.STORAGE.INFO_BUBBLE_LABEL;
+
+  return (
+    <Popover className={cn('relative inline-flex items-center', className)}>
+      {({ open, close }) => (
+        <span
+          // Hover support on pointer-fine devices. Touch devices fire click
+          // on tap, which Headless Popover already handles, so a no-op here
+          // is harmless on mobile.
+          onPointerEnter={(e) => {
+            if (e.pointerType === 'mouse' && !open) {
+              (e.currentTarget.querySelector('[data-info-trigger]') as HTMLButtonElement | null)?.click();
+            }
+          }}
+          onPointerLeave={(e) => {
+            if (e.pointerType === 'mouse' && open) {
+              close();
+            }
+          }}
+        >
+          <PopoverButton
+            type="button"
+            data-info-trigger
+            data-info-content={content}
+            aria-label={label}
+            title={content}
+            className="inline-flex items-center justify-center rounded-full text-neutral-500 hover:text-neutral-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
+            onClick={(e) => {
+              // Prevent the surrounding MenuItem button from receiving the
+              // click and triggering its disabled-action handler.
+              e.stopPropagation();
+            }}
+          >
+            <HelpCircle className="w-3.5 h-3.5" aria-hidden="true" />
+          </PopoverButton>
+          <PopoverPanel
+            anchor={{ to: 'top', gap: 6 }}
+            role="tooltip"
+            className="z-60 bg-neutral-900 text-white text-xs rounded-md px-2 py-1 shadow-lg max-w-[220px] leading-snug"
+          >
+            {content}
+          </PopoverPanel>
+        </span>
+      )}
+    </Popover>
+  );
+}

--- a/src/components/ui/__tests__/InfoPopover.test.tsx
+++ b/src/components/ui/__tests__/InfoPopover.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import InfoPopover from '../InfoPopover';
+
+jest.mock('@/constants/text', () => ({
+  TEXT_CONSTANTS: {
+    FEATURES: {
+      EQUIPMENT: {
+        STORAGE: {
+          INFO_BUBBLE_LABEL: 'Info',
+        },
+      },
+    },
+  },
+}));
+
+describe('InfoPopover', () => {
+  it('renders a trigger button with the default aria-label', () => {
+    render(<InfoPopover content="Why disabled" />);
+    expect(screen.getByRole('button', { name: 'Info' })).toBeInTheDocument();
+  });
+
+  it('uses the custom aria-label when provided', () => {
+    render(<InfoPopover content="Why disabled" ariaLabel="More info" />);
+    expect(screen.getByRole('button', { name: 'More info' })).toBeInTheDocument();
+  });
+
+  it('panel content is hidden until the trigger is clicked', () => {
+    render(<InfoPopover content="Item is in storage" />);
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Info' }));
+
+    const tooltip = screen.getByRole('tooltip');
+    expect(tooltip).toBeInTheDocument();
+    expect(tooltip).toHaveTextContent('Item is in storage');
+  });
+});

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -16,3 +16,6 @@ export type { FormFieldProps } from './FormField';
 
 export { default as Select } from './Select';
 export type { SelectProps, SelectOption } from './Select';
+
+export { default as InfoPopover } from './InfoPopover';
+export type { InfoPopoverProps } from './InfoPopover';

--- a/src/constants/text.en.ts
+++ b/src/constants/text.en.ts
@@ -178,6 +178,8 @@ export const TEXT_EN = {
       PULL_SUBMIT: 'Pull from storage',
       PULL_SUCCESS: 'Item pulled from storage',
       ROUND_CLOSED_TOOLTIP: 'Round is closed — items cannot be pulled from storage right now',
+      TRANSFER_BLOCKED_STORED_TOOLTIP: 'Item is in storage — pull from storage before transferring',
+      INFO_BUBBLE_LABEL: 'Info',
     },
 
     SYSTEM_CONFIG: {

--- a/src/constants/text.ts
+++ b/src/constants/text.ts
@@ -602,6 +602,8 @@ export const TEXT_CONSTANTS = {
         PULL_SUBMIT: 'הוצא מאחסון',
         PULL_SUCCESS: 'הפריט הוצא מהאחסון',
         ROUND_CLOSED_TOOLTIP: 'הסבב סגור — לא ניתן להוציא פריטים מהאחסון כעת',
+        TRANSFER_BLOCKED_STORED_TOOLTIP: 'פריט באחסון — יש להוציאו מהאחסון לפני העברה',
+        INFO_BUBBLE_LABEL: 'מידע',
       },
       SYSTEM_CONFIG: {
         ROUND_OPEN_LABEL: 'סבב פעיל',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -125,6 +125,11 @@ module.exports = {
         '88': '22rem',    // 352px
         '128': '32rem',   // 512px
       },
+      // Z-index stack (extends Tailwind's 0/10/20/30/40/50/auto defaults).
+      // 60 = floats over `Menu`/`Listbox` panels which sit at z-50.
+      zIndex: {
+        '60': '60',
+      },
       // Box shadows
       boxShadow: {
         'soft': '0 2px 15px -3px rgba(0, 0, 0, 0.07), 0 10px 20px -2px rgba(0, 0, 0, 0.04)',


### PR DESCRIPTION
## Summary
- New `InfoPopover` primitive (Headless UI Popover + HelpCircle) — desktop hover/click + mobile tap, z-60 to float over menus.
- `EquipmentRowActions`: replaced native `title=` with `InfoPopover` bubble.
- Pull-from-storage: bubble explains "round closed" when disabled.
- Transfer: shown disabled (not hidden) when item is STORED, with bubble explaining "pull from storage first".
- HE+EN text constants for both tooltips.

## Test plan
- [x] `npm run lint` clean
- [x] `InfoPopover.test.tsx` 3/3
- [x] `EquipmentRowActions.test.tsx` 4/4

Plan: `~/.claude/plans/in-equipment-we-can-rippling-cascade.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)