### PR TITLE
fix(notifications): wire dead click targets + training-plan deep link

### DIFF
--- a/docs/codebase/src/app/ammunition/training/page.md
+++ b/docs/codebase/src/app/ammunition/training/page.md
@@ -1,16 +1,33 @@
 # /ammunition/training
 
 **File:** `src/app/ammunition/training/page.tsx`
-**Status:** Stub (Phase 7 — Ammunition feature)
+**Status:** Active.
 
-## Purpose
+## Composition
 
-URL + nav slot reservation. Renders a "בקרוב" placeholder describing the
-intended scope: training-shoot planning, per-event ammunition budget, soldier
-allocation, and tracking actuals against plan.
+```
+AmmunitionTrainingPage
+  AuthGuard
+    AppShell
+      Suspense (boundary for useSearchParams)
+        AmmunitionTrainingPageContent
+          AmmunitionBellyView   (current on-hand inventory by template)
+          PlannedTrainingsTable (active + archived sections)
+          PlanTrainingModal     (opened by "+ הוסף אימון" — TL+ only)
+```
 
-## Future scope
+## Deep link — `?planId=`
 
-Spec'd in `docs/spec/ammunition-feature.md` ("Out of Scope" → training planner
-functionality). Implementation will follow once the existing ammunition
-modules stabilize.
+The page reads `planId` from `useSearchParams` and forwards it to `PlannedTrainingsTable` as `highlightPlanId`. The matching row gets a `bg-warning-50 ring-2 ring-warning-400` highlight and scrolls into view on mount via a ref + `scrollIntoView({ behavior: 'smooth', block: 'center' })`. If the plan is in the archived bucket, the archive `Disclosure` is `defaultOpen` so the row is reachable.
+
+This deep link is the target route for training-plan notifications (`TRAINING_PLAN_SUBMITTED`, `TRAINING_PLAN_APPROVED`, `TRAINING_PLAN_REJECTED`, `AMMO_RESTOCK_REQUEST`) — see `resolveNotificationTarget` in `src/components/notifications/NotificationItem.tsx`.
+
+`useSearchParams` requires a Suspense boundary in App Router client pages or the page fails to prerender — that's why the body is split into `AmmunitionTrainingPageContent` under `<Suspense>`.
+
+## Hook
+
+`useTrainingPlans()` owns plan state + actions (`create`, `approve`, `reject`, `cancel`, `complete`, `requestRestock`).
+
+## Authorization
+
+TL+ sees the "+ הוסף אימון" button. Approve/reject is gated inside `PlannedTrainingsTable` to admin / system manager / ammo-responsible user (from `systemConfig.ammoNotificationRecipientUserIds`).

--- a/docs/codebase/src/components/notifications/NotificationItem.md
+++ b/docs/codebase/src/components/notifications/NotificationItem.md
@@ -18,9 +18,14 @@ Individual notification item with type-based styling (icon + color), read/unread
 
 `handleClick` calls `markAsRead` and then routes via `next/navigation`. `resolveNotificationTarget` maps the notification type:
 
-- `template_request_approved` → `/equipment?resumeTemplate={relatedEquipmentDocId}` (the equipment page reads the param and opens `AddEquipmentWizard` with the matching draft pre-filled).
-- Equipment-domain types (transfer, retirement, report-request, force-ops, daily-check, maintenance) → `/equipment`.
-- Manager-side template-review types (`template_proposed_for_review`, `new_template_request_for_review`, `template_request_rejected`) → `/management?tab=template-management` so the management page lands directly on the equipment-template tab instead of the default user tab.
+- `TEMPLATE_REQUEST_APPROVED` → `/equipment?resumeTemplate={relatedEquipmentDocId}` (the equipment page reads the param and opens `AddEquipmentWizard` with the matching draft pre-filled).
+- Equipment-domain types (transfer, retirement, report-request, force-ops, equipment_status_change, exchange) → `/equipment`.
+- Manager-side template-review types (`TEMPLATE_PROPOSED_FOR_REVIEW`, `NEW_TEMPLATE_REQUEST_FOR_REVIEW`, `TEMPLATE_REQUEST_REJECTED`) → `/management?tab=template-management` so the management page lands directly on the equipment-template tab instead of the default user tab.
+- Training-plan types (`TRAINING_PLAN_SUBMITTED`, `TRAINING_PLAN_APPROVED`, `TRAINING_PLAN_REJECTED`, `AMMO_RESTOCK_REQUEST`) → `/ammunition/training?planId={relatedEquipmentDocId}` — the page highlights and scrolls to the matching plan row.
+- `AMMO_REPORT_SUBMITTED`, `AMMO_ASSIGNED_FROM_CENTRAL` → `/ammunition`.
+- `AMMO_REPORT_REQUESTED` → `/ammunition?requestId={relatedEquipmentDocId}`.
+- `GUARD_SCHEDULE_SHARED` → `/guard-scheduler/{relatedGuardScheduleId}` (or `/guard-scheduler` if missing).
+- `SYSTEM_MESSAGE` → `/` (home — no domain-specific context).
 
 `resolveNotificationTarget` is exported for unit tests in `__tests__/NotificationItem.test.tsx` — covers the equipment auto-open route, the management tab routing, and the no-duplicates / snake_case enum sanity suite.
 

--- a/src/app/ammunition/training/page.tsx
+++ b/src/app/ammunition/training/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { Suspense, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { Plus } from 'lucide-react';
 import AuthGuard from '@/components/auth/AuthGuard';
 import AppShell from '@/app/components/AppShell';
@@ -26,7 +27,21 @@ function isTeamLeaderOrAbove(userType: UserType | null | undefined): boolean {
 }
 
 export default function AmmunitionTrainingPage() {
+  return (
+    <AuthGuard>
+      <AppShell title={TT.PAGE_TITLE} subtitle={TT.PAGE_SUBTITLE}>
+        <Suspense fallback={null}>
+          <AmmunitionTrainingPageContent />
+        </Suspense>
+      </AppShell>
+    </AuthGuard>
+  );
+}
+
+function AmmunitionTrainingPageContent() {
   const { enhancedUser } = useAuth();
+  const searchParams = useSearchParams();
+  const planId = searchParams.get('planId');
   const {
     plans,
     isLoading,
@@ -43,44 +58,43 @@ export default function AmmunitionTrainingPage() {
   const canPlan = isTeamLeaderOrAbove(enhancedUser?.userType ?? undefined);
 
   return (
-    <AuthGuard>
-      <AppShell title={TT.PAGE_TITLE} subtitle={TT.PAGE_SUBTITLE}>
-        <div className="max-w-6xl mx-auto w-full space-y-6">
-          {error && (
-            <div className="p-3 rounded-lg bg-danger-50 border border-danger-200 text-danger-800 text-sm">
-              {error}
-            </div>
-          )}
-
-          {canPlan && (
-            <div className="flex items-center justify-start">
-              <Button onClick={() => setPlanModalOpen(true)}>
-                <Plus className="w-4 h-4 ms-1" />
-                {TT.PLAN_BUTTON}
-              </Button>
-            </div>
-          )}
-
-          <Card padding="lg">
-            <AmmunitionBellyView plans={plans} onSubmitRestock={requestRestock} />
-          </Card>
-
-          <Card padding="lg">
-            <PlannedTrainingsTable
-              plans={plans}
-              isLoading={isLoading}
-              onApprove={approve}
-              onReject={reject}
-              onCancel={cancel}
-              onComplete={complete}
-            />
-          </Card>
-        </div>
-
-        {planModalOpen && (
-          <PlanTrainingModal onClose={() => setPlanModalOpen(false)} onSubmit={create} />
+    <>
+      <div className="max-w-6xl mx-auto w-full space-y-6">
+        {error && (
+          <div className="p-3 rounded-lg bg-danger-50 border border-danger-200 text-danger-800 text-sm">
+            {error}
+          </div>
         )}
-      </AppShell>
-    </AuthGuard>
+
+        {canPlan && (
+          <div className="flex items-center justify-start">
+            <Button onClick={() => setPlanModalOpen(true)}>
+              <Plus className="w-4 h-4 ms-1" />
+              {TT.PLAN_BUTTON}
+            </Button>
+          </div>
+        )}
+
+        <Card padding="lg">
+          <AmmunitionBellyView plans={plans} onSubmitRestock={requestRestock} />
+        </Card>
+
+        <Card padding="lg">
+          <PlannedTrainingsTable
+            plans={plans}
+            isLoading={isLoading}
+            onApprove={approve}
+            onReject={reject}
+            onCancel={cancel}
+            onComplete={complete}
+            highlightPlanId={planId}
+          />
+        </Card>
+      </div>
+
+      {planModalOpen && (
+        <PlanTrainingModal onClose={() => setPlanModalOpen(false)} onSubmit={create} />
+      )}
+    </>
   );
 }

--- a/src/components/ammunition/PlannedTrainingsTable.tsx
+++ b/src/components/ammunition/PlannedTrainingsTable.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Disclosure,
   DisclosureButton,
@@ -64,6 +64,8 @@ export interface PlannedTrainingsTableProps {
   onReject: (planId: string, reason: string) => Promise<boolean>;
   onCancel: (planId: string) => Promise<boolean>;
   onComplete: (planId: string) => Promise<boolean>;
+  /** When set, the matching plan row scrolls into view and is highlighted. */
+  highlightPlanId?: string | null;
 }
 
 export default function PlannedTrainingsTable({
@@ -73,6 +75,7 @@ export default function PlannedTrainingsTable({
   onReject,
   onCancel,
   onComplete,
+  highlightPlanId,
 }: PlannedTrainingsTableProps) {
   const { enhancedUser } = useAuth();
   const { config: systemConfig } = useSystemConfig();
@@ -95,6 +98,8 @@ export default function PlannedTrainingsTable({
     return { active: a, archived: z };
   }, [plans]);
 
+  const highlightedInArchive = !!highlightPlanId && archived.some((p) => p.id === highlightPlanId);
+
   if (isLoading) {
     return <div className="text-sm text-neutral-500 text-center py-8">{TT.LOADING}</div>;
   }
@@ -111,9 +116,10 @@ export default function PlannedTrainingsTable({
         onReject={onReject}
         onCancel={onCancel}
         onComplete={onComplete}
+        highlightPlanId={highlightPlanId}
       />
 
-      <Disclosure as="div" className="border border-neutral-200 rounded-lg">
+      <Disclosure as="div" className="border border-neutral-200 rounded-lg" defaultOpen={highlightedInArchive}>
         {({ open }) => (
           <>
             <DisclosureButton className="w-full flex items-center justify-between px-4 py-3 text-sm font-medium text-neutral-700 hover:bg-neutral-50">
@@ -135,6 +141,7 @@ export default function PlannedTrainingsTable({
                 onReject={onReject}
                 onCancel={onCancel}
                 onComplete={onComplete}
+                highlightPlanId={highlightPlanId}
               />
             </DisclosurePanel>
           </>
@@ -154,6 +161,7 @@ interface PlanTableProps {
   onReject: (planId: string, reason: string) => Promise<boolean>;
   onCancel: (planId: string) => Promise<boolean>;
   onComplete: (planId: string) => Promise<boolean>;
+  highlightPlanId?: string | null;
 }
 
 function PlanTable({
@@ -166,7 +174,14 @@ function PlanTable({
   onReject,
   onCancel,
   onComplete,
+  highlightPlanId,
 }: PlanTableProps) {
+  const highlightRowRef = useRef<HTMLTableRowElement | null>(null);
+  useEffect(() => {
+    if (highlightPlanId && highlightRowRef.current) {
+      highlightRowRef.current.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+  }, [highlightPlanId, plans]);
   const [busyId, setBusyId] = useState<string | null>(null);
   const [pendingCancelId, setPendingCancelId] = useState<string | null>(null);
   const [rejectingPlanId, setRejectingPlanId] = useState<string | null>(null);
@@ -252,8 +267,17 @@ function PlanTable({
                 const showApproveReject =
                   canApproveOrReject && p.status === 'PENDING_APPROVAL';
                 const busy = busyId === p.id;
+                const isHighlighted = !!highlightPlanId && highlightPlanId === p.id;
                 return (
-                  <tr key={p.id} className="hover:bg-neutral-50">
+                  <tr
+                    key={p.id}
+                    ref={isHighlighted ? highlightRowRef : undefined}
+                    className={
+                      isHighlighted
+                        ? 'bg-warning-50 ring-2 ring-warning-400 ring-inset'
+                        : 'hover:bg-neutral-50'
+                    }
+                  >
                     <td className="px-3 py-2 text-xs text-neutral-700 whitespace-nowrap">
                       {fmtRange(p)}
                     </td>

--- a/src/components/notifications/NotificationItem.tsx
+++ b/src/components/notifications/NotificationItem.tsx
@@ -169,12 +169,27 @@ export function resolveNotificationTarget(n: NotificationDisplayData): string | 
       ? `/ammunition?requestId=${n.relatedEquipmentDocId}`
       : '/ammunition';
   }
+  if (n.type === NotificationType.AMMO_ASSIGNED_FROM_CENTRAL) return '/ammunition';
+
+  const trainingTypes: ReadonlySet<NotificationType> = new Set([
+    NotificationType.TRAINING_PLAN_SUBMITTED,
+    NotificationType.TRAINING_PLAN_APPROVED,
+    NotificationType.TRAINING_PLAN_REJECTED,
+    NotificationType.AMMO_RESTOCK_REQUEST,
+  ]);
+  if (trainingTypes.has(n.type)) {
+    return n.relatedEquipmentDocId
+      ? `/ammunition/training?planId=${n.relatedEquipmentDocId}`
+      : '/ammunition/training';
+  }
 
   if (n.type === NotificationType.GUARD_SCHEDULE_SHARED) {
     return n.relatedGuardScheduleId
       ? `/guard-scheduler/${n.relatedGuardScheduleId}`
       : '/guard-scheduler';
   }
+
+  if (n.type === NotificationType.SYSTEM_MESSAGE) return '/';
 
   return null;
 }

--- a/src/components/notifications/__tests__/NotificationItem.test.tsx
+++ b/src/components/notifications/__tests__/NotificationItem.test.tsx
@@ -108,19 +108,56 @@ describe('resolveNotificationTarget', () => {
     });
   });
 
-  describe('unrouted types', () => {
-    // These notification types exist in the enum (have real producers) but
-    // currently have no route in resolveNotificationTarget. PR-B will wire
-    // them up; this test pins the current state.
+  describe('training plan notifications', () => {
     test.each<NotificationType>([
       NotificationType.TRAINING_PLAN_SUBMITTED,
       NotificationType.TRAINING_PLAN_APPROVED,
       NotificationType.TRAINING_PLAN_REJECTED,
       NotificationType.AMMO_RESTOCK_REQUEST,
-      NotificationType.AMMO_ASSIGNED_FROM_CENTRAL,
-      NotificationType.SYSTEM_MESSAGE,
-    ])('%s returns null (route not yet wired)', (type) => {
-      expect(resolveNotificationTarget(makeNotification({ type }))).toBeNull();
+    ])('%s with planId routes to /ammunition/training?planId=<id>', (type) => {
+      const target = resolveNotificationTarget(
+        makeNotification({ type, relatedEquipmentDocId: 'plan-42' }),
+      );
+      expect(target).toBe('/ammunition/training?planId=plan-42');
+    });
+
+    test('TRAINING_PLAN_SUBMITTED without planId falls back to /ammunition/training', () => {
+      expect(
+        resolveNotificationTarget(makeNotification({ type: NotificationType.TRAINING_PLAN_SUBMITTED })),
+      ).toBe('/ammunition/training');
+    });
+  });
+
+  describe('miscellaneous notifications', () => {
+    test('AMMO_ASSIGNED_FROM_CENTRAL routes to /ammunition', () => {
+      expect(
+        resolveNotificationTarget(makeNotification({ type: NotificationType.AMMO_ASSIGNED_FROM_CENTRAL })),
+      ).toBe('/ammunition');
+    });
+
+    test('SYSTEM_MESSAGE routes to home', () => {
+      expect(
+        resolveNotificationTarget(makeNotification({ type: NotificationType.SYSTEM_MESSAGE })),
+      ).toBe('/');
+    });
+  });
+
+  describe('exhaustiveness', () => {
+    // Every value in the unified NotificationType enum must have a non-null
+    // target. Catches the case where a value is added to the enum without
+    // wiring its route.
+    test('every NotificationType value resolves to a non-null target', () => {
+      for (const type of Object.values(NotificationType) as NotificationType[]) {
+        const target = resolveNotificationTarget(
+          makeNotification({
+            type,
+            // Provide IDs for the branches that read them; safe to overpopulate.
+            relatedEquipmentDocId: 'fake-doc',
+            relatedGuardScheduleId: 'fake-sched',
+          }),
+        );
+        expect(target).not.toBeNull();
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

PR-B of the 3-PR notification-audit batch (PR-A: #156 merged). Wires routes for the 6 notification types that previously returned `null` from `resolveNotificationTarget` — clicking them did nothing.

**Routes added**

| Type(s) | Target | Notes |
|---|---|---|
| `TRAINING_PLAN_SUBMITTED`, `TRAINING_PLAN_APPROVED`, `TRAINING_PLAN_REJECTED`, `AMMO_RESTOCK_REQUEST` | `/ammunition/training?planId=<relatedEquipmentDocId>` | Page highlights + scrolls to matching row; auto-opens archive section if plan is archived |
| `AMMO_ASSIGNED_FROM_CENTRAL` | `/ammunition` | Recipient checks inventory |
| `SYSTEM_MESSAGE` | `/` | No domain context |

Exchange family (`EXCHANGE_REQUEST_APPROVAL/APPROVED/REJECTED/COMPLETED`) already lands on `/equipment` via PR-A's `equipmentTypes` set — no change.

**Page plumbing**
- `useSearchParams` reads `planId` in `/ammunition/training`. Forwarded to `PlannedTrainingsTable` as `highlightPlanId`.
- Page body split into `AmmunitionTrainingPageContent` under `<Suspense>` so static prerender doesn't fail on `useSearchParams`.
- `PlannedTrainingsTable` + `PlanTable` accept `highlightPlanId`. Matching row gets `ref` + `scrollIntoView` on mount + `bg-warning-50 ring-2 ring-warning-400 ring-inset`. Archive `Disclosure` is `defaultOpen` when the highlighted plan is archived.

**Tests**
- Replaced the prior `unrouted types` placeholder block (which pinned the `null` return for these types in PR-A) with concrete route assertions for all 6.
- New `exhaustiveness` suite: iterates `Object.values(NotificationType)` and asserts no value returns `null`. Catches the case where a future enum addition forgets to wire a route.

## Out of scope

- **PR-C** `feat/notifications-cleanup-cron` — server-side cleanup function + Vercel cron. Independent of PR-A/B; can start anytime.

## Test plan

- [x] `npm test` — 877 pass, 36 skipped, 0 failed (was 875 → +2 from new test cases)
- [x] `npm run lint` — clean
- [x] `npm run build` — clean (Suspense wrap fixed the prerender error)
- [ ] Manual: trigger a `TRAINING_PLAN_SUBMITTED` notification, click → land on `/ammunition/training?planId=<id>` with the row highlighted and scrolled into view. Verify works for an archived plan too (archive section should auto-open).
- [ ] Manual: trigger `AMMO_ASSIGNED_FROM_CENTRAL` → land on `/ammunition`.
- [ ] Manual: trigger `SYSTEM_MESSAGE` → land on `/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)