### PR TITLE
refactor(equipment): predecessor display name in history pill + drop debug ISO row

### DIFF
--- a/docs/codebase/src/components/equipment/ActionHistoryPanel.md
+++ b/docs/codebase/src/components/equipment/ActionHistoryPanel.md
@@ -25,4 +25,8 @@ Timestamps in tracking entries can arrive as `Timestamp` instances, `Date`, ISO 
 
 ## Inline expand
 
-Each row is a `role="button"` element (`tabIndex=0`, `aria-expanded`). Click — or Enter / Space — toggles a single-open expansion panel showing the full ISO timestamp, the source (`tracking` / `log`), the owner doc id, the `isPredecessor` flag, the full photo (`max-h-64`), the untruncated note, and `details.condition` when present. Escape collapses the open row. Transition is a simple `max-h` + `opacity` Tailwind animation.
+Each row is a `role="button"` element (`tabIndex=0`, `aria-expanded`). Click — or Enter / Space — toggles a single-open expansion panel showing the source (`tracking` / `log`), the owner doc id, the `isPredecessor` flag, the full photo (`max-h-64`), the untruncated note, and `details.condition` when present. The full ISO timestamp was previously rendered here as well; it was dropped because the collapsed row already shows a localized `dd/mm/yy hh:mm` value, and double-rendering the same datum (in two formats, one of them debug-shaped) added noise without information. Escape collapses the open row. Transition is a simple `max-h` + `opacity` Tailwind animation.
+
+## Predecessor pill
+
+When the item has a predecessor chain (older items it was exchanged from), the header renders a pill formatted via `EXCHANGE.PREDECESSOR_PILL` substituting `{serial}` with the *display name* of the first predecessor, not its raw doc id. For items where `hasSerialNumber === false`, the doc id is a UUID that must never be shown — the pill falls back to the predecessor's `productName`. Computed once when the chain is walked and stored in component state.

--- a/src/components/equipment/ActionHistoryPanel.tsx
+++ b/src/components/equipment/ActionHistoryPanel.tsx
@@ -56,11 +56,11 @@ export default function ActionHistoryPanel({ equipment, onClose }: ActionHistory
   const [timeline, setTimeline] = useState<TimelineEntry[] | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [predecessorChain, setPredecessorChain] = useState<string[]>([]);
+  const [predecessorDisplay, setPredecessorDisplay] = useState<string | null>(null);
   const [expandedKey, setExpandedKey] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!equipment) { setTimeline(null); setPredecessorChain([]); setExpandedKey(null); return; }
+    if (!equipment) { setTimeline(null); setPredecessorDisplay(null); setExpandedKey(null); return; }
     let cancelled = false;
     setLoading(true);
     setError(null);
@@ -99,7 +99,13 @@ export default function ActionHistoryPanel({ equipment, onClose }: ActionHistory
         });
         merged.sort((a, b) => b.ts - a.ts);
         setTimeline(merged);
-        setPredecessorChain(chain.filter((c) => c.isPredecessor).map((c) => c.docId));
+        const firstPred = chain.find((c) => c.isPredecessor);
+        if (firstPred) {
+          const serial = equipmentSerialDisplay(firstPred.eq);
+          setPredecessorDisplay(serial ?? firstPred.eq.productName);
+        } else {
+          setPredecessorDisplay(null);
+        }
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : String(e));
       } finally {
@@ -123,11 +129,6 @@ export default function ActionHistoryPanel({ equipment, onClose }: ActionHistory
       day: '2-digit', month: '2-digit', year: '2-digit',
       hour: '2-digit', minute: '2-digit',
     });
-  };
-
-  const formatIso = (ts: number, date: Date): string => {
-    if (ts === 0 || Number.isNaN(date.getTime())) return labels.UNKNOWN_DATE;
-    return date.toISOString();
   };
 
   const toggle = (key: string) => {
@@ -165,11 +166,11 @@ export default function ActionHistoryPanel({ equipment, onClose }: ActionHistory
                 return serial ? ` · צ: ${serial}` : '';
               })()}
             </p>
-            {predecessorChain.length > 0 && (
+            {predecessorDisplay && (
               <p className="mt-1 text-xs text-primary-700 bg-primary-50 inline-block px-2 py-0.5 rounded-full">
                 {TEXT_CONSTANTS.FEATURES.EQUIPMENT.EXCHANGE.PREDECESSOR_PILL.replace(
                   '{serial}',
-                  predecessorChain[0]
+                  predecessorDisplay
                 )}
               </p>
             )}
@@ -196,7 +197,6 @@ export default function ActionHistoryPanel({ equipment, onClose }: ActionHistory
               {timeline.map((entry) => {
                 const isExpanded = expandedKey === entry.key;
                 const shortDate = formatShortDate(entry.ts, entry.date);
-                const isoDate = formatIso(entry.ts, entry.date);
                 const actionLabel = actionLabels[entry.action] ?? entry.action;
                 const conditionLabel = entry.condition
                   ? conditionLabels[entry.condition] ?? entry.condition
@@ -267,8 +267,6 @@ export default function ActionHistoryPanel({ equipment, onClose }: ActionHistory
                     >
                       <div className="ps-4 pe-3 pb-3 pt-1 text-xs text-neutral-600 space-y-2">
                         <dl className="grid grid-cols-[max-content_1fr] gap-x-2 gap-y-1">
-                          <dt className="font-medium text-neutral-500">{labels.FULL_TIMESTAMP_LABEL}</dt>
-                          <dd className="text-neutral-700 break-all">{isoDate}</dd>
                           <dt className="font-medium text-neutral-500">{labels.SOURCE_LABEL}</dt>
                           <dd className="text-neutral-700">{sourceLabel}</dd>
                           <dt className="font-medium text-neutral-500">{labels.OWNER_DOC_LABEL}</dt>

--- a/src/components/equipment/__tests__/ActionHistoryPanel.test.tsx
+++ b/src/components/equipment/__tests__/ActionHistoryPanel.test.tsx
@@ -38,7 +38,6 @@ jest.mock('@/constants/text', () => ({
           COLLAPSE_ROW_ARIA: 'הסתר פרטים',
           SOURCE_TRACKING: 'מהיסטוריית הפריט',
           SOURCE_LOG: 'מיומן הפעולות',
-          FULL_TIMESTAMP_LABEL: 'זמן מדויק',
           SOURCE_LABEL: 'מקור',
           OWNER_DOC_LABEL: 'מסמך פריט',
           PREDECESSOR_FLAG_LABEL: 'מהיסטוריה של פריט קודם',
@@ -75,7 +74,6 @@ const historyPanelLabels = {
   COLLAPSE_ROW_ARIA: 'הסתר פרטים',
   SOURCE_TRACKING: 'מהיסטוריית הפריט',
   SOURCE_LOG: 'מיומן הפעולות',
-  FULL_TIMESTAMP_LABEL: 'זמן מדויק',
   SOURCE_LABEL: 'מקור',
   OWNER_DOC_LABEL: 'מסמך פריט',
   PREDECESSOR_FLAG_LABEL: 'מהיסטוריה של פריט קודם',
@@ -163,11 +161,10 @@ describe('ActionHistoryPanel', () => {
     await waitFor(() => {
       expect(row!.getAttribute('aria-expanded')).toBe('true');
     });
-    // The full ISO timestamp should appear for the clicked row.
+    // Exact timestamp row removed — collapsed shortDate is the only time shown.
     const iso = new Date(Date.UTC(2026, 4, 1, 10, 30, 0)).toISOString();
-    expect(screen.getByText(iso)).toBeInTheDocument();
-    // Each row carries the detail labels — make sure they are present.
-    expect(screen.getAllByText(historyPanelLabels.FULL_TIMESTAMP_LABEL).length).toBeGreaterThan(0);
+    expect(screen.queryByText(iso)).toBeNull();
+    // Remaining detail labels still render in the expanded panel.
     expect(screen.getAllByText(historyPanelLabels.SOURCE_LABEL).length).toBeGreaterThan(0);
     expect(screen.getAllByText(historyPanelLabels.OWNER_DOC_LABEL).length).toBeGreaterThan(0);
   });

--- a/src/constants/text.en.ts
+++ b/src/constants/text.en.ts
@@ -223,7 +223,6 @@ export const TEXT_EN = {
       COLLAPSE_ROW_ARIA: 'Hide details',
       SOURCE_TRACKING: 'From item history',
       SOURCE_LOG: 'From action log',
-      FULL_TIMESTAMP_LABEL: 'Exact time',
       SOURCE_LABEL: 'Source',
       OWNER_DOC_LABEL: 'Item document',
       PREDECESSOR_FLAG_LABEL: 'From a predecessor item history',

--- a/src/constants/text.ts
+++ b/src/constants/text.ts
@@ -668,7 +668,6 @@ export const TEXT_CONSTANTS = {
         COLLAPSE_ROW_ARIA: 'הסתר פרטים',
         SOURCE_TRACKING: 'מהיסטוריית הפריט',
         SOURCE_LOG: 'מיומן הפעולות',
-        FULL_TIMESTAMP_LABEL: 'זמן מדויק',
         SOURCE_LABEL: 'מקור',
         OWNER_DOC_LABEL: 'מסמך פריט',
         PREDECESSOR_FLAG_LABEL: 'מהיסטוריה של פריט קודם',


### PR DESCRIPTION
## Summary
- `ActionHistoryPanel` predecessor pill now renders the predecessor's serial number (or `productName` fallback for non-serialized items) instead of the raw doc id. UUID doc ids must never reach the UI for items where `hasSerialNumber === false`.
- Dropped the expanded-row "Exact time" / `FULL_TIMESTAMP_LABEL` field — the collapsed row already shows a localized `dd/mm/yy hh:mm` value. Double-rendering as ISO was debug noise.
- Removed `FULL_TIMESTAMP_LABEL` from both `text.ts` and `text.en.ts` (bilingual symmetry).
- Doc updated: new "Predecessor pill" section + revised inline-expand description in `docs/codebase/src/components/equipment/ActionHistoryPanel.md`.

## Test plan
- [ ] Jest: `npx jest src/components/equipment/__tests__/ActionHistoryPanel.test.tsx` — passes (5/5). The previous ISO-row assertion is inverted to `queryByText(iso) === null`.
- [ ] Manual: open an equipment item that was exchanged (has predecessor chain). Pill in header shows predecessor serial, not UUID.
- [ ] Manual: expand a timeline row — no "זמן מדויק" field; other detail labels still present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)