### PR TITLE
feat(equipment): unified toolbar with Switch toggle + row scroll-into-view

### DIFF
--- a/docs/codebase/src/app/equipment/page.md
+++ b/docs/codebase/src/app/equipment/page.md
@@ -11,18 +11,17 @@ AuthGuard
   EquipmentErrorBoundary
     AppShell (mounts WelcomeModal if profile missing teamId/unitId)
       EquipmentPageContent
-        ├ PageHeader   (+ הוסף ציוד button → opens AddEquipmentWizard)
-        ├ EquipmentTabs (Self / Team / All — All gated by manager+; rounded card)
-        ├ ViewToggle    (active / archive — bug #25; sits *between* the tabs and
-        │                the filter card, separated by `mt-4 mb-2` for breathing
-        │                room. EquipmentTabs + FilterBar are independent cards,
-        │                NOT a glued top/bottom unit anymore — that was the
-        │                pre-#25 layout before ViewToggle was inserted between
-        │                them.)
-        ├ FilterBar     (search + status filter + category filter; rounded card)
-        ├ EquipmentTable (or loading / error / empty state)
-        └ BulkActionBar (sticky, surfaces when rows selected)
+        ├ EquipmentTabs    (Self / Team / All — All gated by manager+; rounded card)
+        ├ EquipmentToolbar (single row: active/archive Switch + count badge on
+        │                   the RTL right, "+ הוסף ציוד" button on the RTL left.
+        │                   Replaced the separate PageHeader + ViewToggle layout
+        │                   that wasted two rows. See docs/codebase/src/components/equipment/EquipmentToolbar.md.)
+        ├ FilterBar        (search + status filter + category filter; rounded card)
+        ├ EquipmentTable   (or loading / error / empty state)
+        └ BulkActionBar    (sticky, surfaces when rows selected)
 ```
+
+Switching view (active ↔ archive) clears the row selection set — the set is bucket-scoped, so otherwise a bulk action triggered from the new view could target rows the user can no longer see.
 
 Modals (portal-style, not nested under AppShell): AddEquipmentWizard, ReportModal, ReturnModal, TransferModal, ActionHistoryPanel.
 

--- a/docs/codebase/src/components/equipment/EquipmentTable.md
+++ b/docs/codebase/src/components/equipment/EquipmentTable.md
@@ -20,6 +20,12 @@ Computed client-side from `lastReportUpdate` against a 7-day threshold. Phase 1 
 
 `Equipment.category` and `Equipment.subcategory` are stored as Firestore doc IDs (mirrors `EquipmentType`). The expanded row resolves them to Hebrew names via `useCategoryLookup` and renders `cat / sub`. Unresolved IDs fall back to the raw ID with `text-warning-700` (same pattern as `TemplatesTab`), so orphan refs surface visibly instead of silently. See `docs/bugs.md` #16.
 
+## Expand behaviour
+
+Single-open expansion — clicking another row collapses the previous one. Each row keeps a `useRef<HTMLLIElement>` and runs a `useEffect` keyed on `expanded`: when the row becomes expanded, it schedules `scrollIntoView({ block: 'nearest', behavior: 'smooth' })` inside a `requestAnimationFrame` so the expanded panel is already in the DOM before the browser measures.
+
+`block: 'nearest'` is a no-op when the row is already in view, so already-visible rows don't jump. The expanded row gets a stronger focus ring (`ring-2 ring-primary-400 shadow-md`) and a smooth `transition-shadow transition-colors duration-200` transition.
+
 ## What this component does NOT do
 
 - Filtering / search — that is the page's job; the table receives the already-filtered list.

--- a/docs/codebase/src/components/equipment/EquipmentToolbar.md
+++ b/docs/codebase/src/components/equipment/EquipmentToolbar.md
@@ -1,0 +1,44 @@
+# EquipmentToolbar
+
+**File:** `src/components/equipment/EquipmentToolbar.tsx`
+
+Single-row header for `/equipment`. Pairs the active/archive view Switch with the "Add Item" button to avoid the wasteful two-row layout the page had before.
+
+## Visual layout (RTL)
+
+```
+[ Switch | "ציוד פעיל" | (count) ]            [ + הוסף ציוד ]
+              ^ visual right                       ^ visual left
+```
+
+Implemented as a single `flex flex-wrap items-center gap-3 gap-y-2` row with a `<div className="flex-1" />` spacer between the toggle group and the button. `flex-wrap` lets the Add Item button drop to a new line on viewports narrower than ~360 px without horizontal overflow.
+
+## Toggle
+
+Headless UI `<Switch>`, role=switch, aria-label from `TEXT_CONSTANTS.FEATURES.EQUIPMENT.ARCHIVE.TOGGLE_ARIA`. The visible label string flips between `SHOW_ACTIVE` ↔ `SHOW_ARCHIVE` based on the `view` prop — there is no second label hidden somewhere; the toggle is its own state announcement.
+
+The thumb uses **logical** `start-1` / `start-6` positioning (absolute, not `translate-x-*`) so it flips correctly under the global `dir="rtl"`. This mirrors the pattern in `SystemConfigTab` and `NotificationToggleRow`; `translate-x-*` is a physical transform and breaks in RTL when the parent uses logical layout.
+
+## Archive count badge
+
+Always visible next to the toggle when `archiveCount > 0`, regardless of which view is active. Acts as a passive nudge — "there's stuff in archive" — without making the user flip the toggle to find out.
+
+## Add Item
+
+Same primary-button styling as the rest of the app (`bg-primary-600`, `Plus` icon, `ADD_NEW` label). Hidden when `canAdd=false` so policy gating is a one-prop concern at the call site, not a duplicate condition inside this component.
+
+## Props
+
+| Prop | Type | Purpose |
+|---|---|---|
+| `view` | `'active' \| 'archive'` | Current view; drives Switch state + label |
+| `onViewChange` | `(next) => void` | Called with the next view on toggle |
+| `archiveCount` | `number` | Drives badge visibility |
+| `onAddClick` | `() => void` | Fired when the Add Item button is clicked |
+| `canAdd` | `boolean` | When `false`, hides the Add Item button |
+
+## What this component does NOT do
+
+- Filtering / sorting — that lives in `FilterBar` and `EquipmentTable`.
+- Selection-clearing on view change — the page's `onViewChange` handler clears the bucket-scoped selection set so bulk actions can't target invisible rows.
+- Policy — `canAdd` is computed by the parent; the toolbar just renders or omits the button.

--- a/src/app/equipment/page.tsx
+++ b/src/app/equipment/page.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useMemo, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { Plus, Search } from 'lucide-react';
+import { Search } from 'lucide-react';
 import AuthGuard from '@/components/auth/AuthGuard';
 import AppShell from '@/app/components/AppShell';
 import { TEXT_CONSTANTS } from '@/constants/text';
@@ -12,6 +12,7 @@ import EquipmentErrorBoundary from '@/components/equipment/EquipmentErrorBoundar
 import EquipmentLoadingState from '@/components/equipment/EquipmentLoadingState';
 import EquipmentTabs from '@/components/equipment/EquipmentTabs';
 import EquipmentTable from '@/components/equipment/EquipmentTable';
+import EquipmentToolbar from '@/components/equipment/EquipmentToolbar';
 import BulkActionBar, { type BulkAction } from '@/components/equipment/BulkActionBar';
 import type { EquipmentRowAction } from '@/components/equipment/EquipmentRowActions';
 import AddEquipmentWizard from '@/components/equipment/AddEquipmentWizard';
@@ -29,7 +30,6 @@ import TeamAmmunitionSection from '@/components/equipment/TeamAmmunitionSection'
 import { Select } from '@/components/ui';
 import { useSystemConfig } from '@/hooks/useSystemConfig';
 import { useCategoryLookup } from '@/hooks/useCategoryLookup';
-import { cn } from '@/lib/cn';
 import {
   requestExchange,
   approveExchangeRequest,
@@ -224,20 +224,19 @@ function EquipmentPageContent() {
 
   return (
     <div className="max-w-7xl mx-auto w-full pb-24">
-      <PageHeader onAdd={() => setActiveModal({ kind: 'wizard' })} />
-
       <EquipmentTabs scope={scope} onChange={setScope} user={enhancedUser} />
 
-      <ViewToggle
+      <EquipmentToolbar
         view={view}
-        onChange={(v) => {
+        onViewChange={(v) => {
           setView(v);
           // Selection set is bucket-scoped — clear it when switching views so
           // a bulk action can't accidentally target rows the user can't see.
           setSelectedIds(new Set());
         }}
         archiveCount={archivedEquipment.length}
-        className="mt-4 mb-2"
+        onAddClick={() => setActiveModal({ kind: 'wizard' })}
+        canAdd
       />
 
       <FilterBar
@@ -412,21 +411,6 @@ function EquipmentPageContent() {
   );
 }
 
-function PageHeader({ onAdd }: { onAdd: () => void }) {
-  return (
-    <div className="flex items-center justify-between mb-6">
-      <button
-        type="button"
-        onClick={onAdd}
-        className="inline-flex items-center gap-2 px-4 py-2 bg-primary-600 hover:bg-primary-700 text-white text-sm font-medium rounded-lg shadow-sm transition-colors"
-      >
-        <Plus className="w-4 h-4" />
-        {TEXT_CONSTANTS.FEATURES.EQUIPMENT.ADD_NEW}
-      </button>
-    </div>
-  );
-}
-
 function FilterBar({
   searchTerm,
   onSearch,
@@ -488,66 +472,6 @@ function FilterBar({
           ariaLabel={TEXT_CONSTANTS.FEATURES.EQUIPMENT.ALL_CATEGORIES}
         />
       </div>
-    </div>
-  );
-}
-
-function ViewToggle({
-  view,
-  onChange,
-  archiveCount,
-  className,
-}: {
-  view: 'active' | 'archive';
-  onChange: (v: 'active' | 'archive') => void;
-  archiveCount: number;
-  className?: string;
-}) {
-  const labels = TEXT_CONSTANTS.FEATURES.EQUIPMENT.ARCHIVE;
-  return (
-    <div
-      className={cn('flex gap-2', className ?? 'mb-2')}
-      role="tablist"
-      aria-label="equipment view"
-    >
-      <button
-        type="button"
-        role="tab"
-        aria-selected={view === 'active'}
-        onClick={() => onChange('active')}
-        className={cn(
-          'px-3 py-1.5 text-sm rounded-md transition-colors',
-          view === 'active'
-            ? 'bg-primary-600 text-white'
-            : 'bg-white border border-neutral-200 text-neutral-700 hover:bg-neutral-50',
-        )}
-      >
-        {labels.SHOW_ACTIVE}
-      </button>
-      <button
-        type="button"
-        role="tab"
-        aria-selected={view === 'archive'}
-        onClick={() => onChange('archive')}
-        className={cn(
-          'px-3 py-1.5 text-sm rounded-md transition-colors inline-flex items-center gap-2',
-          view === 'archive'
-            ? 'bg-primary-600 text-white'
-            : 'bg-white border border-neutral-200 text-neutral-700 hover:bg-neutral-50',
-        )}
-      >
-        <span>{labels.SHOW_ARCHIVE}</span>
-        {archiveCount > 0 && (
-          <span
-            className={cn(
-              'inline-flex items-center justify-center text-xs rounded-full min-w-[1.25rem] h-5 px-1.5',
-              view === 'archive' ? 'bg-white/20 text-white' : 'bg-neutral-100 text-neutral-700',
-            )}
-          >
-            {archiveCount}
-          </span>
-        )}
-      </button>
     </div>
   );
 }

--- a/src/components/equipment/EquipmentTable.tsx
+++ b/src/components/equipment/EquipmentTable.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Timestamp } from 'firebase/firestore';
 import { ArrowDown, ArrowUp } from 'lucide-react';
 import type { Equipment } from '@/types/equipment';
@@ -206,11 +206,24 @@ function EquipmentRow({
   const serial = equipmentSerialDisplay(item);
   const requiresSerial = serial !== null;
 
+  // Smooth-scroll the row into view when it expands, so the panel doesn't
+  // render below the fold without any visual cue. `block: 'nearest'` is a
+  // no-op when the row is already in view.
+  const rowRef = useRef<HTMLLIElement>(null);
+  useEffect(() => {
+    if (!expanded || !rowRef.current) return;
+    const id = requestAnimationFrame(() => {
+      rowRef.current?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+    });
+    return () => cancelAnimationFrame(id);
+  }, [expanded]);
+
   return (
     <li
-      className={`bg-white rounded-xl border border-neutral-200 overflow-hidden transition-colors ${
+      ref={rowRef}
+      className={`bg-white rounded-xl border border-neutral-200 overflow-hidden transition-shadow transition-colors duration-200 ${
         dimmed ? 'opacity-60' : ''
-      } ${expanded ? 'ring-1 ring-primary-200 border-primary-300' : 'hover:border-neutral-300'}`}
+      } ${expanded ? 'ring-2 ring-primary-400 border-primary-300 shadow-md' : 'hover:border-neutral-300'}`}
     >
       <div
         role="button"

--- a/src/components/equipment/EquipmentToolbar.tsx
+++ b/src/components/equipment/EquipmentToolbar.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { Switch } from '@headlessui/react';
+import { Plus } from 'lucide-react';
+import { TEXT_CONSTANTS } from '@/constants/text';
+import { cn } from '@/lib/cn';
+
+interface EquipmentToolbarProps {
+  view: 'active' | 'archive';
+  onViewChange: (next: 'active' | 'archive') => void;
+  archiveCount: number;
+  onAddClick: () => void;
+  canAdd: boolean;
+}
+
+/**
+ * Combined header row for `/equipment` — pairs the active/archive Switch
+ * (with a dynamic label + archive count badge) and the "Add Item" button in
+ * a single line. RTL: toggle group sits on visual right, Add Item on visual
+ * left. The Switch thumb uses logical `start-*` positioning so it flips
+ * correctly under `dir="rtl"` (mirrors the SystemConfigTab + NotificationToggleRow
+ * pattern — `translate-x-*` is physical and breaks in RTL).
+ */
+export default function EquipmentToolbar({
+  view,
+  onViewChange,
+  archiveCount,
+  onAddClick,
+  canAdd,
+}: EquipmentToolbarProps) {
+  const labels = TEXT_CONSTANTS.FEATURES.EQUIPMENT.ARCHIVE;
+  const isArchive = view === 'archive';
+  const stateLabel = isArchive ? labels.SHOW_ARCHIVE : labels.SHOW_ACTIVE;
+
+  return (
+    <div className="flex flex-wrap items-center gap-3 gap-y-2 mb-4">
+      <div className="flex items-center gap-2">
+        <Switch
+          checked={isArchive}
+          onChange={(next) => onViewChange(next ? 'archive' : 'active')}
+          aria-label={labels.TOGGLE_ARIA}
+          className={cn(
+            'relative inline-flex h-6 w-11 shrink-0 rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2',
+            isArchive ? 'bg-primary-600' : 'bg-neutral-300',
+          )}
+        >
+          <span
+            className={cn(
+              'absolute top-1/2 -translate-y-1/2 h-4 w-4 rounded-full bg-white shadow-sm transition-all',
+              isArchive ? 'start-6' : 'start-1',
+            )}
+          />
+        </Switch>
+        <span className="text-sm font-medium text-neutral-700">{stateLabel}</span>
+        {archiveCount > 0 && (
+          <span
+            className="inline-flex items-center justify-center text-xs rounded-full min-w-[1.25rem] h-5 px-1.5 bg-neutral-100 text-neutral-700"
+            aria-label={`${archiveCount}`}
+          >
+            {archiveCount}
+          </span>
+        )}
+      </div>
+
+      <div className="flex-1" />
+
+      {canAdd && (
+        <button
+          type="button"
+          onClick={onAddClick}
+          className="inline-flex items-center gap-2 px-4 py-2 bg-primary-600 hover:bg-primary-700 text-white text-sm font-medium rounded-lg shadow-sm transition-colors"
+        >
+          <Plus className="w-4 h-4" />
+          {TEXT_CONSTANTS.FEATURES.EQUIPMENT.ADD_NEW}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/equipment/__tests__/EquipmentTable.test.tsx
+++ b/src/components/equipment/__tests__/EquipmentTable.test.tsx
@@ -1,0 +1,188 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+// EquipmentTable's date helpers do `t instanceof Timestamp`. The default
+// firebase mock exports `Timestamp` as a plain object literal, which makes
+// `instanceof` throw "Right-hand side of 'instanceof' is not callable".
+// Provide a real class shape so the helpers can short-circuit cleanly.
+jest.mock('firebase/firestore', () => {
+  const actual = jest.requireActual('@/lib/__mocks__/firebase');
+  class TimestampClass {
+    seconds: number;
+    nanoseconds: number;
+    constructor(seconds: number, nanoseconds: number) {
+      this.seconds = seconds;
+      this.nanoseconds = nanoseconds;
+    }
+    toDate() {
+      return new Date(this.seconds * 1000);
+    }
+    toMillis() {
+      return this.seconds * 1000;
+    }
+  }
+  return { ...actual, Timestamp: TimestampClass };
+});
+
+import EquipmentTable from '../EquipmentTable';
+import { EquipmentStatus, EquipmentCondition, type Equipment } from '@/types/equipment';
+import { UserType, type EnhancedAuthUser } from '@/types/user';
+
+jest.mock('@/constants/text', () => ({
+  TEXT_CONSTANTS: {
+    FEATURES: {
+      EQUIPMENT: {
+        TABLE_SERIAL: 'Serial',
+        TABLE_ITEM: 'Item',
+        TABLE_HOLDER: 'Holder',
+        TABLE_STATUS: 'Status',
+        TABLE_LAST_CHECK: 'Last check',
+        STATUS_AVAILABLE: 'Available',
+        STATUS_PENDING_TRANSFER: 'Pending',
+        STATUS_SECURITY: 'Security',
+        STATUS_REPAIR: 'Repair',
+        STATUS_LOST: 'Lost',
+        STATUS_EXCHANGE_REQUESTED: 'Exchange',
+        STATUS_STORED: 'Stored',
+        STATUS_RETIRED: 'Retired',
+        LOCATION: 'Location',
+        NOTES: 'Notes',
+        DIMMED_ANNOTATION: 'Item is with {holder}',
+        STALE_REPORT_BADGE: 'Not reported in {days} days',
+        ROW_ACTIONS: {
+          REPORT: 'Report',
+          TRANSFER: 'Transfer',
+          RETURN: 'Return',
+          HISTORY: 'History',
+          MORE: 'More',
+          REQUEST_EXCHANGE: 'Request exchange',
+          APPROVE_EXCHANGE: 'Approve exchange',
+          REJECT_EXCHANGE: 'Reject exchange',
+          REPLACE_BY_ANOTHER: 'Replace',
+          SEND_TO_STORAGE: 'Send to storage',
+          PULL_FROM_STORAGE: 'Pull from storage',
+        },
+        STORAGE: {
+          ROUND_CLOSED_TOOLTIP: 'Round is closed',
+          TRANSFER_BLOCKED_STORED_TOOLTIP: 'Pull first',
+          INFO_BUBBLE_LABEL: 'Info',
+        },
+      },
+    },
+  },
+}));
+
+jest.mock('@/hooks/useCategoryLookup', () => ({
+  useCategoryLookup: () => ({
+    categoryName: (id: string) => id,
+    subcategoryName: (id: string) => id,
+    isLoading: false,
+  }),
+}));
+
+const HOLDER_UID = 'holder-uid';
+
+function makeUser(): EnhancedAuthUser {
+  return {
+    uid: HOLDER_UID,
+    userType: UserType.USER,
+    displayName: 'Test Holder',
+  };
+}
+
+function makeEquipment(overrides: Partial<Equipment> = {}): Equipment {
+  return {
+    id: 'eq-1',
+    equipmentType: 'rifle_m4',
+    productName: 'Rifle A',
+    category: 'weapons',
+    signedBy: 'Signer',
+    signedById: 'signer-uid',
+    currentHolder: 'Holder',
+    currentHolderId: HOLDER_UID,
+    status: EquipmentStatus.AVAILABLE,
+    location: 'base',
+    condition: EquipmentCondition.GOOD,
+    trackingHistory: [],
+    acquisitionDate: {} as Equipment['acquisitionDate'],
+    dateSigned: {} as Equipment['dateSigned'],
+    lastSeen: {} as Equipment['lastSeen'],
+    lastReportUpdate: {} as Equipment['lastReportUpdate'],
+    createdAt: {} as Equipment['createdAt'],
+    updatedAt: {} as Equipment['updatedAt'],
+    ...overrides,
+  };
+}
+
+describe('EquipmentTable — row scrollIntoView on expand', () => {
+  const originalScrollIntoView = Element.prototype.scrollIntoView;
+  let scrollIntoViewMock: jest.Mock;
+  let rafSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    scrollIntoViewMock = jest.fn();
+    Element.prototype.scrollIntoView = scrollIntoViewMock;
+    // Run rAF synchronously so the scrollIntoView call is observable without
+    // additional async waits.
+    rafSpy = jest
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((cb: FrameRequestCallback) => {
+        cb(0);
+        return 0;
+      });
+  });
+
+  afterEach(() => {
+    Element.prototype.scrollIntoView = originalScrollIntoView;
+    rafSpy.mockRestore();
+  });
+
+  function renderTable(items: Equipment[]) {
+    return render(
+      <EquipmentTable
+        equipment={items}
+        user={makeUser()}
+        selectedIds={new Set()}
+        onToggleSelect={jest.fn()}
+        onToggleSelectAllVisible={jest.fn()}
+        onRowAction={jest.fn()}
+        emptyMessage="empty"
+        roundOpen
+      />,
+    );
+  }
+
+  it('does not call scrollIntoView for collapsed rows on initial render', () => {
+    renderTable([makeEquipment({ id: 'a' }), makeEquipment({ id: 'b' })]);
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
+  });
+
+  it('calls scrollIntoView once when a row is expanded', () => {
+    renderTable([makeEquipment({ id: 'a' }), makeEquipment({ id: 'b', productName: 'Rifle B' })]);
+
+    // The row body is the role="button" that toggles expand.
+    const rowButtons = screen.getAllByRole('button').filter((el) =>
+      el.className.includes('cursor-pointer'),
+    );
+    expect(rowButtons.length).toBeGreaterThanOrEqual(2);
+
+    fireEvent.click(rowButtons[0]);
+
+    expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+    expect(scrollIntoViewMock).toHaveBeenCalledWith({ block: 'nearest', behavior: 'smooth' });
+  });
+
+  it('does not call scrollIntoView again when the same row collapses', () => {
+    renderTable([makeEquipment({ id: 'a' })]);
+    const rowButton = screen
+      .getAllByRole('button')
+      .filter((el) => el.className.includes('cursor-pointer'))[0];
+
+    fireEvent.click(rowButton); // expand → scroll
+    expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(rowButton); // collapse → no additional scroll
+    expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/equipment/__tests__/EquipmentToolbar.test.tsx
+++ b/src/components/equipment/__tests__/EquipmentToolbar.test.tsx
@@ -1,0 +1,137 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import EquipmentToolbar from '../EquipmentToolbar';
+
+jest.mock('@/constants/text', () => ({
+  TEXT_CONSTANTS: {
+    FEATURES: {
+      EQUIPMENT: {
+        ADD_NEW: 'Add item',
+        ARCHIVE: {
+          SHOW_ACTIVE: 'Active equipment',
+          SHOW_ARCHIVE: 'Archive',
+          TOGGLE_ARIA: 'Toggle archive view',
+        },
+      },
+    },
+  },
+}));
+
+describe('EquipmentToolbar', () => {
+  it('renders the active label when view=active and Switch is off', () => {
+    render(
+      <EquipmentToolbar
+        view="active"
+        onViewChange={jest.fn()}
+        archiveCount={0}
+        onAddClick={jest.fn()}
+        canAdd
+      />,
+    );
+
+    const sw = screen.getByRole('switch', { name: 'Toggle archive view' });
+    expect(sw).toHaveAttribute('aria-checked', 'false');
+    expect(screen.getByText('Active equipment')).toBeInTheDocument();
+    expect(screen.queryByText('Archive')).not.toBeInTheDocument();
+  });
+
+  it('calls onViewChange("archive") and shows the archive label after toggle', () => {
+    const onViewChange = jest.fn();
+    const { rerender } = render(
+      <EquipmentToolbar
+        view="active"
+        onViewChange={onViewChange}
+        archiveCount={3}
+        onAddClick={jest.fn()}
+        canAdd
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('switch', { name: 'Toggle archive view' }));
+    expect(onViewChange).toHaveBeenCalledWith('archive');
+
+    rerender(
+      <EquipmentToolbar
+        view="archive"
+        onViewChange={onViewChange}
+        archiveCount={3}
+        onAddClick={jest.fn()}
+        canAdd
+      />,
+    );
+    expect(screen.getByText('Archive')).toBeInTheDocument();
+    expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('toggling off from archive calls onViewChange("active")', () => {
+    const onViewChange = jest.fn();
+    render(
+      <EquipmentToolbar
+        view="archive"
+        onViewChange={onViewChange}
+        archiveCount={2}
+        onAddClick={jest.fn()}
+        canAdd
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('switch'));
+    expect(onViewChange).toHaveBeenCalledWith('active');
+  });
+
+  it('shows the archive count badge when archiveCount > 0', () => {
+    render(
+      <EquipmentToolbar
+        view="active"
+        onViewChange={jest.fn()}
+        archiveCount={7}
+        onAddClick={jest.fn()}
+        canAdd
+      />,
+    );
+    expect(screen.getByText('7')).toBeInTheDocument();
+  });
+
+  it('hides the archive count badge when archiveCount = 0', () => {
+    render(
+      <EquipmentToolbar
+        view="active"
+        onViewChange={jest.fn()}
+        archiveCount={0}
+        onAddClick={jest.fn()}
+        canAdd
+      />,
+    );
+    expect(screen.queryByText('0')).not.toBeInTheDocument();
+  });
+
+  it('calls onAddClick when Add item is clicked', () => {
+    const onAddClick = jest.fn();
+    render(
+      <EquipmentToolbar
+        view="active"
+        onViewChange={jest.fn()}
+        archiveCount={0}
+        onAddClick={onAddClick}
+        canAdd
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /add item/i }));
+    expect(onAddClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides the Add item button when canAdd=false', () => {
+    render(
+      <EquipmentToolbar
+        view="active"
+        onViewChange={jest.fn()}
+        archiveCount={0}
+        onAddClick={jest.fn()}
+        canAdd={false}
+      />,
+    );
+    expect(screen.queryByRole('button', { name: /add item/i })).not.toBeInTheDocument();
+  });
+});

--- a/src/constants/text.en.ts
+++ b/src/constants/text.en.ts
@@ -126,6 +126,12 @@ export const TEXT_EN = {
     STATUS_STORED: 'Stored',
     STATUS_RETIRED: 'Returned to army',
 
+    ARCHIVE: {
+      SHOW_ACTIVE: 'Active equipment',
+      SHOW_ARCHIVE: 'Archive',
+      TOGGLE_ARIA: 'Toggle between active and archive views',
+    },
+
     ROW_ACTIONS: {
       REPORT: 'Report',
       TRANSFER: 'Transfer',

--- a/src/constants/text.ts
+++ b/src/constants/text.ts
@@ -618,6 +618,7 @@ export const TEXT_CONSTANTS = {
       ARCHIVE: {
         SHOW_ACTIVE: 'ציוד פעיל',
         SHOW_ARCHIVE: 'ארכיון',
+        TOGGLE_ARIA: 'החלף תצוגה בין ציוד פעיל לארכיון',
         EMPTY_SELF: 'אין פריטים בארכיון.',
         EMPTY_TEAM: 'אין פריטים בארכיון של הצוות.',
         EMPTY_ALL: 'אין פריטים בארכיון.',


### PR DESCRIPTION
## Summary
- New `EquipmentToolbar` combines Add Item + Active/Archive Switch + count badge in a single flex row.
- Active/Archive becomes one Headless UI `Switch` with dynamic label (HE flips between `ציוד פעיל` ↔ `ארכיון`). Thumb uses logical `start-1`/`start-6` for correct RTL behaviour (matches `NotificationToggleRow` precedent).
- Add Item moves to the visual left of the toggle (RTL).
- Archive count badge always visible when `> 0`.
- `EquipmentTable` rows smooth-scroll into view when expanded (`block: 'nearest'`) — no jump for already-visible rows.
- Stronger focus styling on expanded row (`ring-2 ring-primary-400 shadow-md`).

## Test plan
- [x] `npm run lint` clean
- [x] `EquipmentToolbar.test.tsx` — 7/7 pass
- [x] `EquipmentTable.test.tsx` scrollIntoView cases — 3/3 pass

Plan: `~/.claude/plans/equipment-page-toolbar-and-row-focus.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)