### PR TITLE
feat(logistics): Firestore rules + composite index for logisticsTemplates/Items

### DIFF
--- a/docs/codebase/src/app/logistics/page.md
+++ b/docs/codebase/src/app/logistics/page.md
@@ -42,6 +42,19 @@ AuthGuard
 - Create / edit / delete: ADMIN / SYSTEM_MANAGER / MANAGER / TEAM_LEADER.
   Enforced on `/api/logistics-items`; UI hides the buttons for everyone else.
 
+## Firestore rules + indexes
+
+The page relies on two collections — `logisticsTemplates` (managed under
+`Management → תבניות אפסנאות`) and `logisticsItems`. Both have authenticated-
+read rules in `firebase/firestore.rules`; writes are server-only. The template
+read uses `where('isActive','==',true) + orderBy('name')`, which requires the
+composite index `logisticsTemplates(isActive, name)` in
+`firebase/firestore.indexes.json`. Without the rule entries the default
+deny-all match silently empties the templates list, which leaves the Add-item
+button disabled and surfaces the misleading "no templates" banner. Deploy
+both with `firebase deploy --only firestore:rules,firestore:indexes` after
+any change.
+
 ## Empty states
 
 - No templates → info banner directing managers to `Management → תבניות

--- a/firebase/firestore.indexes.json
+++ b/firebase/firestore.indexes.json
@@ -307,6 +307,14 @@
         { "fieldPath": "uid", "order": "ASCENDING" },
         { "fieldPath": "timestamp", "order": "DESCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "logisticsTemplates",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "isActive", "order": "ASCENDING" },
+        { "fieldPath": "name", "order": "ASCENDING" }
+      ]
     }
   ],
   "fieldOverrides": [

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -238,6 +238,20 @@ service cloud.firestore {
       allow write: if false;
     }
 
+    // Logistics templates — authenticated read; writes server-only via
+    // /api/logistics-templates (admin / system_manager / manager).
+    match /logisticsTemplates/{templateId} {
+      allow read: if request.auth != null;
+      allow write: if false;
+    }
+
+    // Logistics items — authenticated read; writes server-only via
+    // /api/logistics-items.
+    match /logisticsItems/{itemId} {
+      allow read: if request.auth != null;
+      allow write: if false;
+    }
+
     // Idempotency synchronization tokens (Phase 4 of offline-first
     // migration). Server-only — clients have zero access. Records are
     // ephemeral; the Firestore TTL on `expiresAt` purges them 24h after


### PR DESCRIPTION
## Summary
- Added authenticated-read rules for `logisticsTemplates` and `logisticsItems` in `firestore.rules`. Writes remain server-only (handled by `/api/logistics-templates` + `/api/logistics-items` where role checks live).
- Added composite index `logisticsTemplates(isActive ASC, name ASC)` in `firestore.indexes.json` — required by the templates query `where('isActive','==',true) + orderBy('name')`.
- Doc: `docs/codebase/src/app/logistics/page.md` now lists the rules + index dependency and the deploy command.

## Failure mode this fixes
Without these rules the default deny-all match swallowed the templates query, leaving `/logistics` with an empty templates list, the misleading "no templates" banner, and a disabled Add-Item button — for every user.

## Operator step (post-merge)

```
firebase deploy --only firestore:rules,firestore:indexes
```

## Test plan
- [ ] After operator deploys rules + indexes: open `/logistics` as any authenticated user — templates list populates, Add-Item button enabled when templates exist.
- [ ] Negative path: unauthenticated request to `logisticsTemplates` still denied (rules require `request.auth != null`).
- [ ] Confirm `firebase deploy --only firestore:rules,firestore:indexes` reports no-op on a second run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)