### PR TITLE
fix(sw-updater): mobile — 3s reload fallback when statechange never fires

### DIFF
--- a/docs/codebase/src/components/pwa/ServiceWorkerUpdater.md
+++ b/docs/codebase/src/components/pwa/ServiceWorkerUpdater.md
@@ -14,9 +14,15 @@ installed and waiting. User-driven activation only — audit note M5.
 1. Mounts → `navigator.serviceWorker.register('/sw.js')`.
 2. Reads existing `reg.waiting`; subscribes to `updatefound` for future installs.
 3. When a waiting worker is present, renders an action banner.
-4. "Update now" → attaches a `statechange` listener to the waiting worker, then posts `{ type: 'SKIP_WAITING' }`.
-5. The listener fires when the worker reaches `'activated'` → page reloads.
+4. "Update now":
+   - If the worker is already `'activated'` (rare but possible if the user sat on the toast through an activation), reload immediately.
+   - Otherwise attach a `statechange` listener to the waiting worker, post `{ type: 'SKIP_WAITING' }`, and arm a 3-second fallback timer.
+5. Reload triggers from whichever fires first: the `'activated'` state transition, or the 3-second fallback (mobile browsers, esp. iOS Safari, do not always fire `statechange` on a worker that never claims the current document).
 6. "Later" hides the banner locally; next page load picks up the waiting worker again.
+
+### Mobile fallback timer
+
+`statechange → 'activated'` is the canonical signal, but iOS Safari and some Chromium-on-iOS WebKit shells do not reliably dispatch it for a worker that activates without adopting the current document (which is exactly our case under `clientsClaim: false`). Symptom on those devices: tap "Update Now" → SW activates in the background → page never reloads → toast stays up. The 3-second `setTimeout` reload fallback handles this — by the time it fires, the new SW is either already activated (so the reload picks it up immediately) or activating (so the next navigation picks it up). Both timers race; whichever wins clears the other.
 
 ### Why `statechange` and not `controllerchange`
 

--- a/src/components/pwa/ServiceWorkerUpdater.tsx
+++ b/src/components/pwa/ServiceWorkerUpdater.tsx
@@ -62,13 +62,35 @@ export default function ServiceWorkerUpdater() {
   const onUpdateNow = () => {
     if (!waitingWorker) return;
     const worker = waitingWorker;
+
+    // Already-activated short-circuit. If the user has been sitting on the
+    // toast long enough that the SW transitioned without us, reload now.
+    if (worker.state === 'activated') {
+      window.location.reload();
+      return;
+    }
+
+    let done = false;
+    const finish = () => {
+      if (done) return;
+      done = true;
+      worker.removeEventListener('statechange', onState);
+      clearTimeout(timeoutId);
+      window.location.reload();
+    };
+
     const onState = () => {
-      if (worker.state === 'activated') {
-        worker.removeEventListener('statechange', onState);
-        window.location.reload();
-      }
+      if (worker.state === 'activated') finish();
     };
     worker.addEventListener('statechange', onState);
+
+    // Mobile fallback. iOS Safari (and some Chromium-on-iOS WebKit shells)
+    // do not reliably fire `statechange` on a worker whose controller is not
+    // adopted by the current document (clientsClaim: false). After we ask the
+    // worker to activate, reload regardless after a short delay — the new SW
+    // is picked up on the next navigation even if it never reaches us.
+    const timeoutId = setTimeout(finish, 3000);
+
     worker.postMessage({ type: 'SKIP_WAITING' });
   };
 

--- a/src/components/pwa/__tests__/ServiceWorkerUpdater.test.tsx
+++ b/src/components/pwa/__tests__/ServiceWorkerUpdater.test.tsx
@@ -125,4 +125,80 @@ describe('ServiceWorkerUpdater', () => {
     await flushPromises();
     expect(swListeners.get('controllerchange')?.length ?? 0).toBe(0);
   });
+
+  it('reloads immediately if the waiting worker is already activated when the user clicks', async () => {
+    const waiting = new FakeWorker();
+    waiting.state = 'activated';
+    registration.waiting = waiting;
+
+    render(<ServiceWorkerUpdater />);
+    await flushPromises();
+
+    const updateBtn = await screen.findByRole('button', { name: /עדכן עכשיו/ });
+    await act(async () => {
+      updateBtn.click();
+    });
+
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(waiting.postMessage).not.toHaveBeenCalled();
+  });
+
+  it('falls back to reloading after 3s if statechange never fires (iOS Safari mobile path)', async () => {
+    jest.useFakeTimers();
+    try {
+      const waiting = new FakeWorker();
+      waiting.state = 'installed';
+      registration.waiting = waiting;
+
+      render(<ServiceWorkerUpdater />);
+      await flushPromises();
+
+      const updateBtn = await screen.findByRole('button', { name: /עדכן עכשיו/ });
+      await act(async () => {
+        updateBtn.click();
+      });
+
+      expect(waiting.postMessage).toHaveBeenCalledWith({ type: 'SKIP_WAITING' });
+      expect(reload).not.toHaveBeenCalled();
+
+      // No statechange ever fires (the broken-mobile case). Advance the
+      // fallback timer and expect a reload.
+      act(() => {
+        jest.advanceTimersByTime(3000);
+      });
+      expect(reload).toHaveBeenCalledTimes(1);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('does not double-reload if statechange and the fallback timer both fire', async () => {
+    jest.useFakeTimers();
+    try {
+      const waiting = new FakeWorker();
+      waiting.state = 'installed';
+      registration.waiting = waiting;
+
+      render(<ServiceWorkerUpdater />);
+      await flushPromises();
+
+      const updateBtn = await screen.findByRole('button', { name: /עדכן עכשיו/ });
+      await act(async () => {
+        updateBtn.click();
+      });
+
+      await act(async () => {
+        waiting.transitionTo('activated');
+      });
+      expect(reload).toHaveBeenCalledTimes(1);
+
+      // Run the fallback timer; it must be a no-op.
+      act(() => {
+        jest.advanceTimersByTime(3000);
+      });
+      expect(reload).toHaveBeenCalledTimes(1);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- Adds a 3-second reload fallback in `ServiceWorkerUpdater.onUpdateNow`.
- Adds already-activated short-circuit (reload immediately if user clicks after the worker has silently transitioned).
- Both timers race; `done` guard prevents double reload.

## Why
iOS Safari and some Chromium-on-iOS WebKit shells do not reliably fire `statechange → 'activated'` on a worker that activates without claiming the current document (`clientsClaim: false` in `src/app/sw.ts`). Symptom: user taps Update Now on mobile, SW activates in background, toast stays up forever.

## Test plan
- [x] `npm run lint` clean
- [x] `ServiceWorkerUpdater.test.tsx` 5/5 (2 new mobile-fallback cases + 1 already-activated case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)