### PR TITLE
feat(ammo): multi-recipient notifications + admin/mgmt settings split

### DIFF
--- a/docs/codebase/src/app/admin/components/SystemConfigPanel.md
+++ b/docs/codebase/src/app/admin/components/SystemConfigPanel.md
@@ -1,0 +1,44 @@
+# SystemConfigPanel.tsx
+
+**File:** `src/app/admin/components/SystemConfigPanel.tsx`
+**Status:** Active
+
+## Purpose
+
+The `/admin` System Config panel. Owns the **teams allowlist** — the list of
+team names the registration flow validates against. Identity boundary; lives
+on `/admin` per `docs/spec/settings-ownership.md`.
+
+## Scope (post settings-split)
+
+| Setting | Owned here? |
+|---|---|
+| `systemConfig.teams` | yes |
+| `systemConfig.ammoNotificationRecipientUserIds` | **no** — moved to `/management` |
+| `systemConfig.roundOpen` | **no** — lives on `/management` |
+
+The ammo recipient editor used to live here too. It was removed when the
+field shape changed from a single uid (`ammoNotificationRecipientUserId:
+string`) to an array (`ammoNotificationRecipientUserIds: string[]`) and the
+operational ownership moved to `/management` (where managers can edit it
+themselves). The teams allowlist stays here because it's an identity
+boundary that ADMIN / SYSTEM_MANAGER own.
+
+## State
+
+| State | Type | Purpose |
+|-------|------|---------|
+| `teams` | `string[]` | Pending edit copy of the teams list |
+| `newTeam` | `string` | Input for the "add team" textbox |
+| `saving` | `boolean` | Disables Save while the request is in flight |
+| `feedback` | `{ kind, text } \| null` | Inline success/error message |
+
+## Behavior
+
+- Reads/saves via `useSystemConfig()` (the same hook the management surface
+  uses).
+- Add: trims input, rejects duplicates, appends to local `teams`. Save sends
+  the array through the server validator.
+- Remove: filters by name from local `teams` only; persist on Save.
+- Server enforces the admin gate on the API route — this panel only renders
+  inside the existing `/admin` admin-gated layout.

--- a/docs/codebase/src/components/management/tabs/SystemConfigTab.md
+++ b/docs/codebase/src/components/management/tabs/SystemConfigTab.md
@@ -1,53 +1,67 @@
 # SystemConfigTab.tsx
 
 **File:** `src/components/management/tabs/SystemConfigTab.tsx`
-**Status:** Active (Phase 1 — Ammunition feature)
+**Status:** Active
 
 ## Purpose
 
-System-wide settings panel inside `/management`. Phase 1 adds the ammunition
-notification recipient picker — the admin chooses one user who receives a copy
-of every ammunition report submission (alongside the reporter's TL).
+System-wide settings surface inside `/management`. Owns the two operational
+flags that managers update day-to-day:
+
+- **Ammunition managers** — array of user UIDs flagged to receive ammo report
+  notifications and to count as ammo-responsible for training-plan approvals.
+- **Round open** — gates pull-from-storage on equipment items in
+  `EquipmentStatus.STORED`.
+
+Both settings live on the single Firestore doc `systemConfig/main`. Teams
+allowlist + authorized personnel stay on `/admin` (identity boundary); the
+ownership split is documented in `docs/spec/settings-ownership.md`.
+
+## Composition
+
+The tab is now a thin shell — most of the recipient UI lives in a child
+component:
+
+| Component | Responsibility |
+|---|---|
+| `AmmoRecipientsSection` (`./system-config/AmmoRecipientsSection.tsx`) | Read-only list + inline edit mode for `ammoNotificationRecipientUserIds` |
+| Inline Headless UI `<Switch>` block | `roundOpen` toggle |
 
 ## State
 
 | State | Type | Purpose |
 |-------|------|---------|
-| `recipient` | `UserSearchResult \| null` | Currently selected user in the picker |
-| `hydratedFor` | `string \| null` | Memo key — last persisted recipient id we hydrated to avoid re-fetching the profile on every render |
-| `saving` | `boolean` | Disables the save button while the request is in-flight |
-| `toast` | `{ kind, message } \| null` | 3-second success/error chip next to the save button |
+| `roundOpen` | `boolean` | Local copy of the round-open toggle; mirrored from `config.roundOpen` on hydrate |
+| `savingRound` | `boolean` | Disables the round save button while the request is in-flight |
+| `toast` | `{ kind, message } \| null` | 3-second success/error chip next to the round save button |
+
+Recipient editing state (`pending`, `editing`, `saving`, `error`) lives inside
+`AmmoRecipientsSection` and is invisible to the tab.
 
 ## Behavior
 
 - Reads `systemConfig/main` via `useSystemConfig()`.
-- After the config loads, calls `getUserProfile(persistedRecipientId)` once to
-  hydrate the picker with the persisted user's display name + email.
-- `UserSearchInput` is rendered read-only for non-admins (pointer-events none +
-  opacity).
-- Admin gate: `UserType.ADMIN || UserType.SYSTEM_MANAGER`. Server enforces the
-  same check via `/api/system-config` PUT.
-- Save button is disabled when nothing has changed (`recipient.uid` equals
-  persisted id) or while saving.
-
-## Removed (vs. previous placeholder)
-
-The old mock fields — auto backup toggle, session timeout, max login attempts,
-notification email, "system info" block, "perform backup now" / "reset
-settings" buttons — were not persisted and not on the Phase 1 spec. They are
-removed; reintroduce them with real backing if that work returns.
+- `AmmoRecipientsSection` is fed the persisted array and a callback that
+  forwards to `useSystemConfig().save({ ammoNotificationRecipientUserIds })`.
+  When the save fails the callback throws so the child surfaces the error
+  inline.
+- Round toggle uses a separate save button so a stale roundOpen edit doesn't
+  get bundled with a recipient change.
+- Admin gate: `UserType.ADMIN || UserType.SYSTEM_MANAGER || UserType.MANAGER`.
+  Server enforces the same check via `/api/system-config` PUT.
 
 ## Round-activation toggle
 
 Headless UI `<Switch>` bound to `roundOpen`. The thumb is **absolutely
 positioned** with the logical `start-1` (off) / `start-6` (on) properties —
 the previous `flex + translate-x-*` pattern pushed the thumb out of the pill
-in RTL because `translate-x` is physical. Same fix applied earlier to
-`NotificationToggleRow`.
+in RTL because `translate-x` is physical.
 
-## Open
+## Notes
 
-- The ammunition recipient is the only field today. Subsequent phases may add
-  more system-wide flags (retention, default scopes). Each new field follows
-  the same shape: extend `SystemConfig` + `validateSystemConfigPayload` + the
-  hook + this UI.
+- The earlier inline `UserSearchInput` was replaced by
+  `AmmoRecipientsSection`. The new layout mirrors profile-section pattern
+  (edit pencil top-left, view-mode shows display names only — no emails).
+- Storage field on the doc is now an array (`ammoNotificationRecipientUserIds:
+  string[]`). One-shot migration script:
+  `scripts/migrate-ammo-recipient-to-array.mjs`.

--- a/docs/spec/ammunition-feature.md
+++ b/docs/spec/ammunition-feature.md
@@ -67,7 +67,7 @@ The feature reuses heavily from the existing equipment + report-request + notifi
 | `ammunitionInventory` | BRUCE-mode stock per holder (one doc per template+holder). |
 | `ammunitionReports` | Submitted usage reports. |
 | `ammunitionReportRequests` | Manager-triggered requests. Mirrors existing `reportRequests`. |
-| `systemConfig` | Single-doc (`main`) for system-wide settings. New field: `ammoNotificationRecipientUserId`. |
+| `systemConfig` | Single-doc (`main`) for system-wide settings. Ammo recipients live on `ammoNotificationRecipientUserIds: string[]` — array of user UIDs flagged to receive every ammo-report notification + count as ammo-responsible for training-plan approvals. Bounded at 10 entries. |
 
 ### Key types (in `src/types/ammunition.ts`)
 
@@ -168,8 +168,8 @@ interface AmmunitionReportRequest {
 
 1. Read reporter's `teamId` from `users/{reporterId}`.
 2. Query `users` where `teamId == reporter.teamId` AND `userType == TEAM_LEADER`. Exclude reporter if reporter is the TL.
-3. Read `systemConfig/main.ammoNotificationRecipientUserId`.
-4. Build target list = TL UIDs ∪ {recipient}; dedupe; remove the reporter.
+3. Read `systemConfig/main.ammoNotificationRecipientUserIds` (array of UIDs, ≤ 10).
+4. Build target list = TL UIDs ∪ recipients; dedupe; remove the reporter.
 5. Batch-create `AMMO_REPORT_SUBMITTED` notifications with deep link to the report.
 6. All inside one transaction with the report write + inventory decrement + actionsLog entry.
 
@@ -205,7 +205,7 @@ Order matters where noted. A phase's "depends on" lists prior phases that must b
 - Create `src/lib/db/server/systemConfigService.ts` — read/write `systemConfig/main`.
 - Create `src/app/api/system-config/route.ts` — GET + PUT (admin only).
 - Create `src/hooks/useSystemConfig.ts` — `{ config, isLoading, error, save }` shape.
-- Modify `src/components/management/tabs/SystemConfigTab.tsx` — replace placeholder with real form. Add `ammoNotificationRecipientUserId` field using a UserPicker (search users by name).
+- Modify `src/components/management/tabs/SystemConfigTab.tsx` — replace placeholder with real form. Recipients live on `ammoNotificationRecipientUserIds` (array, ≤ 10) — managed by the profile-style `AmmoRecipientsSection` (`src/components/management/tabs/system-config/AmmoRecipientsSection.tsx`).
 
 **Verify:** Admin opens System Config, picks a user, saves, refreshes — value persists. Non-admin can't write (rule check). Add Jest test for the service.
 **Docs:** `docs/codebase/src/lib/db/server/systemConfigService.md`, `docs/codebase/src/hooks/useSystemConfig.md`. Update SystemConfigTab.md.
@@ -275,7 +275,7 @@ Order matters where noted. A phase's "depends on" lists prior phases that must b
   1. write `ammunitionReports` doc
   2. decrement `ammunitionInventory` (BRUCE) or update `ammunition` items to CONSUMED (SERIAL)
   3. write `actionsLog` entry
-  4. resolve TL UIDs via team query + read `systemConfig/main.ammoNotificationRecipientUserId`
+  4. resolve TL UIDs via team query + read `systemConfig/main.ammoNotificationRecipientUserIds` (array)
   5. batch-create notifications
 - Create `src/lib/ammunition/reportsService.ts` (client read).
 - Create `src/app/api/ammunition-reports/route.ts` (POST + GET).

--- a/docs/spec/settings-ownership.md
+++ b/docs/spec/settings-ownership.md
@@ -1,0 +1,39 @@
+# Settings ownership: `/admin` vs `/management`
+
+The project has two settings surfaces:
+
+- `/admin` — owned by ADMIN and SYSTEM_MANAGER. Touches identity boundaries (who is allowed to register, how identity-bearing fields are shaped).
+- `/management` — owned by MANAGER (and ADMIN / SYSTEM_MANAGER, who can do everything). Touches day-to-day operations (rounds, ammo recipient list, equipment templates).
+
+Historically the ammo-recipient editor was duplicated on both surfaces — admins were managing an operational setting because the management UI did not exist yet. As of the multi-recipient migration (`feat/ammo-multi-recipient-and-settings-split`) it lives **only** on `/management`. Use the matrix below to decide where a new setting belongs before you start coding.
+
+## Matrix
+
+| Setting | Route | Why |
+|---|---|---|
+| `systemConfig.teams` | `/admin` | Identity/onboarding boundary — registration validates the user's team against this list. |
+| `authorized_personnel` | `/admin` | Pre-registration allowlist; gated by hash of military personal number. |
+| `systemConfig.ammoNotificationRecipientUserIds` | `/management` | Operational — managers own ammo lifecycle (reports + training plan approvals). |
+| `systemConfig.roundOpen` | `/management` | Operational — managers run rounds and toggle this at start/end. |
+| Equipment templates (`equipmentTemplates`) | `/management` | Operational catalog. |
+| Logistics templates (`logisticsTemplates`) | `/management` | Operational catalog. |
+| Permission grants (`permissionGrants`) | `/management` | Operational delegation; admins still grant top-level roles via `/admin`. |
+| Ammo templates (`ammunitionTemplates`) | `/management` | Operational catalog. |
+
+## Reasoning
+
+Two short rules of thumb:
+
+1. **Identity / who-can-get-in → `/admin`.** If the setting decides whether someone can sign up, what high-level role they carry, or what the system uses to recognise them, it belongs on `/admin`.
+2. **Operations / how-we-run-the-unit → `/management`.** If the setting describes how today's work runs (rounds, what equipment exists, who approves an ammo report), it belongs on `/management`.
+
+When you can't classify cleanly, prefer `/management`. It's the surface that day-to-day operators see; admins always have visibility there too.
+
+## Future-additions checklist
+
+Before adding a new setting to `systemConfig` or anywhere on the two surfaces:
+
+- [ ] Identify the user type that should *own* the setting (admin vs manager).
+- [ ] Place the UI on the corresponding surface only — no duplicates.
+- [ ] Add a row to the matrix above.
+- [ ] If the setting is conceptually an operational primitive that admins might also need, expose a *read-only* mirror on `/admin` rather than a second edit path.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -37,6 +37,7 @@ You can also export these directly in your shell — `.env.local` never clobbers
 | `reconcile-phone.js` | Detect / fix drift between Firebase Auth and Firestore `users.phoneNumber`. Report-only without `--fix`. | yes | no |
 | `sweep-account-deletions.js` | Hard-delete soft-deleted users past the 30-day retention window. Mirror of the daily cron. | yes (resumable via `users.deletionStartedAt`) | **yes** |
 | `check-bundle-size.js` | Run after `next build`. Prints gzipped first-load JS of the largest entrypoint. Fails when over `bundle-budget.json.maxFirstLoadKB`. Wired via `npm run bundle-budget`. CI hookup lands with the Serwist SW PR (Phase 3 of `docs/spec/offline-first.md`). | yes | no |
+| `migrate-ammo-recipient-to-array.mjs` | One-shot: rename `systemConfig/main.ammoNotificationRecipientUserId` (string) → `ammoNotificationRecipientUserIds` (string[]). Ships with the multi-recipient PR. Run once post-merge against prod; idempotent so a second invocation is a no-op. | yes | no |
 
 ## Common flags
 

--- a/scripts/migrate-ammo-recipient-to-array.mjs
+++ b/scripts/migrate-ammo-recipient-to-array.mjs
@@ -1,0 +1,147 @@
+/**
+ * One-shot migration: rename
+ *   `systemConfig/main.ammoNotificationRecipientUserId` (string)
+ *   →
+ *   `systemConfig/main.ammoNotificationRecipientUserIds` (string[])
+ *
+ * Behaviour (idempotent):
+ *   - new field already present (array)  → no-op, skip
+ *   - old field present + non-empty      → write `[<old>]` AND delete old
+ *   - old field absent / empty           → write `[]` AND delete old if any
+ *
+ * Service-account credential + project id are read from `.env.local` using
+ * the same conventions as the rest of `scripts/`:
+ *   - GOOGLE_SERVICE_ACCOUNT_JSON     (plain JSON or base64-encoded JSON)
+ *   - NEXT_PUBLIC_FIREBASE_PROJECT_ID (or pass --project <id> on the CLI)
+ *
+ * Usage:
+ *   node scripts/migrate-ammo-recipient-to-array.mjs              # apply
+ *   node scripts/migrate-ammo-recipient-to-array.mjs --dry-run    # log only
+ *   node scripts/migrate-ammo-recipient-to-array.mjs --project xyz
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import admin from 'firebase-admin';
+
+function loadEnvLocal() {
+  try {
+    const file = readFileSync(resolve(process.cwd(), '.env.local'), 'utf8');
+    for (const line of file.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#')) continue;
+      const eq = trimmed.indexOf('=');
+      if (eq < 0) continue;
+      const key = trimmed.slice(0, eq).trim();
+      let value = trimmed.slice(eq + 1).trim();
+      if (
+        (value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))
+      ) {
+        value = value.slice(1, -1);
+      }
+      if (!(key in process.env)) process.env[key] = value;
+    }
+  } catch {
+    /* .env.local missing — caller may have exported env vars directly. */
+  }
+}
+
+function parseServiceAccount(raw) {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    /* fall through to base64 */
+  }
+  try {
+    const decoded = Buffer.from(raw, 'base64').toString('utf8');
+    return JSON.parse(decoded);
+  } catch (e) {
+    throw new Error(
+      `GOOGLE_SERVICE_ACCOUNT_JSON is neither plain JSON nor base64-encoded JSON: ${e.message}`,
+    );
+  }
+}
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const projectIdx = args.indexOf('--project');
+  const cliProject = projectIdx >= 0 ? args[projectIdx + 1] : undefined;
+  return {
+    dryRun: args.includes('--dry-run'),
+    projectId: cliProject || process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+  };
+}
+
+async function main() {
+  loadEnvLocal();
+  const { dryRun, projectId } = parseArgs(process.argv);
+
+  if (!projectId) {
+    console.error('[migrate] Missing project id (pass --project or set NEXT_PUBLIC_FIREBASE_PROJECT_ID).');
+    process.exit(1);
+  }
+  const saRaw = process.env.GOOGLE_SERVICE_ACCOUNT_JSON;
+  if (!saRaw) {
+    console.error('[migrate] Missing GOOGLE_SERVICE_ACCOUNT_JSON in .env.local');
+    process.exit(1);
+  }
+
+  const saJson = parseServiceAccount(saRaw);
+  if (admin.apps.length === 0) {
+    admin.initializeApp({
+      credential: admin.credential.cert(saJson),
+      projectId,
+    });
+  }
+  const db = admin.firestore();
+  const ref = db.collection('systemConfig').doc('main');
+  const snap = await ref.get();
+
+  if (!snap.exists) {
+    console.log('[migrate] systemConfig/main does not exist — nothing to migrate.');
+    return;
+  }
+
+  const data = snap.data() ?? {};
+  const oldVal = data.ammoNotificationRecipientUserId;
+  const newVal = data.ammoNotificationRecipientUserIds;
+
+  if (Array.isArray(newVal)) {
+    console.log(
+      `[migrate] Skip: ammoNotificationRecipientUserIds already present (length=${newVal.length}).`,
+    );
+    return;
+  }
+
+  let nextArray;
+  if (typeof oldVal === 'string' && oldVal.trim().length > 0) {
+    nextArray = [oldVal.trim()];
+  } else {
+    nextArray = [];
+  }
+
+  const updates = {
+    ammoNotificationRecipientUserIds: nextArray,
+    ammoNotificationRecipientUserId: admin.firestore.FieldValue.delete(),
+    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+  };
+
+  if (dryRun) {
+    console.log('[migrate] [dry-run] would write:', {
+      ammoNotificationRecipientUserIds: nextArray,
+      ammoNotificationRecipientUserId: '<DELETE>',
+    });
+    return;
+  }
+
+  await ref.set(updates, { merge: true });
+  console.log(
+    `[migrate] Done. ammoNotificationRecipientUserIds = ${JSON.stringify(nextArray)}; old field removed.`,
+  );
+}
+
+main().catch((err) => {
+  console.error('[migrate] failed:', err);
+  process.exit(1);
+});

--- a/src/components/ammunition/PlannedTrainingsTable.tsx
+++ b/src/components/ammunition/PlannedTrainingsTable.tsx
@@ -76,13 +76,13 @@ export default function PlannedTrainingsTable({
 }: PlannedTrainingsTableProps) {
   const { enhancedUser } = useAuth();
   const { config: systemConfig } = useSystemConfig();
-  const ammoResponsibleUid = systemConfig?.ammoNotificationRecipientUserId ?? null;
+  const ammoResponsibleUids = systemConfig?.ammoNotificationRecipientUserIds ?? [];
 
   const isAdminOrSysMgr =
     enhancedUser?.userType === UserType.ADMIN ||
     enhancedUser?.userType === UserType.SYSTEM_MANAGER;
   const isAmmoResponsible =
-    !!ammoResponsibleUid && enhancedUser?.uid === ammoResponsibleUid;
+    !!enhancedUser?.uid && ammoResponsibleUids.includes(enhancedUser.uid);
   const canApproveOrReject = isAdminOrSysMgr || isAmmoResponsible;
 
   const { active, archived } = useMemo(() => {

--- a/src/components/management/tabs/SystemConfigTab.tsx
+++ b/src/components/management/tabs/SystemConfigTab.tsx
@@ -1,14 +1,12 @@
 'use client';
 
-import React, { useEffect, useMemo, useState } from 'react';
-import { Bell, ShieldAlert, Save, Package } from 'lucide-react';
+import React, { useEffect, useState } from 'react';
+import { ShieldAlert, Save, Package } from 'lucide-react';
 import { Switch } from '@headlessui/react';
 import { useSystemConfig } from '@/hooks/useSystemConfig';
 import { useAuth } from '@/contexts/AuthContext';
 import { UserType } from '@/types/user';
-import UserSearchInput from '@/components/users/UserSearchInput';
-import type { UserSearchResult } from '@/lib/userService';
-import { getUserProfile } from '@/lib/userService';
+import AmmoRecipientsSection from '@/components/management/tabs/system-config/AmmoRecipientsSection';
 import { TEXT_CONSTANTS } from '@/constants/text';
 import { cn } from '@/lib/cn';
 
@@ -21,70 +19,39 @@ export default function SystemConfigTab() {
     enhancedUser?.userType === UserType.SYSTEM_MANAGER ||
     enhancedUser?.userType === UserType.MANAGER;
 
-  const [recipient, setRecipient] = useState<UserSearchResult | null>(null);
-  const [hydratedFor, setHydratedFor] = useState<string | null>(null);
   const [roundOpen, setRoundOpen] = useState<boolean>(false);
-  const [saving, setSaving] = useState(false);
+  const [savingRound, setSavingRound] = useState(false);
   const [toast, setToast] = useState<{ kind: 'success' | 'error'; message: string } | null>(null);
 
-  const persistedRecipientId = config?.ammoNotificationRecipientUserId || '';
   const persistedRoundOpen = !!config?.roundOpen;
+  const recipientIds = config?.ammoNotificationRecipientUserIds ?? [];
 
   useEffect(() => {
     if (!config) return;
-    if (hydratedFor === persistedRecipientId) return;
     setRoundOpen(persistedRoundOpen);
-    if (!persistedRecipientId) {
-      setRecipient(null);
-      setHydratedFor('');
-      return;
-    }
-    let alive = true;
-    (async () => {
-      const profile = await getUserProfile(persistedRecipientId);
-      if (!alive) return;
-      if (profile) {
-        setRecipient({
-          uid: profile.uid,
-          displayName: `${profile.firstName || ''} ${profile.lastName || ''}`.trim(),
-          email: profile.email || '',
-          firstName: profile.firstName,
-          lastName: profile.lastName,
-          rank: profile.rank,
-          status: profile.status,
-        });
-      } else {
-        setRecipient(null);
-      }
-      setHydratedFor(persistedRecipientId);
-    })();
-    return () => {
-      alive = false;
-    };
-  }, [config, persistedRecipientId, persistedRoundOpen, hydratedFor]);
+  }, [config, persistedRoundOpen]);
 
-  const dirty = useMemo(() => {
-    return (
-      (recipient?.uid || '') !== persistedRecipientId ||
-      roundOpen !== persistedRoundOpen
-    );
-  }, [recipient, persistedRecipientId, roundOpen, persistedRoundOpen]);
+  const roundDirty = roundOpen !== persistedRoundOpen;
 
-  const handleSave = async () => {
+  const handleSaveRound = async () => {
     if (!canEdit) return;
-    setSaving(true);
+    setSavingRound(true);
     setToast(null);
-    const ok = await save({
-      ammoNotificationRecipientUserId: recipient?.uid || '',
-      roundOpen,
-    });
-    setSaving(false);
+    const ok = await save({ roundOpen });
+    setSavingRound(false);
     setToast(
       ok
         ? { kind: 'success', message: 'הגדרות נשמרו' }
         : { kind: 'error', message: 'שמירת ההגדרות נכשלה' }
     );
     setTimeout(() => setToast(null), 3000);
+  };
+
+  const handleSaveRecipients = async (next: string[]) => {
+    const ok = await save({ ammoNotificationRecipientUserIds: next });
+    if (!ok) {
+      throw new Error('save_failed');
+    }
   };
 
   return (
@@ -102,30 +69,15 @@ export default function SystemConfigTab() {
         </div>
       )}
 
-      <div className="bg-white rounded-lg border border-neutral-200 p-6">
-        <div className="flex items-center gap-2 mb-4">
-          <Bell className="w-5 h-5 text-primary-600" />
-          <h4 className="text-lg font-medium text-neutral-900">התראות תחמושת</h4>
-        </div>
-        <p className="text-sm text-neutral-600 mb-4">
-          המנהל האחראי לתחמושת יקבל התראה על כל דיווח חדש בנוסף למפקד הצוות של המדווח.
-        </p>
-
-        <label className="block text-sm font-medium text-neutral-700 mb-2">
-          המנהל האחראי
-        </label>
-        {isLoading ? (
-          <div className="h-10 rounded-lg bg-neutral-100 animate-pulse" />
-        ) : (
-          <div className={canEdit ? '' : 'pointer-events-none opacity-60'}>
-            <UserSearchInput
-              value={recipient}
-              onChange={setRecipient}
-              placeholder="חפש משתמש לפי שם או אימייל"
-            />
-          </div>
-        )}
-      </div>
+      {isLoading ? (
+        <div className="h-32 rounded-lg bg-neutral-100 animate-pulse" />
+      ) : (
+        <AmmoRecipientsSection
+          value={recipientIds}
+          onSave={handleSaveRecipients}
+          disabled={!canEdit}
+        />
+      )}
 
       <div className="bg-white rounded-lg border border-neutral-200 p-6">
         <div className="flex items-center gap-2 mb-4">
@@ -162,12 +114,12 @@ export default function SystemConfigTab() {
       <div className="flex items-center gap-3">
         <button
           type="button"
-          disabled={!canEdit || !dirty || saving}
-          onClick={handleSave}
+          disabled={!canEdit || !roundDirty || savingRound}
+          onClick={handleSaveRound}
           className="inline-flex items-center gap-2 px-4 py-2 bg-primary-600 hover:bg-primary-700 disabled:bg-neutral-300 disabled:cursor-not-allowed text-white font-medium rounded-lg transition-colors"
         >
           <Save className="w-4 h-4" />
-          {saving ? 'שומר...' : 'שמור הגדרות'}
+          {savingRound ? 'שומר...' : 'שמור הגדרות'}
         </button>
         {toast && (
           <span

--- a/src/components/management/tabs/system-config/AmmoRecipientsSection.tsx
+++ b/src/components/management/tabs/system-config/AmmoRecipientsSection.tsx
@@ -1,0 +1,193 @@
+'use client';
+
+/**
+ * Card that lists the configured "ammunition managers" — uids stored on
+ * `systemConfig.ammoNotificationRecipientUserIds`. Mirrors the
+ * `MilitaryInfoSection` profile pattern: view mode = name list with a
+ * top-left edit button, edit mode = same list with X buttons + a
+ * `UserSearchInput` to add more, plus Save/Cancel buttons inline.
+ *
+ * Emails are NEVER shown — recipients are an org-wide setting and the
+ * surface stays name-only on purpose. The component takes a raw uid array
+ * via `value`, resolves names through `useUsersByIds`, and reports the new
+ * uid array through `onSave`. Persistence is the parent's job.
+ */
+import React, { useEffect, useMemo, useState } from 'react';
+import { Pencil, X } from 'lucide-react';
+import UserSearchInput from '@/components/users/UserSearchInput';
+import type { UserSearchResult } from '@/lib/userService';
+import { useUsersByIds } from '@/hooks/useUsersByIds';
+import { FEATURES } from '@/constants/text';
+import { cn } from '@/lib/cn';
+
+const TT = FEATURES.AMMUNITION.RECIPIENTS;
+
+/** Keep aligned with `AMMO_RECIPIENTS_MAX` on the server. */
+const MAX_RECIPIENTS = 10;
+
+export interface AmmoRecipientsSectionProps {
+  value: string[];
+  onSave: (next: string[]) => Promise<void>;
+  disabled?: boolean;
+}
+
+export default function AmmoRecipientsSection({
+  value,
+  onSave,
+  disabled,
+}: AmmoRecipientsSectionProps) {
+  const [editing, setEditing] = useState(false);
+  const [pending, setPending] = useState<string[]>(value);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Resolve display names for whichever list is currently shown. Re-resolves
+  // when the user adds/removes during edit.
+  const idsToResolve = editing ? pending : value;
+  const { users, isLoading } = useUsersByIds(idsToResolve);
+
+  useEffect(() => {
+    if (!editing) setPending(value);
+  }, [value, editing]);
+
+  const renderedList = editing ? pending : value;
+
+  const handleAdd = (user: UserSearchResult | null) => {
+    if (!user) return;
+    if (pending.includes(user.uid)) return;
+    if (pending.length >= MAX_RECIPIENTS) {
+      setError(TT.MAX_REACHED);
+      return;
+    }
+    setPending((prev) => [...prev, user.uid]);
+    setError(null);
+  };
+
+  const handleRemove = (uid: string) => {
+    setPending((prev) => prev.filter((id) => id !== uid));
+    setError(null);
+  };
+
+  const handleSave = async () => {
+    if (saving) return;
+    if (pending.length > MAX_RECIPIENTS) {
+      setError(TT.MAX_REACHED);
+      return;
+    }
+    // Dedup as a defensive measure — UI already guards but the contract is
+    // "pass a clean array down".
+    const deduped = Array.from(new Set(pending));
+    setSaving(true);
+    setError(null);
+    try {
+      await onSave(deduped);
+      setEditing(false);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : TT.SAVE_ERROR);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleCancel = () => {
+    setPending(value);
+    setError(null);
+    setEditing(false);
+  };
+
+  const remainingSlots = useMemo(() => MAX_RECIPIENTS - pending.length, [pending.length]);
+
+  return (
+    <div className="bg-white rounded-lg border border-neutral-200 p-6">
+      <div className="flex items-center justify-between gap-2 mb-2">
+        <h4 className="text-lg font-medium text-neutral-900 min-w-0 truncate">
+          {TT.SECTION_TITLE}
+        </h4>
+        {!editing && (
+          <button
+            type="button"
+            onClick={() => setEditing(true)}
+            aria-label={TT.EDIT_ARIA}
+            disabled={disabled}
+            className={cn(
+              'btn-ghost text-sm flex items-center gap-1 shrink-0',
+              disabled && 'pointer-events-none opacity-60'
+            )}
+          >
+            <Pencil className="w-4 h-4" aria-hidden="true" />
+            <span>{TT.EDIT}</span>
+          </button>
+        )}
+      </div>
+
+      <p className="text-sm text-neutral-600 mb-4">{TT.SECTION_DESCRIPTION}</p>
+
+      {renderedList.length === 0 && !editing && (
+        <p className="text-sm text-neutral-500 italic">{TT.EMPTY_STATE}</p>
+      )}
+
+      {renderedList.length > 0 && (
+        <ul className="space-y-2">
+          {renderedList.map((uid) => {
+            const resolved = users[uid];
+            const label = resolved?.displayName ?? (isLoading ? '...' : uid);
+            return (
+              <li
+                key={uid}
+                className="flex items-center justify-between bg-neutral-50 rounded-lg px-3 py-2"
+              >
+                <span className="text-sm text-neutral-900 truncate">{label}</span>
+                {editing && (
+                  <button
+                    type="button"
+                    onClick={() => handleRemove(uid)}
+                    aria-label={TT.REMOVE_ARIA}
+                    className="p-1 rounded-md text-neutral-500 hover:bg-neutral-200 hover:text-danger-600 transition-colors shrink-0"
+                  >
+                    <X className="w-4 h-4" aria-hidden="true" />
+                  </button>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      {editing && (
+        <div className="mt-4 space-y-3">
+          {remainingSlots > 0 ? (
+            <UserSearchInput
+              value={null}
+              onChange={handleAdd}
+              placeholder={TT.ADD_PLACEHOLDER}
+              excludeUserIds={pending}
+            />
+          ) : (
+            <p className="text-sm text-warning-700">{TT.MAX_REACHED}</p>
+          )}
+
+          {error && <p className="text-sm text-danger-600">{error}</p>}
+
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={saving || disabled}
+              className="btn-primary"
+            >
+              {saving ? TT.SAVING : TT.SAVE}
+            </button>
+            <button
+              type="button"
+              onClick={handleCancel}
+              disabled={saving}
+              className="btn-ghost"
+            >
+              {TT.CANCEL}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/management/tabs/system-config/__tests__/AmmoRecipientsSection.test.tsx
+++ b/src/components/management/tabs/system-config/__tests__/AmmoRecipientsSection.test.tsx
@@ -1,0 +1,199 @@
+/**
+ * Tests for `AmmoRecipientsSection` — the profile-style edit card backing
+ * `systemConfig.ammoNotificationRecipientUserIds`.
+ *
+ * Scope:
+ *   - empty-state copy in view mode
+ *   - renders display names from `useUsersByIds`, never emails
+ *   - edit toggle exposes X buttons + UserSearchInput
+ *   - X removes the row from the pending list
+ *   - search-add appends to pending; save calls onSave with the new array
+ *   - cancel reverts the pending list and exits edit mode
+ *   - duplicate uids cannot be added by the user
+ */
+
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+// ─── Mocks ────────────────────────────────────────────────────────────────
+
+jest.mock('@/hooks/useUsersByIds', () => ({
+  useUsersByIds: (uids: string[]) => ({
+    users: Object.fromEntries(
+      uids.map((uid) => [
+        uid,
+        { uid, displayName: NAME_BY_UID[uid] || uid },
+      ])
+    ),
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+// Lightweight UserSearchInput double — exposes a button per pre-seeded user
+// so tests can pick whichever one they want without dealing with the real
+// debounced search.
+jest.mock('@/components/users/UserSearchInput', () => ({
+  __esModule: true,
+  default: (props: {
+    onChange: (u: { uid: string; displayName: string; email: string }) => void;
+    excludeUserIds?: string[];
+    placeholder?: string;
+  }) => {
+    const pool = [
+      { uid: 'uid-1', displayName: 'דניאל כהן', email: 'd@example.com' },
+      { uid: 'uid-2', displayName: 'יואב לוי', email: 'y@example.com' },
+      { uid: 'uid-3', displayName: 'שירה בן-דוד', email: 's@example.com' },
+      { uid: 'uid-4', displayName: 'New User', email: 'n@example.com' },
+    ];
+    const filtered = pool.filter((u) => !props.excludeUserIds?.includes(u.uid));
+    return (
+      <div data-testid="user-search-input">
+        <span>{props.placeholder}</span>
+        {filtered.map((u) => (
+          <button
+            type="button"
+            key={u.uid}
+            onClick={() => props.onChange(u)}
+            data-testid={`search-pick-${u.uid}`}
+          >
+            {u.displayName}
+          </button>
+        ))}
+      </div>
+    );
+  },
+}));
+
+const NAME_BY_UID: Record<string, string> = {
+  'uid-1': 'דניאל כהן',
+  'uid-2': 'יואב לוי',
+  'uid-3': 'שירה בן-דוד',
+  'uid-4': 'New User',
+};
+
+import AmmoRecipientsSection from '../AmmoRecipientsSection';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────
+
+function renderSection({
+  value = [],
+  onSave = jest.fn(async () => {}),
+  disabled = false,
+}: {
+  value?: string[];
+  onSave?: jest.Mock;
+  disabled?: boolean;
+} = {}) {
+  const utils = render(
+    <AmmoRecipientsSection value={value} onSave={onSave} disabled={disabled} />
+  );
+  return { ...utils, onSave };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────
+
+describe('AmmoRecipientsSection — view mode', () => {
+  it('renders the empty state when no recipients are configured', () => {
+    renderSection({ value: [] });
+    expect(screen.getByText('לא הוגדר מנהל אחראי')).toBeInTheDocument();
+  });
+
+  it('renders display names for each recipient uid', () => {
+    renderSection({ value: ['uid-1', 'uid-2'] });
+    expect(screen.getByText('דניאל כהן')).toBeInTheDocument();
+    expect(screen.getByText('יואב לוי')).toBeInTheDocument();
+  });
+
+  it('never renders emails', () => {
+    renderSection({ value: ['uid-1', 'uid-2'] });
+    expect(screen.queryByText(/@example\.com/)).not.toBeInTheDocument();
+  });
+
+  it('hides the edit affordance when disabled', () => {
+    renderSection({ value: ['uid-1'], disabled: true });
+    const editBtn = screen.getByRole('button', { name: 'ערוך מנהלים אחראים לתחמושת' });
+    expect(editBtn).toHaveClass('pointer-events-none');
+  });
+});
+
+describe('AmmoRecipientsSection — edit mode', () => {
+  it('shows the search input and X buttons when entering edit mode', () => {
+    renderSection({ value: ['uid-1', 'uid-2'] });
+    fireEvent.click(screen.getByRole('button', { name: 'ערוך מנהלים אחראים לתחמושת' }));
+
+    expect(screen.getByTestId('user-search-input')).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: 'הסר מנהל' })).toHaveLength(2);
+  });
+
+  it('X removes the row from the pending list without calling onSave', () => {
+    const onSave = jest.fn();
+    renderSection({ value: ['uid-1', 'uid-2'], onSave });
+    fireEvent.click(screen.getByRole('button', { name: 'ערוך מנהלים אחראים לתחמושת' }));
+
+    const removeBtns = screen.getAllByRole('button', { name: 'הסר מנהל' });
+    fireEvent.click(removeBtns[0]);
+
+    // After removal the row is gone (only one X button left) and the search
+    // pool has the just-removed uid available again.
+    expect(screen.getAllByRole('button', { name: 'הסר מנהל' })).toHaveLength(1);
+    expect(screen.getByText('יואב לוי')).toBeInTheDocument();
+    expect(screen.getByTestId('search-pick-uid-1')).toBeInTheDocument();
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it('search-add appends a user, and save calls onSave with the resulting array', async () => {
+    const onSave = jest.fn(async () => {});
+    renderSection({ value: ['uid-1'], onSave });
+    fireEvent.click(screen.getByRole('button', { name: 'ערוך מנהלים אחראים לתחמושת' }));
+
+    fireEvent.click(screen.getByTestId('search-pick-uid-2'));
+    expect(screen.getByText('יואב לוי')).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'שמור' }));
+    });
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(onSave).toHaveBeenCalledWith(['uid-1', 'uid-2']);
+  });
+
+  it('excludes already-selected uids from the search', () => {
+    renderSection({ value: ['uid-1'] });
+    fireEvent.click(screen.getByRole('button', { name: 'ערוך מנהלים אחראים לתחמושת' }));
+
+    expect(screen.queryByTestId('search-pick-uid-1')).not.toBeInTheDocument();
+    expect(screen.getByTestId('search-pick-uid-2')).toBeInTheDocument();
+  });
+
+  it('cancel reverts pending and exits edit mode', () => {
+    const onSave = jest.fn();
+    renderSection({ value: ['uid-1'], onSave });
+    fireEvent.click(screen.getByRole('button', { name: 'ערוך מנהלים אחראים לתחמושת' }));
+
+    fireEvent.click(screen.getByTestId('search-pick-uid-2'));
+    expect(screen.getByText('יואב לוי')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'ביטול' }));
+
+    expect(screen.queryByText('יואב לוי')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('user-search-input')).not.toBeInTheDocument();
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it('surfaces save errors inline', async () => {
+    const onSave = jest.fn(async () => {
+      throw new Error('boom');
+    });
+    renderSection({ value: ['uid-1'], onSave });
+    fireEvent.click(screen.getByRole('button', { name: 'ערוך מנהלים אחראים לתחמושת' }));
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'שמור' }));
+    });
+    await waitFor(() => expect(screen.getByText('boom')).toBeInTheDocument());
+    // Stays in edit mode after a failed save so the user can retry.
+    expect(screen.getByTestId('user-search-input')).toBeInTheDocument();
+  });
+});

--- a/src/constants/text.en.ts
+++ b/src/constants/text.en.ts
@@ -214,4 +214,23 @@ export const TEXT_EN = {
     SAVED: 'Saved',
     SAVE_ERROR: 'Save failed. Try again.',
   },
+  FEATURES: {
+    AMMUNITION: {
+      RECIPIENTS: {
+        SECTION_TITLE: 'Ammunition managers',
+        SECTION_DESCRIPTION:
+          'Listed managers receive a notification for every ammunition report and can approve training plans.',
+        EMPTY_STATE: 'No managers configured',
+        ADD_PLACEHOLDER: 'Add manager...',
+        EDIT: 'Edit',
+        EDIT_ARIA: 'Edit ammunition managers',
+        SAVE: 'Save',
+        SAVING: 'Saving...',
+        CANCEL: 'Cancel',
+        REMOVE_ARIA: 'Remove manager',
+        MAX_REACHED: 'Up to 10 managers',
+        SAVE_ERROR: 'Saving the list failed. Try again.',
+      },
+    },
+  },
 } as const;

--- a/src/constants/text.ts
+++ b/src/constants/text.ts
@@ -897,6 +897,21 @@ export const TEXT_CONSTANTS = {
         REPORT_SUBMITTED_TITLE: 'דיווח תחמושת חדש',
         REPORT_REQUESTED_TITLE: 'בקשה לדיווח תחמושת'
       },
+      RECIPIENTS: {
+        SECTION_TITLE: 'מנהל אחראי לתחמושת',
+        SECTION_DESCRIPTION:
+          'המנהלים שמוגדרים כאן יקבלו התראה על כל דיווח תחמושת ויקבלו הרשאות לאשר תכנוני אימונים.',
+        EMPTY_STATE: 'לא הוגדר מנהל אחראי',
+        ADD_PLACEHOLDER: 'הוסף מנהל...',
+        EDIT: 'ערוך',
+        EDIT_ARIA: 'ערוך מנהלים אחראים לתחמושת',
+        SAVE: 'שמור',
+        SAVING: 'שומר...',
+        CANCEL: 'ביטול',
+        REMOVE_ARIA: 'הסר מנהל',
+        MAX_REACHED: 'ניתן להגדיר עד 10 מנהלים',
+        SAVE_ERROR: 'שמירת הרשימה נכשלה. נסה שוב.'
+      },
       TRAINING: {
         PAGE_TITLE: 'תכנון אימוני ירי',
         PAGE_SUBTITLE: 'תכנון אימונים, אישור ע״י אחראי תחמושת ובקרה על הבטן',

--- a/src/hooks/__tests__/useUsersByIds.test.ts
+++ b/src/hooks/__tests__/useUsersByIds.test.ts
@@ -1,0 +1,121 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Coverage for the chunked `documentId() in [...]` resolution behind
+ * `useUsersByIds`. The hook is the only piece between the recipient list and
+ * the rendered name, so the contract that matters is:
+ *
+ *   - empty input -> empty map, never reads Firestore
+ *   - dedupes uids before reading
+ *   - chunks at the 10-doc Firestore `in` limit
+ *   - shape of the returned map matches `{ uid: string; displayName }`
+ */
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { useUsersByIds } from '../useUsersByIds';
+
+const mockGetDocs = jest.fn();
+const mockWhere = jest.fn();
+
+jest.mock('firebase/firestore', () => ({
+  collection: jest.fn(() => ({ _kind: 'collection' })),
+  query: jest.fn((c, ...rest) => ({ _kind: 'query', collection: c, where: rest })),
+  where: (...args: unknown[]) => {
+    mockWhere(...args);
+    return { _kind: 'where', args };
+  },
+  documentId: jest.fn(() => '__name__'),
+  getDocs: (...args: unknown[]) => mockGetDocs(...args),
+}));
+
+jest.mock('@/lib/firebase', () => ({
+  db: {},
+}));
+
+function fakeSnapshot(docs: Array<{ id: string; firstName?: string; lastName?: string }>) {
+  return {
+    docs: docs.map((d) => ({
+      id: d.id,
+      data: () => ({ firstName: d.firstName, lastName: d.lastName }),
+    })),
+  };
+}
+
+describe('useUsersByIds', () => {
+  beforeEach(() => {
+    mockGetDocs.mockReset();
+    mockWhere.mockReset();
+  });
+
+  it('returns an empty map and skips Firestore when input is empty', async () => {
+    const { result } = renderHook(() => useUsersByIds([]));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.users).toEqual({});
+    expect(mockGetDocs).not.toHaveBeenCalled();
+  });
+
+  it('resolves a single small batch in one query', async () => {
+    mockGetDocs.mockResolvedValueOnce(
+      fakeSnapshot([
+        { id: 'u1', firstName: 'דנה', lastName: 'כהן' },
+        { id: 'u2', firstName: 'יואב', lastName: 'לוי' },
+      ])
+    );
+
+    const { result } = renderHook(() => useUsersByIds(['u1', 'u2']));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(mockGetDocs).toHaveBeenCalledTimes(1);
+    expect(result.current.users).toEqual({
+      u1: { uid: 'u1', displayName: 'דנה כהן' },
+      u2: { uid: 'u2', displayName: 'יואב לוי' },
+    });
+  });
+
+  it('falls back to uid when no name is stored', async () => {
+    mockGetDocs.mockResolvedValueOnce(fakeSnapshot([{ id: 'u1' }]));
+    const { result } = renderHook(() => useUsersByIds(['u1']));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.users).toEqual({ u1: { uid: 'u1', displayName: 'u1' } });
+  });
+
+  it('dedupes uids before reading', async () => {
+    mockGetDocs.mockResolvedValueOnce(
+      fakeSnapshot([{ id: 'u1', firstName: 'A', lastName: 'B' }])
+    );
+    const { result } = renderHook(() => useUsersByIds(['u1', 'u1', '  ', '']));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(mockGetDocs).toHaveBeenCalledTimes(1);
+    // The single where-call should include exactly one uid in its `in` list.
+    expect(mockWhere).toHaveBeenCalledTimes(1);
+    expect(mockWhere.mock.calls[0][2]).toEqual(['u1']);
+  });
+
+  it('chunks at the 10-uid Firestore `in` limit', async () => {
+    const ids = Array.from({ length: 23 }, (_, i) => `u${i}`);
+    mockGetDocs.mockImplementation(async () =>
+      fakeSnapshot([{ id: 'u0', firstName: 'X', lastName: 'Y' }])
+    );
+
+    const { result } = renderHook(() => useUsersByIds(ids));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    // 23 ids → chunks of 10 + 10 + 3 → 3 queries.
+    expect(mockGetDocs).toHaveBeenCalledTimes(3);
+    expect(mockWhere).toHaveBeenCalledTimes(3);
+    const chunkLengths = mockWhere.mock.calls.map(
+      (call) => (call[2] as string[]).length
+    );
+    // Sort because dedup-sort may reorder vs original input order.
+    expect(chunkLengths.sort((a, b) => b - a)).toEqual([10, 10, 3]);
+  });
+
+  it('reports load errors without throwing', async () => {
+    mockGetDocs.mockRejectedValueOnce(new Error('network'));
+    const { result } = renderHook(() => useUsersByIds(['u1']));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.error).toMatch(/network/);
+    expect(result.current.users).toEqual({});
+  });
+});

--- a/src/hooks/useSystemConfig.ts
+++ b/src/hooks/useSystemConfig.ts
@@ -5,7 +5,7 @@ import { apiFetch } from '@/lib/apiFetch';
 import type { SystemConfig } from '@/types/ammunition';
 
 export interface SystemConfigSavePayload {
-  ammoNotificationRecipientUserId?: string;
+  ammoNotificationRecipientUserIds?: string[];
   teams?: string[];
   roundOpen?: boolean;
 }

--- a/src/hooks/useUsersByIds.ts
+++ b/src/hooks/useUsersByIds.ts
@@ -1,0 +1,100 @@
+'use client';
+
+/**
+ * Resolve a list of user UIDs to display names. Used by surfaces that store
+ * `users.uid` references (e.g. `systemConfig.ammoNotificationRecipientUserIds`)
+ * and need to render names without showing emails.
+ *
+ * Implementation: Firestore `documentId() in [...]` query, chunked at the
+ * 10-doc limit. Memoised on the joined uid list — re-runs only when the set
+ * actually changes.
+ */
+import { useEffect, useMemo, useState } from 'react';
+import {
+  collection,
+  documentId,
+  getDocs,
+  query as fsQuery,
+  where,
+} from 'firebase/firestore';
+import { db } from '@/lib/firebase';
+import { ADMIN_CONFIG } from '@/constants/admin';
+
+export interface ResolvedUser {
+  uid: string;
+  displayName: string;
+}
+
+export interface UseUsersByIdsReturn {
+  users: Record<string, ResolvedUser>;
+  isLoading: boolean;
+  error: string | null;
+}
+
+/** Firestore caps `in` queries at 10 values. */
+const IN_CHUNK_SIZE = 10;
+
+function chunk<T>(arr: T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) {
+    out.push(arr.slice(i, i + size));
+  }
+  return out;
+}
+
+export function useUsersByIds(uids: string[]): UseUsersByIdsReturn {
+  // Dedup + stable key so the effect dep array doesn't re-fire on identity
+  // change when content is unchanged.
+  const uniqueKey = useMemo(() => {
+    const cleaned = Array.from(new Set(uids.filter((u) => typeof u === 'string' && u.trim().length > 0)));
+    cleaned.sort();
+    return cleaned.join('|');
+  }, [uids]);
+
+  const [users, setUsers] = useState<Record<string, ResolvedUser>>({});
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!uniqueKey) {
+      setUsers({});
+      setIsLoading(false);
+      setError(null);
+      return;
+    }
+    const ids = uniqueKey.split('|');
+    let alive = true;
+    setIsLoading(true);
+    setError(null);
+
+    (async () => {
+      try {
+        const next: Record<string, ResolvedUser> = {};
+        const usersCol = collection(db, ADMIN_CONFIG.FIRESTORE_USERS_COLLECTION);
+        for (const part of chunk(ids, IN_CHUNK_SIZE)) {
+          const q = fsQuery(usersCol, where(documentId(), 'in', part));
+          const snap = await getDocs(q);
+          snap.docs.forEach((d) => {
+            const data = d.data() as { firstName?: string; lastName?: string };
+            const displayName = `${data.firstName || ''} ${data.lastName || ''}`.trim() || d.id;
+            next[d.id] = { uid: d.id, displayName };
+          });
+        }
+        if (!alive) return;
+        setUsers(next);
+      } catch (e) {
+        if (!alive) return;
+        console.error('[useUsersByIds] resolve failed:', e);
+        setError(e instanceof Error ? e.message : 'שגיאה בטעינת משתמשים');
+      } finally {
+        if (alive) setIsLoading(false);
+      }
+    })();
+
+    return () => {
+      alive = false;
+    };
+  }, [uniqueKey]);
+
+  return { users, isLoading, error };
+}

--- a/src/lib/__tests__/ammunitionReportsService.recipients.test.ts
+++ b/src/lib/__tests__/ammunitionReportsService.recipients.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Targeted tests for `resolveRecipients` in ammunitionReportsService.
+ * Covers the multi-recipient array shape + the dedupe / reporter-exclusion
+ * post-processing applied in `serverSubmitAmmunitionReport`.
+ */
+
+jest.mock('firebase-admin/firestore', () => ({
+  Timestamp: {
+    now: () => ({ toDate: () => new Date(), seconds: 0, nanoseconds: 0 }),
+    fromDate: (d: Date) => ({ toDate: () => d, seconds: 0, nanoseconds: 0 }),
+  },
+  FieldValue: {
+    serverTimestamp: () => 'SERVER_TIMESTAMP',
+  },
+}));
+
+jest.mock('firebase-admin/app', () => ({
+  initializeApp: () => ({}),
+  getApps: () => [],
+  cert: () => ({}),
+  applicationDefault: () => ({}),
+}));
+
+// ─── In-memory admin DB fake ───────────────────────────────────────────────
+
+interface FakeDocSnap {
+  exists: boolean;
+  id: string;
+  data: () => Record<string, unknown> | undefined;
+}
+
+interface FakeQuery {
+  where: (field: string, op: string, value: unknown) => FakeQuery;
+  get: () => Promise<{ docs: FakeDocSnap[] }>;
+}
+
+interface UserDocSeed {
+  id: string;
+  teamId?: string;
+  userType?: string;
+}
+
+interface DbSeed {
+  users: UserDocSeed[];
+  systemConfigMain: Record<string, unknown> | null;
+}
+
+let seed: DbSeed = { users: [], systemConfigMain: null };
+
+const fakeDb = {
+  collection: (name: string) => {
+    if (name === 'users') {
+      return {
+        doc: (id: string): { get: () => Promise<FakeDocSnap> } => ({
+          get: async () => {
+            const u = seed.users.find((x) => x.id === id);
+            return {
+              exists: !!u,
+              id,
+              data: () => (u ? { teamId: u.teamId, userType: u.userType } : undefined),
+            };
+          },
+        }),
+        where: (field: string, op: string, value: unknown): FakeQuery => {
+          const filters: Array<[string, string, unknown]> = [[field, op, value]];
+          const q: FakeQuery = {
+            where: (f2, o2, v2) => {
+              filters.push([f2, o2, v2]);
+              return q;
+            },
+            get: async () => {
+              const docs: FakeDocSnap[] = seed.users
+                .filter((u) =>
+                  filters.every(([f, , v]) => {
+                    if (f === 'teamId') return u.teamId === v;
+                    if (f === 'userType') return u.userType === v;
+                    return true;
+                  })
+                )
+                .map((u) => ({
+                  exists: true,
+                  id: u.id,
+                  data: () => ({ teamId: u.teamId, userType: u.userType }),
+                }));
+              return { docs };
+            },
+          };
+          return q;
+        },
+      };
+    }
+    if (name === 'systemConfig') {
+      return {
+        doc: (id: string) => ({
+          get: async (): Promise<FakeDocSnap> => ({
+            exists: id === 'main' && seed.systemConfigMain !== null,
+            id,
+            data: () => seed.systemConfigMain ?? undefined,
+          }),
+        }),
+      };
+    }
+    throw new Error(`unexpected collection: ${name}`);
+  },
+};
+
+jest.mock('@/lib/db/admin', () => ({
+  getAdminDb: jest.fn(() => fakeDb),
+}));
+
+jest.mock('@/lib/db/collections', () => ({
+  COLLECTIONS: {
+    USERS: 'users',
+    SYSTEM_CONFIG: 'systemConfig',
+    AMMUNITION_TEMPLATES: 'ammunitionTemplates',
+    AMMUNITION_REPORTS: 'ammunitionReports',
+    AMMUNITION_INVENTORY: 'ammunitionInventory',
+    AMMUNITION: 'ammunition',
+  },
+}));
+
+import { resolveRecipients } from '@/lib/db/server/ammunitionReportsService';
+import { UserType } from '@/types/user';
+
+describe('resolveRecipients', () => {
+  beforeEach(() => {
+    seed = { users: [], systemConfigMain: null };
+  });
+
+  it('returns empty arrays when reporter has no team and no managers configured', async () => {
+    seed.users = [{ id: 'reporter', teamId: '' }];
+    const out = await resolveRecipients('reporter');
+    expect(out).toEqual({ teamLeaderIds: [], responsibleManagerIds: [] });
+  });
+
+  it('includes all configured responsible managers from the array', async () => {
+    seed.users = [{ id: 'reporter', teamId: '' }];
+    seed.systemConfigMain = {
+      ammoNotificationRecipientUserIds: ['mgr-1', 'mgr-2', 'mgr-3'],
+    };
+    const out = await resolveRecipients('reporter');
+    expect(out.responsibleManagerIds).toEqual(['mgr-1', 'mgr-2', 'mgr-3']);
+  });
+
+  it('skips empty + non-string entries inside the array', async () => {
+    seed.users = [{ id: 'reporter', teamId: '' }];
+    seed.systemConfigMain = {
+      ammoNotificationRecipientUserIds: ['mgr-1', '', '  ', null, 42, 'mgr-2'],
+    };
+    const out = await resolveRecipients('reporter');
+    expect(out.responsibleManagerIds).toEqual(['mgr-1', 'mgr-2']);
+  });
+
+  it('returns empty managers when the field is missing', async () => {
+    seed.users = [{ id: 'reporter' }];
+    seed.systemConfigMain = {};
+    const out = await resolveRecipients('reporter');
+    expect(out.responsibleManagerIds).toEqual([]);
+  });
+
+  it('unions team leaders of the reporter team excluding the reporter', async () => {
+    seed.users = [
+      { id: 'reporter', teamId: 'alpha', userType: UserType.USER },
+      { id: 'tl-1', teamId: 'alpha', userType: UserType.TEAM_LEADER },
+      { id: 'tl-2', teamId: 'alpha', userType: UserType.TEAM_LEADER },
+      { id: 'tl-3', teamId: 'bravo', userType: UserType.TEAM_LEADER },
+    ];
+    seed.systemConfigMain = { ammoNotificationRecipientUserIds: ['mgr-1'] };
+
+    const out = await resolveRecipients('reporter');
+    expect(new Set(out.teamLeaderIds)).toEqual(new Set(['tl-1', 'tl-2']));
+    expect(out.responsibleManagerIds).toEqual(['mgr-1']);
+  });
+
+  it('keeps reporter-as-TL out of the team-leader list', async () => {
+    seed.users = [
+      { id: 'reporter', teamId: 'alpha', userType: UserType.TEAM_LEADER },
+      { id: 'tl-2', teamId: 'alpha', userType: UserType.TEAM_LEADER },
+    ];
+    const out = await resolveRecipients('reporter');
+    expect(out.teamLeaderIds).toEqual(['tl-2']);
+  });
+});
+
+describe('recipient post-processing (union + dedupe + reporter exclusion)', () => {
+  // The unioning happens inside `serverSubmitAmmunitionReport`. We replicate
+  // the same Set + filter pipeline here so a regression in the inline logic
+  // gets caught by a focused test.
+  function unionAndExclude(
+    teamLeaderIds: string[],
+    responsibleManagerIds: string[],
+    reporterUid: string
+  ): string[] {
+    return Array.from(new Set([...teamLeaderIds, ...responsibleManagerIds])).filter(
+      (uid) => uid !== reporterUid
+    );
+  }
+
+  it('dedupes when a TL is also a configured manager', () => {
+    const out = unionAndExclude(['tl-1', 'tl-2'], ['tl-1', 'mgr-1'], 'reporter');
+    expect(out.sort()).toEqual(['mgr-1', 'tl-1', 'tl-2']);
+  });
+
+  it('excludes the reporter even when listed as a manager', () => {
+    const out = unionAndExclude(['tl-1'], ['reporter', 'mgr-1'], 'reporter');
+    expect(out.sort()).toEqual(['mgr-1', 'tl-1']);
+  });
+});

--- a/src/lib/__tests__/systemConfigService.array.test.ts
+++ b/src/lib/__tests__/systemConfigService.array.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Validation tests for the array-shaped recipient field on
+ * `validateSystemConfigPayload`. Mirrors the patterns used in
+ * `systemConfigService.test.ts` — admin DB is sentinel-mocked so we cover
+ * input-shape behaviour without touching Firestore.
+ */
+
+jest.mock('firebase-admin/firestore', () => ({
+  Timestamp: {
+    now: () => ({ toDate: () => new Date(), seconds: 0, nanoseconds: 0 }),
+    fromDate: (d: Date) => ({ toDate: () => d, seconds: 0, nanoseconds: 0 }),
+  },
+  FieldValue: {
+    serverTimestamp: () => 'SERVER_TIMESTAMP',
+  },
+}));
+
+jest.mock('firebase-admin/app', () => ({
+  initializeApp: () => ({}),
+  getApps: () => [],
+  cert: () => ({}),
+  applicationDefault: () => ({}),
+}));
+
+jest.mock('@/lib/db/admin', () => ({
+  getAdminDb: jest.fn(() => {
+    throw new Error('Test reached admin DB without setting up a fake');
+  }),
+}));
+
+import {
+  validateSystemConfigPayload,
+  AMMO_RECIPIENTS_MAX,
+} from '@/lib/db/server/systemConfigService';
+
+describe('validateSystemConfigPayload — ammoNotificationRecipientUserIds', () => {
+  it('accepts an empty array', () => {
+    expect(
+      validateSystemConfigPayload({ ammoNotificationRecipientUserIds: [] })
+    ).toEqual({ ammoNotificationRecipientUserIds: [] });
+  });
+
+  it('passes through a normalized array of uids', () => {
+    expect(
+      validateSystemConfigPayload({
+        ammoNotificationRecipientUserIds: ['uid-1', 'uid-2', 'uid-3'],
+      })
+    ).toEqual({ ammoNotificationRecipientUserIds: ['uid-1', 'uid-2', 'uid-3'] });
+  });
+
+  it('coerces null and undefined to an empty array', () => {
+    expect(
+      validateSystemConfigPayload({ ammoNotificationRecipientUserIds: null })
+    ).toEqual({ ammoNotificationRecipientUserIds: [] });
+    expect(
+      validateSystemConfigPayload({ ammoNotificationRecipientUserIds: undefined })
+    ).toEqual({ ammoNotificationRecipientUserIds: [] });
+  });
+
+  it('throws when the value is not an array', () => {
+    expect(() =>
+      validateSystemConfigPayload({ ammoNotificationRecipientUserIds: 'uid-1' })
+    ).toThrow(/must be an array/);
+    expect(() =>
+      validateSystemConfigPayload({ ammoNotificationRecipientUserIds: 42 })
+    ).toThrow(/must be an array/);
+  });
+
+  it('throws when entries are not strings', () => {
+    expect(() =>
+      validateSystemConfigPayload({
+        ammoNotificationRecipientUserIds: ['uid-1', 42 as unknown as string],
+      })
+    ).toThrow(/entries must be strings/);
+  });
+
+  it('throws when entries contain only whitespace', () => {
+    expect(() =>
+      validateSystemConfigPayload({
+        ammoNotificationRecipientUserIds: ['uid-1', '   '],
+      })
+    ).toThrow(/non-empty/);
+  });
+
+  it('rejects duplicate uids', () => {
+    expect(() =>
+      validateSystemConfigPayload({
+        ammoNotificationRecipientUserIds: ['uid-1', 'uid-1'],
+      })
+    ).toThrow(/duplicate/);
+  });
+
+  it('trims whitespace inside entries', () => {
+    expect(
+      validateSystemConfigPayload({
+        ammoNotificationRecipientUserIds: ['  uid-1  ', 'uid-2'],
+      })
+    ).toEqual({ ammoNotificationRecipientUserIds: ['uid-1', 'uid-2'] });
+  });
+
+  it('enforces the maximum length cap', () => {
+    const overflow = Array.from({ length: AMMO_RECIPIENTS_MAX + 1 }, (_, i) => `uid-${i}`);
+    expect(() =>
+      validateSystemConfigPayload({ ammoNotificationRecipientUserIds: overflow })
+    ).toThrow(/exceeds the maximum/);
+
+    const atCap = Array.from({ length: AMMO_RECIPIENTS_MAX }, (_, i) => `uid-${i}`);
+    expect(
+      validateSystemConfigPayload({ ammoNotificationRecipientUserIds: atCap })
+    ).toEqual({ ammoNotificationRecipientUserIds: atCap });
+  });
+});

--- a/src/lib/__tests__/systemConfigService.test.ts
+++ b/src/lib/__tests__/systemConfigService.test.ts
@@ -39,24 +39,6 @@ describe('systemConfigService.validateSystemConfigPayload', () => {
     expect(validateSystemConfigPayload({})).toEqual({});
   });
 
-  it('passes through a string recipient id', () => {
-    const out = validateSystemConfigPayload({ ammoNotificationRecipientUserId: 'uid-1' });
-    expect(out.ammoNotificationRecipientUserId).toBe('uid-1');
-  });
-
-  it('coerces null/empty/undefined recipient to empty string for clearing', () => {
-    expect(validateSystemConfigPayload({ ammoNotificationRecipientUserId: null }))
-      .toEqual({ ammoNotificationRecipientUserId: '' });
-    expect(validateSystemConfigPayload({ ammoNotificationRecipientUserId: '' }))
-      .toEqual({ ammoNotificationRecipientUserId: '' });
-  });
-
-  it('throws when recipient id is not a string', () => {
-    expect(() =>
-      validateSystemConfigPayload({ ammoNotificationRecipientUserId: 42 })
-    ).toThrow(/must be a string/);
-  });
-
   it('throws when payload is not an object', () => {
     expect(() => validateSystemConfigPayload(undefined)).toThrow(/payload is required/);
     expect(() => validateSystemConfigPayload(null)).toThrow(/payload is required/);
@@ -82,7 +64,7 @@ describe('systemConfigService — admin DB reach (proves validation passed)', ()
   it('serverUpdateSystemConfig touches the admin DB after validation', async () => {
     await expect(
       serverUpdateSystemConfig({
-        payload: { ammoNotificationRecipientUserId: 'uid-1' },
+        payload: { roundOpen: true },
         actorUserId: 'admin-uid',
       })
     ).rejects.toThrow(/Test reached admin DB/);

--- a/src/lib/db/server/ammunitionInventoryService.ts
+++ b/src/lib/db/server/ammunitionInventoryService.ts
@@ -8,7 +8,7 @@
  *
  * Permission model (enforced here, not by callers):
  *   - ADMIN / SYSTEM_MANAGER / MANAGER → any holder.
- *   - admin-configured `ammoNotificationRecipientUserId` → any holder.
+ *   - any uid in `systemConfig.ammoNotificationRecipientUserIds` → any holder.
  *   - TEAM_LEADER → own team + members of own team.
  *   - USER → self only, USER-allocated templates only.
  *   - Update / delete: actor's own writes only, manager+ overrides.
@@ -40,11 +40,13 @@ function isManagerOrAbove(userType: UserType): boolean {
   );
 }
 
-async function getResponsibleManagerId(): Promise<string | null> {
+async function getResponsibleManagerIds(): Promise<string[]> {
   const db = getAdminDb();
   const snap = await db.collection(COLLECTIONS.SYSTEM_CONFIG).doc('main').get();
-  if (!snap.exists) return null;
-  return (snap.data()?.ammoNotificationRecipientUserId as string) || null;
+  if (!snap.exists) return [];
+  const raw = snap.data()?.ammoNotificationRecipientUserIds;
+  if (!Array.isArray(raw)) return [];
+  return raw.filter((uid): uid is string => typeof uid === 'string' && uid.trim().length > 0);
 }
 
 async function userTeamId(uid: string): Promise<string | undefined> {
@@ -71,18 +73,18 @@ export interface MutationContext {
 export async function canMutateAmmunitionInventory(ctx: MutationContext): Promise<boolean> {
   const { actor, template, holderType, holderId } = ctx;
 
-  // UNIT (central pool) is admin/manager + responsible-mgr only. TL and USER
+  // UNIT (central pool) is admin/manager + responsible-mgrs only. TL and USER
   // never write to the warehouse — they receive via assignFromCentral.
   if (holderType === 'UNIT') {
     if (isManagerOrAbove(actor.userType)) return true;
-    const responsibleId = await getResponsibleManagerId();
-    return !!responsibleId && responsibleId === actor.uid;
+    const responsibleIds = await getResponsibleManagerIds();
+    return responsibleIds.includes(actor.uid);
   }
 
   if (isManagerOrAbove(actor.userType)) return true;
 
-  const responsibleId = await getResponsibleManagerId();
-  if (responsibleId && responsibleId === actor.uid) return true;
+  const responsibleIds = await getResponsibleManagerIds();
+  if (responsibleIds.includes(actor.uid)) return true;
 
   if (actor.userType === UserType.TEAM_LEADER) {
     if (!actor.teamId) return false;
@@ -205,8 +207,8 @@ export async function serverUpsertAmmunitionStock(
     existingCreatedBy &&
     existingCreatedBy !== input.actor.uid
   ) {
-    const responsibleId = await getResponsibleManagerId();
-    if (responsibleId !== input.actor.uid) {
+    const responsibleIds = await getResponsibleManagerIds();
+    if (!responsibleIds.includes(input.actor.uid)) {
       throw new Error('Forbidden: cannot modify another user\'s inventory entry');
     }
   }
@@ -244,8 +246,8 @@ export async function serverDeleteAmmunitionStock(input: DeleteStockInput): Prom
     createdBy &&
     createdBy !== input.actor.uid
   ) {
-    const responsibleId = await getResponsibleManagerId();
-    if (responsibleId !== input.actor.uid) {
+    const responsibleIds = await getResponsibleManagerIds();
+    if (!responsibleIds.includes(input.actor.uid)) {
       throw new Error('Forbidden: cannot delete another user\'s inventory entry');
     }
   }
@@ -386,13 +388,16 @@ export async function serverReturnSerialItemToMgr(
     throw new Error('Only CONSUMED items can be returned to the ammo manager');
   }
 
-  const ammoMgrId = await getResponsibleManagerId();
-  if (!ammoMgrId) {
+  const ammoMgrIds = await getResponsibleManagerIds();
+  if (ammoMgrIds.length === 0) {
     throw new Error('No ammo-responsible user is configured in system config');
   }
+  // When multiple managers are configured, the first entry is the canonical
+  // "return-to" target — UI lists them in display order, top is primary.
+  const ammoMgrId = ammoMgrIds[0];
 
-  // Permission: admin / system_manager / manager, OR ammo-responsible user, OR TL of holding team.
-  let allowed = isManagerOrAbove(actor.userType) || actor.uid === ammoMgrId;
+  // Permission: admin / system_manager / manager, OR any ammo-responsible user, OR TL of holding team.
+  let allowed = isManagerOrAbove(actor.userType) || ammoMgrIds.includes(actor.uid);
   if (!allowed && actor.userType === UserType.TEAM_LEADER && actor.teamId) {
     if (item.currentHolderType === 'TEAM') {
       allowed = item.currentHolderId === actor.teamId;

--- a/src/lib/db/server/ammunitionReportsService.ts
+++ b/src/lib/db/server/ammunitionReportsService.ts
@@ -114,10 +114,10 @@ export function validateSubmitReportInput(input: unknown): SubmitReportInput {
 
 interface ResolvedRecipients {
   teamLeaderIds: string[];
-  responsibleManagerId: string | null;
+  responsibleManagerIds: string[];
 }
 
-async function resolveRecipients(reporterUid: string): Promise<ResolvedRecipients> {
+export async function resolveRecipients(reporterUid: string): Promise<ResolvedRecipients> {
   const db = getAdminDb();
 
   const reporterSnap = await db.collection(COLLECTIONS.USERS).doc(reporterUid).get();
@@ -136,11 +136,15 @@ async function resolveRecipients(reporterUid: string): Promise<ResolvedRecipient
   }
 
   const cfgSnap = await db.collection(COLLECTIONS.SYSTEM_CONFIG).doc('main').get();
-  const responsibleManagerId = cfgSnap.exists
-    ? ((cfgSnap.data()?.ammoNotificationRecipientUserId as string) || null)
-    : null;
+  const responsibleManagerIds = cfgSnap.exists
+    ? (((cfgSnap.data()?.ammoNotificationRecipientUserIds as unknown) instanceof Array
+        ? (cfgSnap.data()?.ammoNotificationRecipientUserIds as unknown[])
+        : []
+      )
+        .filter((uid): uid is string => typeof uid === 'string' && uid.trim().length > 0))
+    : [];
 
-  return { teamLeaderIds, responsibleManagerId };
+  return { teamLeaderIds, responsibleManagerIds };
 }
 
 export interface SubmitReportResult {
@@ -262,7 +266,7 @@ export async function serverSubmitAmmunitionReport(
 
   const recipients = await resolveRecipients(reporterUid);
   const recipientIds = Array.from(
-    new Set([...recipients.teamLeaderIds, ...(recipients.responsibleManagerId ? [recipients.responsibleManagerId] : [])])
+    new Set([...recipients.teamLeaderIds, ...recipients.responsibleManagerIds])
   ).filter((uid) => uid !== reporterUid);
 
   // Side effects — failures here do not roll back the report.

--- a/src/lib/db/server/systemConfigService.ts
+++ b/src/lib/db/server/systemConfigService.ts
@@ -1,8 +1,9 @@
 /**
  * Server-side System Config Service (firebase-admin).
  * Backs the single doc `systemConfig/main` — system-wide settings.
- * Currently used for `ammoNotificationRecipientUserId`; will accumulate
- * additional system-wide flags as features land.
+ * Currently used for `ammoNotificationRecipientUserIds` (array of ammo
+ * managers), `teams`, and `roundOpen`; will accumulate additional system-wide
+ * flags as features land.
  */
 import { getAdminDb } from '../admin';
 import { COLLECTIONS } from '../collections';
@@ -11,13 +12,19 @@ import type { SystemConfig } from '@/types/ammunition';
 
 const MAIN_DOC_ID = 'main';
 
+/**
+ * Maximum number of ammo notification recipients we allow callers to store.
+ * Keep in sync with `AmmoRecipientsSection` UI cap.
+ */
+export const AMMO_RECIPIENTS_MAX = 10;
+
 export type SystemConfigUpdatableFields = Pick<
   SystemConfig,
-  'ammoNotificationRecipientUserId' | 'teams' | 'roundOpen'
+  'ammoNotificationRecipientUserIds' | 'teams' | 'roundOpen'
 >;
 
 export interface SystemConfigPayload {
-  ammoNotificationRecipientUserId?: string;
+  ammoNotificationRecipientUserIds?: string[];
   teams?: string[];
   roundOpen?: boolean;
 }
@@ -41,14 +48,35 @@ export function validateSystemConfigPayload(payload: unknown): SystemConfigPaylo
   const p = payload as Record<string, unknown>;
   const out: SystemConfigPayload = {};
 
-  if ('ammoNotificationRecipientUserId' in p) {
-    const v = p.ammoNotificationRecipientUserId;
-    if (v === null || v === '' || v === undefined) {
-      out.ammoNotificationRecipientUserId = '';
-    } else if (typeof v === 'string') {
-      out.ammoNotificationRecipientUserId = v;
+  if ('ammoNotificationRecipientUserIds' in p) {
+    const v = p.ammoNotificationRecipientUserIds;
+    if (v === undefined || v === null) {
+      out.ammoNotificationRecipientUserIds = [];
+    } else if (!Array.isArray(v)) {
+      throw new Error('ammoNotificationRecipientUserIds must be an array of strings');
     } else {
-      throw new Error('ammoNotificationRecipientUserId must be a string');
+      const seen = new Set<string>();
+      const normalized: string[] = [];
+      for (const item of v) {
+        if (typeof item !== 'string') {
+          throw new Error('ammoNotificationRecipientUserIds entries must be strings');
+        }
+        const trimmed = item.trim();
+        if (!trimmed) {
+          throw new Error('ammoNotificationRecipientUserIds entries must be non-empty');
+        }
+        if (seen.has(trimmed)) {
+          throw new Error('ammoNotificationRecipientUserIds contains duplicate uids');
+        }
+        seen.add(trimmed);
+        normalized.push(trimmed);
+      }
+      if (normalized.length > AMMO_RECIPIENTS_MAX) {
+        throw new Error(
+          `ammoNotificationRecipientUserIds exceeds the maximum of ${AMMO_RECIPIENTS_MAX}`
+        );
+      }
+      out.ammoNotificationRecipientUserIds = normalized;
     }
   }
 

--- a/src/lib/db/server/trainingPlanService.ts
+++ b/src/lib/db/server/trainingPlanService.ts
@@ -44,17 +44,18 @@ function isTeamLeaderOrAbove(actor: ApiActor): boolean {
   );
 }
 
-async function getAmmoResponsibleUserId(): Promise<string | null> {
+async function getAmmoResponsibleUserIds(): Promise<string[]> {
   const db = getAdminDb();
   const snap = await db.collection(COLLECTIONS.SYSTEM_CONFIG).doc('main').get();
-  if (!snap.exists) return null;
+  if (!snap.exists) return [];
   const data = snap.data() ?? {};
-  const id = data.ammoNotificationRecipientUserId;
-  return typeof id === 'string' && id ? id : null;
+  const raw = data.ammoNotificationRecipientUserIds;
+  if (!Array.isArray(raw)) return [];
+  return raw.filter((uid): uid is string => typeof uid === 'string' && uid.trim().length > 0);
 }
 
-function isAmmoResponsible(actor: ApiActor, ammoResponsibleUid: string | null): boolean {
-  return !!ammoResponsibleUid && actor.uid === ammoResponsibleUid;
+function isAmmoResponsible(actor: ApiActor, ammoResponsibleUids: string[]): boolean {
+  return ammoResponsibleUids.includes(actor.uid);
 }
 
 export function validateCreateTrainingPlanInput(input: unknown): CreateTrainingPlanInput {
@@ -153,8 +154,8 @@ export async function serverCreateTrainingPlan(
   await ref.set(data);
 
   try {
-    const ammoResponsibleUid = await getAmmoResponsibleUserId();
-    if (ammoResponsibleUid) {
+    const ammoResponsibleUids = await getAmmoResponsibleUserIds();
+    for (const ammoResponsibleUid of ammoResponsibleUids) {
       await serverCreateNotification({
         userId: ammoResponsibleUid,
         type: NotificationType.TRAINING_PLAN_SUBMITTED,
@@ -184,7 +185,7 @@ export async function serverTransitionTrainingPlan(input: TransitionInput): Prom
   }
   const db = getAdminDb();
   const ref = db.collection(COLLECTIONS.TRAINING_PLANS).doc(input.planId);
-  const ammoResponsibleUid = await getAmmoResponsibleUserId();
+  const ammoResponsibleUids = await getAmmoResponsibleUserIds();
 
   let newStatus: TrainingPlanStatus = 'PENDING_APPROVAL';
   let plannedBy = '';
@@ -199,7 +200,7 @@ export async function serverTransitionTrainingPlan(input: TransitionInput): Prom
     teamId = (data.teamId as string) || '';
 
     const isPlanner = input.actor.uid === plannedBy;
-    const isApprover = isAdminOrSystemManager(input.actor) || isAmmoResponsible(input.actor, ammoResponsibleUid);
+    const isApprover = isAdminOrSystemManager(input.actor) || isAmmoResponsible(input.actor, ammoResponsibleUids);
 
     if (input.action === 'approve' || input.action === 'reject') {
       if (!isApprover) throw new Error('Forbidden: only the ammo-responsible user, system manager, or admin may approve or reject');
@@ -276,18 +277,20 @@ export async function serverCreateRestockRequest(input: RestockRequestInput): Pr
   const planSnap = await planRef.get();
   if (!planSnap.exists) throw new Error('Training plan not found');
 
-  const ammoResponsibleUid = await getAmmoResponsibleUserId();
-  if (!ammoResponsibleUid) {
+  const ammoResponsibleUids = await getAmmoResponsibleUserIds();
+  if (ammoResponsibleUids.length === 0) {
     throw new Error('No ammo-responsible user is configured in system config');
   }
 
-  await serverCreateNotification({
-    userId: ammoResponsibleUid,
-    type: NotificationType.AMMO_RESTOCK_REQUEST,
-    title: 'בקשה לתוספת תחמושת',
-    message: input.note
-      ? `${input.actorName} מבקש ${input.shortfallQty} ${input.templateName}: ${input.note}`
-      : `${input.actorName} מבקש תוספת של ${input.shortfallQty} ${input.templateName} עבור אימון`,
-    relatedEquipmentDocId: input.planId,
-  });
+  for (const ammoResponsibleUid of ammoResponsibleUids) {
+    await serverCreateNotification({
+      userId: ammoResponsibleUid,
+      type: NotificationType.AMMO_RESTOCK_REQUEST,
+      title: 'בקשה לתוספת תחמושת',
+      message: input.note
+        ? `${input.actorName} מבקש ${input.shortfallQty} ${input.templateName}: ${input.note}`
+        : `${input.actorName} מבקש תוספת של ${input.shortfallQty} ${input.templateName} עבור אימון`,
+      relatedEquipmentDocId: input.planId,
+    });
+  }
 }

--- a/src/types/ammunition.ts
+++ b/src/types/ammunition.ts
@@ -136,7 +136,13 @@ export interface AmmunitionReportRequest {
 
 export interface SystemConfig {
   id: string;
-  ammoNotificationRecipientUserId?: string;
+  /**
+   * Array of user UIDs flagged as "ammunition managers" — receive every
+   * ammo-report notification (in addition to the reporter's team leader) and
+   * count as ammo-responsible for training-plan approvals + central-stock
+   * mutations. Bounded at 10 entries. Empty/absent = no extra recipients.
+   */
+  ammoNotificationRecipientUserIds?: string[];
   teams?: string[];
   /**
    * Gates pull-from-storage on equipment items in EquipmentStatus.STORED.


### PR DESCRIPTION
## Summary
- `SystemConfig.ammoNotificationRecipientUserIds` (string[]) replaces single uid field. Cap 10, deduped, validated server-side.
- New `AmmoRecipientsSection` (profile-style top-left edit button; renders names only; X to remove; UserSearchInput to add).
- New `useUsersByIds` hook (chunked Firestore `in` queries, max 10/chunk).
- Resolver in `serverSubmitAmmunitionReport` now unions team leaders + all array recipients (dedupe, exclude reporter).
- New `docs/spec/settings-ownership.md` clarifies admin vs management split.
- One-shot migration script `scripts/migrate-ammo-recipient-to-array.mjs` + README.

## Test plan
- [x] `npm run lint` clean
- [x] 33 new tests across 4 files (systemConfigService.array, ammunitionReportsService.recipients, AmmoRecipientsSection, useUsersByIds)
- [x] Full suite: 52 suites, 765 passing
- [ ] **Operator post-merge:** run `node scripts/migrate-ammo-recipient-to-array.mjs` once against prod

Plan: `~/.claude/plans/ammo-multi-recipient-and-admin-mgmt-split.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)